### PR TITLE
so: Bump version of TSSOP packages

### DIFF
--- a/generate_so.py
+++ b/generate_so.py
@@ -539,8 +539,8 @@ if __name__ == '__main__':
         lead_contact_length=0.6,
         pkgcat='241d9d5d-8f74-4740-8901-3cf51cf50091',
         keywords='so,sop,tssop,small outline package,smd',
-        version='0.1',
-        create_date='2019-07-21T12:15:54Z',
+        version='0.2',
+        create_date='2019-06-16T12:46:54Z',
     )
 
     # SSOP


### PR DESCRIPTION
The TSSOP packages in the base library already have the version 0.1, but they differ from the output currently generated by the script. So we need to bump the version before we update these packages in the base library.

Also fixed the creation date which currently does not correspond to the date of the packages already added to the base library. So this fix ensures that re-generating these packages does not change their creation date.

Corresponding update in base library: https://github.com/LibrePCB-Libraries/LibrePCB_Base.lplib/pull/101

Fixes #101