### PR TITLE
Generate output into corresponding library directory

### DIFF
--- a/dfn_configs.py
+++ b/dfn_configs.py
@@ -49,6 +49,7 @@ class DfnConfig:
                  lead_width: Optional[float] = None,
                  name: Optional[str] = None,
                  create_date: Optional[str] = None,
+                 library: Optional[str] = None,
                  pin1_corner_dx_dy: Optional[float] = None,  # Some parts have a triangular pin1 marking
                  extended_doc_fn: Optional[Callable[['DfnConfig', Callable[[str], str], List[str]], None]] = None,
                  ):
@@ -79,6 +80,7 @@ class DfnConfig:
         self.keywords = keywords
         self.name = name
         self.create_date = create_date
+        self.library = library or "LibrePCB_Base.lplib"
 
         self.extended_doc_fn = extended_doc_fn
 
@@ -294,6 +296,7 @@ THIRD_CONFIGS = [
         keywords='sensirion,sht,shtcx,shtc1,shtc3',
         name='SENSIRION_SHTCx',
         create_date='2019-01-24T21:50:44Z',
+        library="Sensirion.lplib",
         no_exp=False,
         pin1_corner_dx_dy=0.2,
         extended_doc_fn=draw_circle(diameter=0.9),
@@ -312,6 +315,7 @@ THIRD_CONFIGS = [
         keywords='sensirion,sht,sht2x,sht20,sht21,sht25',
         name='SENSIRION_SHT2x',
         create_date='2019-01-24T22:13:46Z',
+        library="Sensirion.lplib",
         no_exp=False,
         pin1_corner_dx_dy=0.2,
     ),
@@ -328,6 +332,7 @@ THIRD_CONFIGS = [
         exposed_length=1.25,
         keywords='sensirion,sgp,sgp30,sgpc3',
         name='SENSIRION_SGPxx',
+        library="Sensirion.lplib",
         no_exp=False,
         pin1_corner_dx_dy=0.3,
         extended_doc_fn=draw_circle(diameter=1.1),

--- a/generate_capacitor_radial_tht.py
+++ b/generate_capacitor_radial_tht.py
@@ -62,7 +62,7 @@ def get_variant(
 
 
 def generate_pkg(
-    dirpath: str,
+    library: str,
     diameter: float,
     height: float,
     pitch: float,
@@ -249,7 +249,7 @@ def generate_pkg(
     ))
 
     # write files
-    pkg_dir_path = path.join(dirpath, package.uuid)
+    pkg_dir_path = path.join('out', library, 'pkg', package.uuid)
     if not (path.exists(pkg_dir_path) and path.isdir(pkg_dir_path)):
         makedirs(pkg_dir_path)
     with open(path.join(pkg_dir_path, '.librepcb-pkg'), 'w') as f:
@@ -261,7 +261,7 @@ def generate_pkg(
 
 
 def generate_dev(
-    dirpath: str,
+    library: str,
     diameter: float,
     height: float,
     pitch: float,
@@ -306,7 +306,7 @@ def generate_dev(
     ))
 
     # write files
-    pkg_dir_path = path.join(dirpath, device.uuid)
+    pkg_dir_path = path.join('out', library, 'dev', device.uuid)
     if not (path.exists(pkg_dir_path) and path.isdir(pkg_dir_path)):
         makedirs(pkg_dir_path)
     with open(path.join(pkg_dir_path, '.librepcb-dev'), 'w') as f:
@@ -349,7 +349,7 @@ if __name__ == '__main__':
 
     for config in CONFIGS:
         generate_pkg(
-            dirpath='out/capacitors_radial_tht/pkg',
+            library='LibrePCB_Base.lplib',
             diameter=config['diameter'],
             height=config['height'],
             pitch=config['pitch'],
@@ -359,7 +359,7 @@ if __name__ == '__main__':
             create_date='2019-12-29T14:14:11Z',
         )
         generate_dev(
-            dirpath='out/capacitors_radial_tht/dev',
+            library='LibrePCB_Base.lplib',
             diameter=config['diameter'],
             height=config['height'],
             pitch=config['pitch'],

--- a/generate_chip.py
+++ b/generate_chip.py
@@ -171,7 +171,7 @@ class PolarizationConfig:
 
 
 def generate_pkg(
-    dirpath: str,
+    library: str,
     author: str,
     name: str,
     description: str,
@@ -480,7 +480,7 @@ def generate_pkg(
 
         lines.append(')')
 
-        pkg_dir_path = path.join(dirpath, uuid_pkg)
+        pkg_dir_path = path.join('out', library, category, uuid_pkg)
         if not (path.exists(pkg_dir_path) and path.isdir(pkg_dir_path)):
             makedirs(pkg_dir_path)
         with open(path.join(pkg_dir_path, '.librepcb-pkg'), 'w') as f:
@@ -491,7 +491,7 @@ def generate_pkg(
 
 
 def generate_dev(
-    dirpath: str,
+    library: str,
     author: str,
     name: str,
     description: str,
@@ -540,7 +540,7 @@ def generate_dev(
             lines.append(' (pad {} (signal {}))'.format(pad, signal))
         lines.append(')')
 
-        dev_dir_path = path.join(dirpath, uuid_dev)
+        dev_dir_path = path.join('out', library, category, uuid_dev)
         if not (path.exists(dev_dir_path) and path.isdir(dev_dir_path)):
             makedirs(dev_dir_path)
         with open(path.join(dev_dir_path, '.librepcb-dev'), 'w') as f:
@@ -551,15 +551,9 @@ def generate_dev(
 
 
 if __name__ == '__main__':
-    def _make(dirpath: str) -> None:
-        if not (path.exists(dirpath) and path.isdir(dirpath)):
-            makedirs(dirpath)
-    _make('out')
-    _make('out/chip')
-    _make('out/chip/pkg')
     # Chip resistors (RESC)
     generate_pkg(
-        dirpath='out/chip/pkg',
+        library='LibrePCB_Base.lplib',
         author='Danilo B.',
         name='RESC{size_metric} ({size_imperial})',
         description='Generic chip resistor {size_metric} (imperial {size_imperial}).\\n\\n'
@@ -585,7 +579,7 @@ if __name__ == '__main__':
     )
     # J-Lead resistors (RESJ)
     generate_pkg(
-        dirpath='out/chip/pkg',
+        library='LibrePCB_Base.lplib',
         author='Danilo B.',
         name='RESJ{size_metric} ({size_imperial})',
         description='Generic J-lead resistor {size_metric} (imperial {size_imperial}).\\n\\n'
@@ -604,7 +598,7 @@ if __name__ == '__main__':
     # and KEMET documentation: https://content.kemet.com/datasheets/KEM_T2005_T491.pdf
     # (see Table 2: Land Dimensions / Courtyard)
     generate_pkg(
-        dirpath='out/chip/pkg',
+        library='LibrePCB_Base.lplib',
         author='Danilo B.',
         name='CAPPM{length}X{width}X{height}L{lead_length}X{lead_width}',
         description='Generic polarized molded inward-L capacitor (EIA {meta[eia]}).\\n\\n'
@@ -680,9 +674,8 @@ if __name__ == '__main__':
         create_date='2019-11-18T21:56:00Z',
     )
     # Generic devices
-    _make('out/chip/dev')
     generate_dev(
-        dirpath='out/chip/dev',
+        library='LibrePCB_Base.lplib',
         author='Danilo B.',
         name='Resistor {size_metric} ({size_imperial})',
         description='Generic SMD resistor {size_metric} (imperial {size_imperial}).',

--- a/generate_connectors.py
+++ b/generate_connectors.py
@@ -114,7 +114,7 @@ def get_rectangle_bounds(
 
 
 def generate_pkg(
-    dirpath: str,
+    library: str,
     author: str,
     name: str,
     name_lower: str,
@@ -206,7 +206,7 @@ def generate_pkg(
             lines.append(' )')
             lines.append(')')
 
-            pkg_dir_path = path.join(dirpath, uuid_pkg)
+            pkg_dir_path = path.join('out', library, category, uuid_pkg)
             if not (path.exists(pkg_dir_path) and path.isdir(pkg_dir_path)):
                 makedirs(pkg_dir_path)
             with open(path.join(pkg_dir_path, '.librepcb-pkg'), 'w') as f:
@@ -285,7 +285,7 @@ def generate_silkscreen_male(
 
 
 def generate_sym(
-    dirpath: str,
+    library: str,
     author: str,
     name: str,
     name_lower: str,
@@ -404,7 +404,7 @@ def generate_sym(
         text = Text(uuid_text_value, Layer('sym_values'), Value('{{VALUE}}'), Align('center top'), Height(sym_text_height), Position(0.0, y_min), Rotation(0.0))
         symbol.add_text(text)
 
-        sym_dir_path = path.join(dirpath, uuid_sym)
+        sym_dir_path = path.join('out', library, category, uuid_sym)
         if not (path.exists(sym_dir_path) and path.isdir(sym_dir_path)):
             makedirs(sym_dir_path)
         with open(path.join(sym_dir_path, '.librepcb-sym'), 'w') as f:
@@ -417,7 +417,7 @@ def generate_sym(
 
 
 def generate_cmp(
-    dirpath: str,
+    library: str,
     author: str,
     name: str,
     name_lower: str,
@@ -492,13 +492,13 @@ def generate_cmp(
 
         component.add_variant(Variant(uuid_variant, Norm.EMPTY, Name('default'), Description(''), gate))
 
-        component.serialize(dirpath)
+        component.serialize(path.join('out', library, category))
 
         print('{}x{} {}: Wrote component {}'.format(rows, per_row, kind, uuid_cmp))
 
 
 def generate_dev(
-    dirpath: str,
+    library: str,
     author: str,
     name: str,
     name_lower: str,
@@ -550,7 +550,7 @@ def generate_dev(
             lines.extend(sorted(signalmappings))
             lines.append(')')
 
-            dev_dir_path = path.join(dirpath, uuid_dev)
+            dev_dir_path = path.join('out', library, category, uuid_dev)
             if not (path.exists(dev_dir_path) and path.isdir(dev_dir_path)):
                 makedirs(dev_dir_path)
             with open(path.join(dev_dir_path, '.librepcb-dev'), 'w') as f:
@@ -563,17 +563,9 @@ def generate_dev(
 
 
 if __name__ == '__main__':
-    def _make(dirpath: str) -> None:
-        if not (path.exists(dirpath) and path.isdir(dirpath)):
-            makedirs(dirpath)
-    _make('out')
-    _make('out/connectors')
-    _make('out/connectors/pkg')
-    _make('out/connectors/sym')
-
     # Male pin headers
     generate_sym(
-        dirpath='out/connectors/sym',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Pin Header',
         name_lower='male pin header',
@@ -587,7 +579,7 @@ if __name__ == '__main__':
         create_date='2018-10-17T19:13:41Z',
     )
     generate_sym(
-        dirpath='out/connectors/sym',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Pin Header',
         name_lower='male pin header',
@@ -601,7 +593,7 @@ if __name__ == '__main__':
         create_date='2019-09-10T21:02:02Z',
     )
     generate_cmp(
-        dirpath='out/connectors/cmp',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Pin Header',
         name_lower='male pin header',
@@ -616,7 +608,7 @@ if __name__ == '__main__':
         create_date='2018-10-17T19:13:41Z',
     )
     generate_cmp(
-        dirpath='out/connectors/cmp',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Pin Header',
         name_lower='male pin header',
@@ -631,7 +623,7 @@ if __name__ == '__main__':
         create_date='2019-09-11T19:13:41Z',
     )
     generate_pkg(
-        dirpath='out/connectors/pkg',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Pin Header 2.54mm',
         name_lower='male pin header',
@@ -647,7 +639,7 @@ if __name__ == '__main__':
         create_date='2018-10-17T19:13:41Z',
     )
     generate_pkg(
-        dirpath='out/connectors/pkg',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Pin Header 2.54mm',
         name_lower='male pin header',
@@ -663,7 +655,7 @@ if __name__ == '__main__':
         create_date='2019-09-17T20:00:41Z',
     )
     generate_dev(
-        dirpath='out/connectors/dev',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Generic Pin Header 2.54mm',
         name_lower='generic male pin header',
@@ -677,7 +669,7 @@ if __name__ == '__main__':
         create_date='2018-10-17T19:13:41Z',
     )
     generate_dev(
-        dirpath='out/connectors/dev',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Generic Pin Header 2.54mm',
         name_lower='generic male pin header',
@@ -693,7 +685,7 @@ if __name__ == '__main__':
 
     # Female pin sockets
     generate_sym(
-        dirpath='out/connectors/sym',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Pin Socket',
         name_lower='female pin socket',
@@ -707,7 +699,7 @@ if __name__ == '__main__':
         create_date='2018-10-17T19:13:41Z',
     )
     generate_sym(
-        dirpath='out/connectors/sym',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Pin Socket',
         name_lower='female pin socket',
@@ -721,7 +713,7 @@ if __name__ == '__main__':
         create_date='2019-09-10T21:02:02Z',
     )
     generate_cmp(
-        dirpath='out/connectors/cmp',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Pin Socket',
         name_lower='female pin socket',
@@ -736,7 +728,7 @@ if __name__ == '__main__':
         create_date='2018-10-17T19:13:41Z',
     )
     generate_cmp(
-        dirpath='out/connectors/cmp',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Pin Socket',
         name_lower='female pin socket',
@@ -751,7 +743,7 @@ if __name__ == '__main__':
         create_date='2019-09-11T19:13:41Z',
     )
     generate_pkg(
-        dirpath='out/connectors/pkg',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Pin Socket 2.54mm',
         name_lower='female pin socket',
@@ -767,7 +759,7 @@ if __name__ == '__main__':
         create_date='2018-10-17T19:13:41Z',
     )
     generate_pkg(
-        dirpath='out/connectors/pkg',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Pin Socket 2.54mm',
         name_lower='female pin socket',
@@ -783,7 +775,7 @@ if __name__ == '__main__':
         create_date='2019-09-17T20:00:41Z',
     )
     generate_dev(
-        dirpath='out/connectors/dev',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Generic Pin Socket 2.54mm',
         name_lower='generic female pin socket',
@@ -797,7 +789,7 @@ if __name__ == '__main__':
         create_date='2018-10-17T19:13:41Z',
     )
     generate_dev(
-        dirpath='out/connectors/dev',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Generic Pin Socket 2.54mm',
         name_lower='generic female pin socket',
@@ -813,7 +805,7 @@ if __name__ == '__main__':
 
     # Generic connector
     generate_sym(
-        dirpath='out/connectors/sym',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Connector',
         name_lower='connector',
@@ -829,7 +821,7 @@ if __name__ == '__main__':
 
     # Soldered wire connector
     generate_cmp(
-        dirpath='out/connectors/cmp',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Soldered Wire Connector',
         name_lower='soldered wire connector',
@@ -844,7 +836,7 @@ if __name__ == '__main__':
         create_date='2018-10-17T19:13:41Z',
     )
     generate_pkg(
-        dirpath='out/connectors/pkg',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Soldered Wire Connector',
         name_lower='soldered wire connector',
@@ -860,7 +852,7 @@ if __name__ == '__main__':
         create_date='2018-10-17T19:13:41Z',
     )
     generate_dev(
-        dirpath='out/connectors/dev',
+        library='LibrePCB_Connectors.lplib',
         author='Danilo B.',
         name='Soldered Wire Connector 2.54mm',
         name_lower='generic soldered wire connector',

--- a/generate_dfn.py
+++ b/generate_dfn.py
@@ -67,7 +67,6 @@ def get_y(pin_number: int, pin_count: int, spacing: float, grid_align: bool) -> 
 
 
 def generate_pkg(
-    dirpath: str,
     author: str,
     name: str,
     description: str,
@@ -367,7 +366,7 @@ def generate_pkg(
     lines.append(')')
 
     # Save package
-    pkg_dir_path = path.join(dirpath, uuid_pkg)
+    pkg_dir_path = path.join('out', config.library, category, uuid_pkg)
     if not (path.exists(pkg_dir_path) and path.isdir(pkg_dir_path)):
         makedirs(pkg_dir_path)
     with open(path.join(pkg_dir_path, '.librepcb-pkg'), 'w') as f:
@@ -380,13 +379,6 @@ def generate_pkg(
 
 
 if __name__ == '__main__':
-    def _make(dirpath: str) -> None:
-        if not (path.exists(dirpath) and path.isdir(dirpath)):
-            makedirs(dirpath)
-    _make('out')
-    _make('out/dfn')
-    _make('out/dfn/pkg')
-
     generated_packages = []  # type: List[str]
 
     for config in JEDEC_CONFIGS:
@@ -401,7 +393,6 @@ if __name__ == '__main__':
 
         for make_exposed in exposed_settings:
             name = generate_pkg(
-                dirpath='out/dfn/pkg',
                 author='Hannes Badertscher',
                 name='DFN{pitch}P{length}X{width}X{height}-{pin_count}',
                 description='{pin_count}-pin Dual Flat No-Lead package (DFN), '
@@ -421,9 +412,6 @@ if __name__ == '__main__':
             else:
                 print("Duplicate name found: {}".format(name))
 
-    _make('out/3rd_party')
-    _make('out/3rd_party/pkg')
-
     for config in THIRD_CONFIGS:
         # Find out which configs to create
         if config.exposed_width > 0.0 and config.exposed_length > 0.0:
@@ -436,7 +424,6 @@ if __name__ == '__main__':
 
         for make_exposed in exposed_settings:
             name = generate_pkg(
-                dirpath='out/3rd_party/pkg',
                 author='Hannes Badertscher',
                 name='DFN{pitch}P{length}X{width}X{height}-{pin_count}',
                 description='{pin_count}-pin Dual Flat No-Lead package (DFN), '

--- a/generate_dip.py
+++ b/generate_dip.py
@@ -81,7 +81,7 @@ def get_rectangle_bounds(
 
 
 def generate_pkg(
-    dirpath: str,
+    library: str,
     author: str,
     name: str,
     name_lower: str,
@@ -224,7 +224,7 @@ def generate_pkg(
 
         lines.append(')')
 
-        pkg_dir_path = path.join(dirpath, uuid_pkg)
+        pkg_dir_path = path.join('out', library, category, uuid_pkg)
         if not (path.exists(pkg_dir_path) and path.isdir(pkg_dir_path)):
             makedirs(pkg_dir_path)
         with open(path.join(pkg_dir_path, '.librepcb-pkg'), 'w') as f:
@@ -237,14 +237,8 @@ def generate_pkg(
 
 
 if __name__ == '__main__':
-    def _make(dirpath: str) -> None:
-        if not (path.exists(dirpath) and path.isdir(dirpath)):
-            makedirs(dirpath)
-    _make('out')
-    _make('out/dip')
-    _make('out/dip/pkg')
     generate_pkg(
-        dirpath='out/dip/pkg',
+        library='LibrePCB_Base.lplib',
         author='Danilo B.',
         name='DIP',
         name_lower='Dual Inline Package',
@@ -256,7 +250,7 @@ if __name__ == '__main__':
         create_date='2018-11-04T23:13:00Z',
     )
     generate_pkg(
-        dirpath='out/dip/pkg',
+        library='LibrePCB_Base.lplib',
         author='Danilo B.',
         name='DIP',
         name_lower='Dual Inline Package',

--- a/generate_idc.py
+++ b/generate_idc.py
@@ -102,7 +102,7 @@ def get_coords(pin_number: int, pin_count: int, row_count: int, pitch: float, ro
 
 
 def generate_pkg(
-    dirpath: str,
+    library: str,
     author: str,
     name: str,
     description: str,
@@ -300,7 +300,7 @@ def generate_pkg(
         lines.append(' )')
         lines.append(')')
 
-        pkg_dir_path = path.join(dirpath, uuid_pkg)
+        pkg_dir_path = path.join('out', library, category, uuid_pkg)
         if not (path.exists(pkg_dir_path) and path.isdir(pkg_dir_path)):
             makedirs(pkg_dir_path)
         with open(path.join(pkg_dir_path, '.librepcb-pkg'), 'w') as f:
@@ -313,14 +313,8 @@ def generate_pkg(
 
 
 if __name__ == '__main__':
-    def _make(dirpath: str) -> None:
-        if not (path.exists(dirpath) and path.isdir(dirpath)):
-            makedirs(dirpath)
-    _make('out')
-    _make('out/idc')
-    _make('out/idc/pkg')
     generate_pkg(
-        dirpath='out/idc/pkg',
+        library='CNC_Tech.lplib',
         author='Danilo Bargen',
         name='CNCTECH_3220-{pin_count}-0300-XX',
         description='{pin_count}-pin 1.27mm pitch SMD IDC box header by CNC Tech.',
@@ -340,7 +334,7 @@ if __name__ == '__main__':
         create_date='2019-07-09T21:31:21Z',
     )
     generate_pkg(
-        dirpath='out/idc/pkg',
+        library='CNC_Tech.lplib',
         author='Danilo Bargen',
         name='CNCTECH_3120-{pin_count}-0300-XX',
         description='{pin_count}-pin 2.00mm pitch SMD IDC box header by CNC Tech.',
@@ -360,7 +354,7 @@ if __name__ == '__main__':
         create_date='2019-07-09T21:31:21Z',
     )
     generate_pkg(
-        dirpath='out/idc/pkg',
+        library='CNC_Tech.lplib',
         author='Danilo Bargen',
         name='CNCTECH_3020-{pin_count}-0300-XX',
         description='{pin_count}-pin 2.54mm pitch SMD IDC box header by CNC Tech.',

--- a/generate_led.py
+++ b/generate_led.py
@@ -104,7 +104,7 @@ class LedConfig:
 
 
 def generate_pkg(
-    dirpath: str,
+    library: str,
     author: str,
     configs: Iterable[LedConfig],
     pkgcat: str,
@@ -516,7 +516,7 @@ def generate_pkg(
             body_offset=7.62,
         )
 
-        pkg_dir_path = path.join(dirpath, uuid_pkg)
+        pkg_dir_path = path.join('out', library, category, uuid_pkg)
         if not (path.exists(pkg_dir_path) and path.isdir(pkg_dir_path)):
             makedirs(pkg_dir_path)
         with open(path.join(pkg_dir_path, '.librepcb-pkg'), 'w') as f:
@@ -527,7 +527,7 @@ def generate_pkg(
 
 
 def generate_dev(
-    dirpath: str,
+    library: str,
     author: str,
     configs: Iterable[LedConfig],
     cmpcat: str,
@@ -566,7 +566,7 @@ def generate_dev(
             signal=SignalUUID('7b023430-b68f-403a-80b8-c7deb12e7a0c'),
         ))
 
-        dev_dir_path = path.join(dirpath, device.uuid)
+        dev_dir_path = path.join('out', library, category, device.uuid)
         if not (path.exists(dev_dir_path) and path.isdir(dev_dir_path)):
             makedirs(dev_dir_path)
         with open(path.join(dev_dir_path, '.librepcb-dev'), 'w') as f:
@@ -577,10 +577,6 @@ def generate_dev(
 
 
 if __name__ == '__main__':
-    def _make(dirpath: str) -> None:
-        if not (path.exists(dirpath) and path.isdir(dirpath)):
-            makedirs(dirpath)
-
     configs = []  # type: List[LedConfig]
 
     # Generic LEDs
@@ -599,9 +595,8 @@ if __name__ == '__main__':
     configs.append(LedConfig(5.00, 5.80, 2.54, 8.7, 1.0, False, 'Clear'))
     configs.append(LedConfig(5.00, 5.80, 2.54, 8.7, 5.0, True, 'Clear'))
 
-    _make('out/led/pkg')
     generate_pkg(
-        dirpath='out/led/pkg',
+        library='LibrePCB_Base.lplib',
         author='Danilo B.',
         configs=configs,
         pkgcat='9c36c4be-3582-4f27-ae00-4c1229f1e870',
@@ -610,7 +605,7 @@ if __name__ == '__main__':
         create_date='2022-02-26T00:06:03Z',
     )
     generate_dev(
-        dirpath='out/led/dev',
+        library='LibrePCB_Base.lplib',
         author='U. Bruhin',
         configs=configs,
         cmpcat='70421345-ae1d-4fed-aa60-e7619524b97f',

--- a/generate_mosfet_dual.py
+++ b/generate_mosfet_dual.py
@@ -99,7 +99,7 @@ class FetConfig:
 
 
 def generate_dev(
-    dirpath: str,
+    library: str,
     name: str,
     author: str,
     description: str,
@@ -160,7 +160,7 @@ def generate_dev(
         lines.extend(sorted(pad_signal_mappings))
         lines.append(')')
 
-        dev_dir_path = path.join(dirpath, uuid_dev)
+        dev_dir_path = path.join('out', library, 'dev', uuid_dev)
         if not (path.exists(dev_dir_path) and path.isdir(dev_dir_path)):
             makedirs(dev_dir_path)
         with open(path.join(dev_dir_path, '.librepcb-dev'), 'w') as f:
@@ -171,16 +171,9 @@ def generate_dev(
 
 
 if __name__ == '__main__':
-    def _make(dirpath: str) -> None:
-        if not (path.exists(dirpath) and path.isdir(dirpath)):
-            makedirs(dirpath)
-    _make('out')
-    _make('out/mosfet_dual')
-    _make('out/mosfet_dual/diodes_inc')
-    _make('out/mosfet_dual/diodes_inc/dev')
     # Diodes Incorporated
     generate_dev(
-        dirpath='out/mosfet_dual/diodes_inc/dev',
+        library='Diodes_Incorporated.lplib',
         name='{name}',
         author='Danilo B.',
         description='Diodes Incorporated {name} Dual MOSFET N/P-Channel {max_voltage}V.',

--- a/generate_qfp.py
+++ b/generate_qfp.py
@@ -323,7 +323,7 @@ def get_pad_coords(
 
 
 def generate_pkg(
-    dirpath: str,
+    library: str,
     author: str,
     configs: Iterable[QfpConfig],
     pkgcat: str,
@@ -540,7 +540,7 @@ def generate_pkg(
 
         lines.append(')')
 
-        pkg_dir_path = path.join(dirpath, uuid_pkg)
+        pkg_dir_path = path.join('out', library, category, uuid_pkg)
         if not (path.exists(pkg_dir_path) and path.isdir(pkg_dir_path)):
             makedirs(pkg_dir_path)
         with open(path.join(pkg_dir_path, '.librepcb-pkg'), 'w') as f:
@@ -551,15 +551,9 @@ def generate_pkg(
 
 
 if __name__ == '__main__':
-    def _make(dirpath: str) -> None:
-        if not (path.exists(dirpath) and path.isdir(dirpath)):
-            makedirs(dirpath)
-    _make('out')
-    _make('out/qfp')
-    _make('out/qfp/pkg')
     configs = list(chain.from_iterable(c.get_configs() for c in JEDEC_CONFIGS))
     generate_pkg(
-        dirpath='out/qfp/pkg',
+        library='LibrePCB_Base.lplib',
         author='Danilo B.',
         configs=configs,
         pkgcat='3363b8b1-6fa8-4041-962e-5f839cfd86b7',

--- a/generate_so.py
+++ b/generate_so.py
@@ -110,7 +110,7 @@ class SoConfig:
 
 
 def generate_pkg(
-    dirpath: str,
+    library: str,
     author: str,
     name: str,
     description: str,
@@ -333,7 +333,7 @@ def generate_pkg(
 
         lines.append(')')
 
-        pkg_dir_path = path.join(dirpath, uuid_pkg)
+        pkg_dir_path = path.join('out', library, category, uuid_pkg)
         if not (path.exists(pkg_dir_path) and path.isdir(pkg_dir_path)):
             makedirs(pkg_dir_path)
         with open(path.join(pkg_dir_path, '.librepcb-pkg'), 'w') as f:
@@ -344,13 +344,7 @@ def generate_pkg(
 
 
 if __name__ == '__main__':
-    def _make(dirpath: str) -> None:
-        if not (path.exists(dirpath) and path.isdir(dirpath)):
-            makedirs(dirpath)
-
     # SOIC
-
-    _make('out/soic/pkg')
     configs = []  # type: List[SoConfig]
     for pin_count in [6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 28, 30, 32]:
         for height in [1.2, 1.4, 1.7, 2.7]:
@@ -360,7 +354,7 @@ if __name__ == '__main__':
             total_width = 8.42  # effective, not nominal (7.62)
             configs.append(SoConfig(pin_count, pitch, body_length, body_width, total_width, height))
     generate_pkg(
-        dirpath='out/soic/pkg',
+        library='LibrePCB_Base.lplib',
         author='Danilo B.',
         name='SOIC{pitch}P762X{height}-{pin_count}',
         description='{pin_count}-pin Small Outline Integrated Circuit (SOIC), '
@@ -383,7 +377,7 @@ if __name__ == '__main__':
             total_width = 16.04  # effective, not nominal (15.42)
             configs.append(SoConfig(pin_count, pitch, body_length, body_width, total_width, height))
     generate_pkg(
-        dirpath='out/soic/pkg',
+        library='LibrePCB_Base.lplib',
         author='Danilo B.',
         name='SOIC{pitch}P1524X{height}-{pin_count}',
         description='{pin_count}-pin Small Outline Integrated Circuit (SOIC), '
@@ -406,7 +400,7 @@ if __name__ == '__main__':
         total_width = 6.0
         configs.append(SoConfig(pin_count, pitch, body_length, body_width, total_width, height))
     generate_pkg(
-        dirpath='out/soic/pkg',
+        library='LibrePCB_Base.lplib',
         author='Danilo B.',
         name='SOIC{pitch}P600X{height}-{pin_count}',
         description='{pin_count}-pin Small Outline Integrated Circuit (SOIC), '
@@ -429,7 +423,7 @@ if __name__ == '__main__':
         total_width = 10.3
         configs.append(SoConfig(pin_count, pitch, body_length, body_width, total_width, height))
     generate_pkg(
-        dirpath='out/soic/pkg',
+        library='LibrePCB_Base.lplib',
         author='U. Bruhin',
         name='SOIC{pitch}P1030X{height}-{pin_count}',
         description='{pin_count}-pin Small Outline Integrated Circuit (SOIC), '
@@ -445,10 +439,8 @@ if __name__ == '__main__':
     )
 
     # TSSOP
-
-    _make('out/tssop/pkg')
     generate_pkg(
-        dirpath='out/tssop/pkg',
+        library='LibrePCB_Base.lplib',
         author='Danilo B.',
         # Name according to IPC7351C
         name='TSSOP{pin_count}P{pitch}_{body_length}X{lead_span}X{height}L{lead_length}X{lead_width}',
@@ -544,10 +536,8 @@ if __name__ == '__main__':
     )
 
     # SSOP
-
-    _make('out/ssop/pkg')
     generate_pkg(
-        dirpath='out/ssop/pkg',
+        library='LibrePCB_Base.lplib',
         author='Danilo B.',
         # Name according to IPC7351C
         name='SSOP{pin_count}P{pitch}_{body_length}X{lead_span}X{height}L{lead_length}X{lead_width}',
@@ -637,7 +627,7 @@ if __name__ == '__main__':
         create_date='2019-07-21T12:55:20Z',
     )
     generate_pkg(
-        dirpath='out/ssop/pkg',
+        library='LibrePCB_Base.lplib',
         author='Danilo B.',
         # Name according to IPC7351C
         name='SSOP{pin_count}P{pitch}_{body_length}X{lead_span}X{height}L{lead_length}X{lead_width}',
@@ -675,10 +665,8 @@ if __name__ == '__main__':
     )
 
     # TSOP
-
-    _make('out/tsop/pkg')
     generate_pkg(
-        dirpath='out/tsop/pkg',
+        library='LibrePCB_Base.lplib',
         author='Tubbles',
         # Name extrapolated from IPC7351C
         name='TSOP{pin_count}P{pitch}_{body_length}X{lead_span}X{height}L{lead_length}X{lead_width}',

--- a/generate_stm_mcu.py
+++ b/generate_stm_mcu.py
@@ -57,6 +57,7 @@ keywords_stm32 = Keywords('stm32, stm, st, mcu, microcontroller, arm, cortex')
 keywords_stm8 = Keywords('stm8, stm, st, mcu, microcontroller, 8bit')
 author = Author('Danilo Bargen, John Eaton')
 cmpcat = Category('22151601-c2d9-419a-87bc-266f9c7c3459')
+outdir = path.join('out', 'STMicroelectronics.lplib')
 
 # Initialize UUID cache
 uuid_cache_file = 'uuid_cache_stm_mcu.csv'
@@ -652,8 +653,7 @@ def generate_sym(mcus: List[MCU], symbol_map: Dict[str, str], debug: bool = Fals
     # Make sure all grouped symbols are identical
     assert len(set([str(s) for s in symbols])) == 1
 
-    dirpath = 'out/stm_mcu/sym'
-    sym_dir_path = path.join(dirpath, symbols[0].uuid)
+    sym_dir_path = path.join(outdir, 'sym', symbols[0].uuid)
     if not (path.exists(sym_dir_path) and path.isdir(sym_dir_path)):
         makedirs(sym_dir_path)
     with open(path.join(sym_dir_path, '.librepcb-sym'), 'w') as f:
@@ -756,7 +756,7 @@ def generate_cmp(
     # Make sure all grouped components are identical
     assert len(set([str(c) for c in components])) == 1
 
-    components[0].serialize('out/stm_mcu/cmp')
+    components[0].serialize(path.join(outdir, 'cmp'))
 
     print('Wrote cmp {}'.format(name))
 
@@ -811,22 +811,12 @@ def generate_dev(mcu: MCU, symbol_map: Dict[str, str], base_lib_path: str, debug
             SignalUUID(uuid('cmp', mcu.component_identifier, 'signal-{}'.format(pin.name))),
         ))
 
-    device.serialize('out/stm_mcu/dev')
+    device.serialize(path.join(outdir, 'dev'))
 
     print('Wrote dev {}'.format(name))
 
 
 def generate(data: Dict[str, MCU], base_lib_path: str, debug: bool = False) -> None:
-
-    def _make(dirpath: str) -> None:
-        if not (path.exists(dirpath) and path.isdir(dirpath)):
-            makedirs(dirpath)
-
-    _make('out')
-    _make('out/stm_mcu')
-    _make('out/stm_mcu/sym')
-    _make('out/stm_mcu/cmp')
-
     # A map mapping symbol names to UUIDs
     symbol_map = {}  # type: Dict[str, str]
 


### PR DESCRIPTION
Instead of generating the output into a directory like "out/led/pkg/", use the actual library directory where the files need to be added to, for example "out/LibrePCB_Base.lplib/pkg". This makes it much easier to copy the generated elements into the libraries. 

In addition, it is less error-prone since the library assignment is now stored in the generators (until now it was cumbersome to find out which files need to be copied into which library - especially if a single script generates output for multiple libraries).

I've run all generators to verify that their new output directory is correct.