### PR TITLE
qfp: Fix duplicate sentence in description

### DIFF
--- a/generate_qfp.py
+++ b/generate_qfp.py
@@ -350,7 +350,7 @@ def generate_pkg(
         # General info
         lines.append('(librepcb_package {}'.format(uuid_pkg))
         lines.append(' (name "{}")'.format(full_name))
-        lines.append(' (description "{}\\n\\nGenerated with {}")'.format(full_description, generator))
+        lines.append(' (description "{}")'.format(full_description))
         lines.append(' (keywords "{}")'.format(config.keywords))
         lines.append(' (author "{}")'.format(author))
         lines.append(' (version "{}")'.format(version))


### PR DESCRIPTION
The sentence "Generated with librepcb-parts-generator" was contained twice in the generated package description.

@rnestler Git blame mentioned your name and commit 586e4560f1f08bf552a8f34b81d842be858dc1d1 :grinning:  