### PR TITLE
Automatically escape strings by StringValue entity

### DIFF
--- a/common.py
+++ b/common.py
@@ -9,6 +9,18 @@ from datetime import datetime
 
 from typing import Any, Dict, Iterable, List, Union
 
+# String escape sequences
+STRING_ESCAPE_SEQUENCES = (
+    ('\\', '\\\\'),  # Must be the first one to avoid recursion!
+    ('\b', '\\b'),
+    ('\f', '\\f'),
+    ('\n', '\\n'),
+    ('\r', '\\r'),
+    ('\t', '\\t'),
+    ('\v', '\\v'),
+    ('"',  '\\"'),
+)
+
 # Commonly used dimensions
 COURTYARD_LINE_WIDTH = 0.1
 
@@ -40,6 +52,15 @@ def now() -> str:
     Return current timestamp as string.
     """
     return datetime.utcnow().replace(microsecond=0).isoformat() + 'Z'
+
+
+def escape_string(string: str) -> str:
+    """
+    Escape a string according to LibrePCB S-Expression escaping rules.
+    """
+    for search, replacement in STRING_ESCAPE_SEQUENCES:
+        string = string.replace(search, replacement)
+    return string
 
 
 def format_float(number: float) -> str:

--- a/entities/common.py
+++ b/entities/common.py
@@ -6,7 +6,7 @@ from enum import Enum
 
 from typing import List
 
-from common import format_float
+from common import escape_string, format_float
 
 from .helper import indent_entities
 
@@ -57,7 +57,7 @@ class StringValue():
         self.value = value
 
     def __str__(self) -> str:
-        return '({} "{}")'.format(self.name, self.value.replace('"', '\\"'))
+        return '({} "{}")'.format(self.name, escape_string(self.value))
 
 
 class FloatValue():

--- a/generate_capacitor_radial_tht.py
+++ b/generate_capacitor_radial_tht.py
@@ -227,11 +227,11 @@ def generate_pkg(
         uuid=_pkg_uuid('pkg'),
         name=Name(name),
         description=Description(
-            'Polarized radial electrolytic capacitor.\\n\\n' +
-            'Diameter: {} mm\\n'.format(diameter) +
-            'Height: {} mm\\n'.format(height) +
-            'Lead Spacing: {} mm\\n'.format(pitch) +
-            'Max. Lead Diameter: {} mm\\n\\n'.format(lead_width) +
+            'Polarized radial electrolytic capacitor.\n\n' +
+            'Diameter: {} mm\n'.format(diameter) +
+            'Height: {} mm\n'.format(height) +
+            'Lead Spacing: {} mm\n'.format(pitch) +
+            'Max. Lead Diameter: {} mm\n\n'.format(lead_width) +
             'Generated with {}'.format(generator)
         ),
         keywords=Keywords('electrolytic,capacitor,polarized,radial,c,cap,cpol'),
@@ -280,11 +280,11 @@ def generate_dev(
         uuid=_uuid('dev'),
         name=Name(name),
         description=Description(
-            'Generic polarized radial electrolytic capacitor.\\n\\n' +
-            'Diameter: {} mm\\n'.format(diameter) +
-            'Height: {} mm\\n'.format(height) +
-            'Lead Spacing: {} mm\\n'.format(pitch) +
-            'Max. Lead Diameter: {} mm\\n\\n'.format(lead_width) +
+            'Generic polarized radial electrolytic capacitor.\n\n' +
+            'Diameter: {} mm\n'.format(diameter) +
+            'Height: {} mm\n'.format(height) +
+            'Lead Spacing: {} mm\n'.format(pitch) +
+            'Max. Lead Diameter: {} mm\n\n'.format(lead_width) +
             'Generated with {}'.format(generator)
         ),
         keywords=Keywords('electrolytic,capacitor,polarized,radial,c,cap,cpol'),

--- a/generate_connectors.py
+++ b/generate_connectors.py
@@ -320,7 +320,7 @@ def generate_sym(
         symbol = Symbol(
             uuid_sym,
             Name('{} {}x{:02d}'.format(name, rows, per_row)),
-            Description('A {}x{} {}.\\n\\n'
+            Description('A {}x{} {}.\n\n'
                         'Generated with {}'.format(rows, per_row, name_lower, generator)),
             Keywords('connector, {}x{}, {}'.format(rows, per_row, keywords)),
             Author(author),
@@ -451,7 +451,7 @@ def generate_cmp(
         component = Component(
             uuid_cmp,
             Name('{} {}x{:02d}'.format(name, rows, per_row)),
-            Description('A {}x{} {}.\\n\\n'
+            Description('A {}x{} {}.\n\n'
                         'Generated with {}'.format(rows, per_row, name_lower, generator)),
             Keywords('connector, {}x{}, {}'.format(rows, per_row, keywords)),
             Author(author),

--- a/generate_led.py
+++ b/generate_led.py
@@ -79,12 +79,12 @@ class LedConfig:
         )
         self.pkg_description = \
             'Generic through-hole LED with {top_diameter:.2f} mm' \
-            ' body diameter.\\n\\n' \
-            'Body height: {body_height:.2f} mm.\\n' \
-            'Lead spacing: {lead_spacing:.2f} mm.\\n' \
-            'Standoff: {standoff:.2f} mm.\\n' \
+            ' body diameter.\n\n' \
+            'Body height: {body_height:.2f} mm.\n' \
+            'Lead spacing: {lead_spacing:.2f} mm.\n' \
+            'Standoff: {standoff:.2f} mm.\n' \
             'Body color: {body_color}.' \
-            '\\n\\nGenerated with {generator}'.format(
+            '\n\nGenerated with {generator}'.format(
                 top_diameter=top_diameter,
                 body_height=body_height,
                 lead_spacing=lead_spacing,

--- a/generate_stm_mcu.py
+++ b/generate_stm_mcu.py
@@ -409,11 +409,11 @@ class MCU:
         """
         Get a description of the symbol.
         """
-        description = 'A {} MCU by ST Microelectronics with the following pins:\\n\\n'.format(self.family)
+        description = 'A {} MCU by ST Microelectronics with the following pins:\n\n'.format(self.family)
         for pin_type in sorted(self.pin_types()):
             count = len(self.get_pin_names_by_type(pin_type))
-            description += '- {} {} pins\\n'.format(count, pin_type)
-        description += '\\nGenerated with {}'.format(generator)
+            description += '- {} {} pins\n'.format(count, pin_type)
+        description += '\nGenerated with {}'.format(generator)
         return description
 
     @property
@@ -432,22 +432,22 @@ class MCU:
         """
         Get a description of the component.
         """
-        description = 'A {} MCU by ST Microelectronics.\\n\\n'.format(self.ref_without_flash)
-        description += 'I/Os: {}\\n'.format(self.io_count)
-        description += '\\nGenerated with {}'.format(generator)
+        description = 'A {} MCU by ST Microelectronics.\n\n'.format(self.ref_without_flash)
+        description += 'I/Os: {}\n'.format(self.io_count)
+        description += '\nGenerated with {}'.format(generator)
         return description
 
     @property
     def description(self) -> str:
-        description = 'A {} MCU by ST Microelectronics.\\n\\n'.format(self.name)
-        description += 'Package: {}\\nFlash: {}\\nRAM: {}\\nI/Os: {}\\nFrequency: {}\\n'.format(
+        description = 'A {} MCU by ST Microelectronics.\n\n'.format(self.name)
+        description += 'Package: {}\nFlash: {}\nRAM: {}\nI/Os: {}\nFrequency: {}\n'.format(
             self.package, self.flash, self.ram, self.io_count, self.frequency,
         )
         if self.voltage:
-            description += 'Voltage: {}\\n'.format(self.voltage)
+            description += 'Voltage: {}\n'.format(self.voltage)
         if self.temperature:
-            description += 'Temperature range: {}\\n'.format(self.temperature)
-        description += '\\nGenerated with {}'.format(generator)
+            description += 'Temperature range: {}\n'.format(self.temperature)
+        description += '\nGenerated with {}'.format(generator)
         return description
 
     def generate_placement_data(self, debug: bool = False) -> Tuple[SymbolPinPlacement, Dict[str, str]]:

--- a/test_common.py
+++ b/test_common.py
@@ -1,7 +1,16 @@
 import pytest
 
-from common import format_float as ff
-from common import format_ipc_dimension, human_sort_key, sign
+from common import escape_string, format_float, format_ipc_dimension, human_sort_key, sign
+
+
+@pytest.mark.parametrize(['inval', 'outval'], [
+    ('', ''),
+    ('"', '\\"'),
+    ('\n', '\\n'),
+    ('\\', '\\\\'),
+])
+def test_escape_string(inval: str, outval: str):
+    assert escape_string(inval) == outval
 
 
 @pytest.mark.parametrize(['inval', 'outval'], [
@@ -12,7 +21,7 @@ from common import format_ipc_dimension, human_sort_key, sign
     (-0.0001, '0.0'),  # Unsigned zero, due to rounding to 3 decimals
 ])
 def test_format_float(inval: float, outval: str):
-    assert ff(inval) == outval
+    assert format_float(inval) == outval
 
 
 @pytest.mark.parametrize(['inval', 'outval'], [

--- a/test_entities.py
+++ b/test_entities.py
@@ -21,7 +21,7 @@ def test_name() -> None:
 
 
 def test_description() -> None:
-    description = str(Description("My Description\\nWith two \" lines"))
+    description = str(Description("My Description\nWith two \" lines"))
     assert description == '(description "My Description\\nWith two \\" lines")'
 
 
@@ -81,7 +81,7 @@ def test_text() -> None:
 
 
 def test_symbol() -> None:
-    symbol = Symbol('01b03c10-7334-4bd5-b2bc-942c18325d2b', Name('Sym name'), Description(r'A multiline description.\n\nDescription'), Keywords('my, keywords'), Author('Test'), Version('0.2'), Created('2018-10-17T19:13:41Z'), Category('d0618c29-0436-42da-a388-fdadf7b23892'))
+    symbol = Symbol('01b03c10-7334-4bd5-b2bc-942c18325d2b', Name('Sym name'), Description('A multiline description.\n\nDescription'), Keywords('my, keywords'), Author('Test'), Version('0.2'), Created('2018-10-17T19:13:41Z'), Category('d0618c29-0436-42da-a388-fdadf7b23892'))
     symbol.add_pin(SymbolPin('6da06b2b-7806-4e68-bd0c-e9f18eb2f9d8', Name('1'), Position(5.08, 20.32), Rotation(180.0), Length(3.81)))
     polygon = Polygon('743dbf3d-98e8-46f0-9a32-00e00d0e811f', Layer('sym_outlines'), Width(0.25), Fill(False), GrabArea(True))
     polygon.add_vertex(Vertex(Position(-2.54, 22.86), Angle(0.0)))
@@ -163,7 +163,7 @@ def test_component_variant() -> None:
 
 
 def test_component() -> None:
-    component = Component('00c36da8-e22b-43a1-9a87-c3a67e863f49', Name('Generic Connector 1x27'), Description(r'A 1x27 soldered wire connector.\n\nNext line'), Keywords('connector, 1x27'), Author('Test R.'), Version('0.2'), Created('2018-10-17T19:13:41Z'), Deprecated(False), Category('d0618c29-0436-42da-a388-fdadf7b23892'), SchematicOnly(False), DefaultValue(''), Prefix('J'))
+    component = Component('00c36da8-e22b-43a1-9a87-c3a67e863f49', Name('Generic Connector 1x27'), Description('A 1x27 soldered wire connector.\n\nNext line'), Keywords('connector, 1x27'), Author('Test R.'), Version('0.2'), Created('2018-10-17T19:13:41Z'), Deprecated(False), Category('d0618c29-0436-42da-a388-fdadf7b23892'), SchematicOnly(False), DefaultValue(''), Prefix('J'))
     component.add_signal(Signal('f46a4643-fc68-4593-a889-3d987bfe3544', Name('1'), Role.PASSIVE, Required(False), Negated(False), Clock(False), ForcedNet('')))
 
     gate = Gate('c1e4b542-a1b1-44d5-bec3-070776143a29', SymbolUUID('8f1a97f2-4cdf-43da-b38d-b3787c47b5ad'), Position(0.0, 0.0), Rotation(0.0), Required(True), Suffix(''))
@@ -272,7 +272,7 @@ def test_package() -> None:
     package.add_footprint(create_footprint())
     assert str(package) == """(librepcb_package 009e35ef-1f50-4bf3-ab58-11eb85bf5503
  (name "Soldered Wire Connector 1x19 ⌀1.0mm")
- (description "A 1x19 soldered wire connector with 2.54mm pin spacing and 1.0mm drill holes.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)")
+ (description "A 1x19 soldered wire connector with 2.54mm pin spacing and 1.0mm drill holes.\\n\\nGenerated with librepcb-parts-generator (generate_connectors.py)")
  (keywords "connector, 1x19, d1.0, connector, soldering, generic")
  (author "Danilo B.")
  (version "0.1")


### PR DESCRIPTION
Instead of escaping each string manually within the generators (mainly `\n` -> `\\n`), perform the escaping during serialization of the `StringValue` entity. So the generators do no longer need to know how strings need to be escaped.