### PR TITLE
entities: Escape double quotes in string values

### DIFF
--- a/entities/common.py
+++ b/entities/common.py
@@ -57,7 +57,7 @@ class StringValue():
         self.value = value
 
     def __str__(self) -> str:
-        return '({} "{}")'.format(self.name, self.value)
+        return '({} "{}")'.format(self.name, self.value.replace('"', '\\"'))
 
 
 class FloatValue():

--- a/test_entities.py
+++ b/test_entities.py
@@ -21,8 +21,8 @@ def test_name() -> None:
 
 
 def test_description() -> None:
-    description = str(Description("My Description\\nWith two lines"))
-    assert description == '(description "My Description\\nWith two lines")'
+    description = str(Description("My Description\\nWith two \" lines"))
+    assert description == '(description "My Description\\nWith two \\" lines")'
 
 
 def test_position() -> None:


### PR DESCRIPTION
Avoid that descriptions containing a double quote will result in an invalid file.