### PR TITLE
common: Fix bug in format_ipc_dimension

### DIFF
--- a/common.py
+++ b/common.py
@@ -4,6 +4,7 @@ Common functionality for generator scripts.
 import collections
 import csv
 from datetime import datetime
+import re
 from typing import Iterable
 
 
@@ -58,7 +59,9 @@ def format_ipc_dimension(number: float, decimal_places: int = 2) -> str:
     """
     Format a dimension (e.g. lead span or height) according to IPC rules.
     """
-    return '{:.2f}'.format(number).replace('0.', '').replace('.', '')
+    formatted = '{:.2f}'.format(number)
+    stripped = re.sub(r'^0\.', '', formatted)
+    return stripped.replace('.', '')
 
 
 def indent(level: int, lines: Iterable[str]):

--- a/test_common.py
+++ b/test_common.py
@@ -18,6 +18,7 @@ def test_format_float(inval: float, outval: str):
     (75.0, '7500'),
     (0.4, '40'),
     (0.75, '75'),
+    (30.0, '3000'),
 ])
 def test_format_ipc_dimension(inval: float, outval: str):
     assert format_ipc_dimension(inval) == outval


### PR DESCRIPTION
The previous version would represent `30.0` as `300` instead of `3000`.

Fortunately none of the existing parts is affected.