### PR TITLE
Add script to generate 3D models for TO-92

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ __pycache__/
 .mypy_cache/
 .pytest_cache/
 out/
+out_3d/
 *.pdf

--- a/generate_to92.py
+++ b/generate_to92.py
@@ -1,0 +1,84 @@
+"""
+Generate only the 3D models for TO-92
+"""
+from os import path
+
+import cadquery as cq
+
+from cadquery_helpers import StepAssembly, StepColor, StepConstants
+
+
+def generate_leg_path(plane: str, length: float, delta: float) -> cq.Workplane:
+    straight_length = 1
+    return cq.Workplane(plane) \
+        .vLine(length - straight_length - abs(delta)) \
+        .line(-delta, abs(delta)) \
+        .vLine(straight_length)
+
+
+def generate(
+    name: str,
+    pitch_x: float,
+    pitch_y: float,
+) -> None:
+    print(f'Generating pkg 3D model "{name}"')
+
+    body_standoff = 3.0
+    body_height = 5.0
+    body_diameter = 5.1
+    body_edge = -1.65
+    leg_width = 0.45
+    leg_z = -StepConstants.THT_LEAD_SOLDER_LENGTH
+    leg_length = StepConstants.THT_LEAD_SOLDER_LENGTH + body_standoff + 0.1
+
+    body = cq.Workplane('XY', origin=(0, 0, body_standoff)) \
+        .cylinder(body_height, body_diameter / 2, centered=(True, True, False)) \
+        .fillet(0.3) \
+        .moveTo(0, body_edge - 10) \
+        .box(20, 10, 50, centered=(True, False, False), combine='cut')
+
+    leg_straight = cq.Workplane('XY', origin=(0, 0, leg_z)) \
+        .box(leg_width, leg_width, leg_length, centered=(True, True, False))
+    if pitch_x == 1.27:
+        leg_1 = leg_straight
+        leg_3 = leg_straight
+    else:
+        leg_1 = cq.Workplane('XY') \
+            .rect(leg_width, leg_width) \
+            .sweep(generate_leg_path('XZ', leg_length, -pitch_x + 1.27)) \
+            .translate((-pitch_x + 1.27, 0, leg_z))
+        leg_3 = cq.Workplane('XY') \
+            .rect(leg_width, leg_width) \
+            .sweep(generate_leg_path('XZ', leg_length, pitch_x - 1.27)) \
+            .translate((pitch_x - 1.27, 0, leg_z))
+    if pitch_y == 0:
+        leg_2 = leg_straight
+    else:
+        leg_2 = cq.Workplane('XY') \
+            .rect(leg_width, leg_width) \
+            .sweep(generate_leg_path('YZ', leg_length, pitch_y)) \
+            .translate((0, pitch_y, leg_z))
+
+    assembly = StepAssembly(name)
+    assembly.add_body(body, 'body', StepColor.IC_BODY)
+    assembly.add_body(
+        leg_1, 'leg-1', StepColor.LEAD_SMT,
+        location=cq.Location((-1.27, 0, 0))
+    )
+    assembly.add_body(
+        leg_2, 'leg-2', StepColor.LEAD_SMT,
+        location=cq.Location((0, 0, 0))
+    )
+    assembly.add_body(
+        leg_3, 'leg-3', StepColor.LEAD_SMT,
+        location=cq.Location((1.27, 0, 0))
+    )
+
+    out_path = path.join('out_3d', 'to92', f'{name}.step')
+    assembly.save(out_path, fused=True)
+
+
+if __name__ == '__main__':
+    generate(name='Straight', pitch_x=1.27, pitch_y=0)
+    generate(name='Zigzag', pitch_x=1.27, pitch_y=1.27)
+    generate(name='Wide', pitch_x=2.54, pitch_y=0)


### PR DESCRIPTION
I already had the situation several times that I wanted to generate a 3D model for a package which was created by hand and without the intention to also generate the package because it's just a single (or a few) package not worth to generate. One example is TO-92, but there are many more such packages.

However, so far this repository contains only generators creating the complete library elements. So I wonder how we should handle the case where we only want to generate the 3D model. Initially I started with a new top-level directory called "3d" which would contain pure 3D generators, and a corresponding "out" directory. However, I think this doesn't work because the dependency `cadquery_helpers.py` is in the top level directory ("ImportError: attempted relative import with no known parent package").

So for now I came up with just adding the new script `generate_to92.py` and its output directory `out_3d` to the root directory. Maybe that's actually not that bad since those scripts might some day be extend to also generate the whole package, then they are already at the correct location.

Note that we cannot reuse the existing `out` directory for plain 3D models because the `out` directory is intended to be copied 1:1 into a LibrePCB workspace, while the 3D models need to be imported manually into the LibrePCB library editor. So the new script just writes some 3D models into `out_3d/to92/` and these STEP models then need to be manually loaded into LibrePCB.

Theoretically we don't need to store these scripts (because no UUIDs are generated, no cache is needed) but of course it would be nice to still have the source of the 3D models stored somewhere.

Any opinions/ideas welcome!

Btw, here the generated models:

![librepcb-to92](https://github.com/LibrePCB/librepcb-parts-generator/assets/5374821/b5149db8-557a-4e05-b2d5-71e107721b14)