### PR TITLE
connectors: Fix all reported library editor messages

### DIFF
--- a/uuid_cache_connectors.csv
+++ b/uuid_cache_connectors.csv
@@ -6847,6 +6847,8 @@ pkg-pinheader-1x1-d0.9-footprint-default,0357e4dd-24e8-44ae-84aa-f1c04d1117d4
 pkg-pinheader-1x1-d0.9-pad-0,20ab181f-f087-4a17-95b4-dd2ecb4095a9
 pkg-pinheader-1x1-d0.9-pkg,3bb768ad-be21-4eb7-a1ce-cc9b38b317e9
 pkg-pinheader-1x1-d0.9-polygon-contour,c9d2e55e-8eb2-4e68-b113-d6232ee99ae7
+pkg-pinheader-1x1-d0.9-polygon-courtyard,1f3dd705-3da7-4798-a705-15ebab3d2631
+pkg-pinheader-1x1-d0.9-polygon-outline,17e8daef-3af8-49b5-908b-8c11ed3351e4
 pkg-pinheader-1x1-d0.9-text-name,e3568adf-a3fb-4d67-8464-3efd9aac4d12
 pkg-pinheader-1x1-d0.9-text-value,edb32bb2-8ced-4199-8289-99ff1fadff73
 pkg-pinheader-1x1-d1.0-3d,4448ef35-52a9-4bd1-92ad-8b9f5e383037
@@ -6854,6 +6856,8 @@ pkg-pinheader-1x1-d1.0-footprint-default,d3e0fc9b-f423-4c9b-85cf-9f8e1c33dc0e
 pkg-pinheader-1x1-d1.0-pad-0,9adeac7a-860e-4a62-a938-b1214a7fce00
 pkg-pinheader-1x1-d1.0-pkg,f771d9ab-c693-4a32-b2ab-7f84278ec86d
 pkg-pinheader-1x1-d1.0-polygon-contour,96708d15-1ee3-4381-a73a-b3cda9d3121c
+pkg-pinheader-1x1-d1.0-polygon-courtyard,73e354d2-9b10-44f7-8ceb-a9aa41cd4880
+pkg-pinheader-1x1-d1.0-polygon-outline,257b93f1-d033-40d2-a254-a646fa397794
 pkg-pinheader-1x1-d1.0-text-name,b85f5118-c598-4827-9ecf-0f3920e90f7d
 pkg-pinheader-1x1-d1.0-text-value,f92189d5-31f7-4cbf-bf95-70ad15cc65c3
 pkg-pinheader-1x1-d1.1-3d,569176d3-2203-420a-8a2b-02848c5ee76c
@@ -6861,6 +6865,8 @@ pkg-pinheader-1x1-d1.1-footprint-default,5cb38751-ddb3-452b-87c5-78c1190b14ae
 pkg-pinheader-1x1-d1.1-pad-0,bc6d43e4-e1fd-4983-98ce-5f51920b0cf5
 pkg-pinheader-1x1-d1.1-pkg,1e379491-e8bd-4851-ab03-15f5fee37044
 pkg-pinheader-1x1-d1.1-polygon-contour,1c50cbf0-3399-4a2c-a0b8-3d1e0abda45e
+pkg-pinheader-1x1-d1.1-polygon-courtyard,14caa0ed-faf1-448a-b2c4-190a68c743c9
+pkg-pinheader-1x1-d1.1-polygon-outline,9c27afc7-3d02-48bc-a270-7f448f262557
 pkg-pinheader-1x1-d1.1-text-name,2d1d8778-de46-47d7-ae2e-a1fa9c6a29d1
 pkg-pinheader-1x1-d1.1-text-value,07964601-e5e5-442d-b044-fa1b2bfede2b
 pkg-pinheader-1x10-d0.9-3d,b37f4fd0-5e56-4f3e-8108-038fe7c5bc7a
@@ -6877,6 +6883,8 @@ pkg-pinheader-1x10-d0.9-pad-8,dd7fb056-12e1-4ab4-820b-7f89041d5132
 pkg-pinheader-1x10-d0.9-pad-9,ac12a017-79a4-4b62-a581-b73052d0d55d
 pkg-pinheader-1x10-d0.9-pkg,4d8ac719-70ed-423c-8538-ffd26b05ffc3
 pkg-pinheader-1x10-d0.9-polygon-contour,a86d674f-af05-4b9f-bc4a-ccfcd513f1a8
+pkg-pinheader-1x10-d0.9-polygon-courtyard,33461973-c990-48b7-8e7b-4ac3f5bb5c4d
+pkg-pinheader-1x10-d0.9-polygon-outline,ca667d90-dc19-4751-b700-f217794bd2e6
 pkg-pinheader-1x10-d0.9-text-name,30283081-4c58-49fc-9a10-c92eed11b04e
 pkg-pinheader-1x10-d0.9-text-value,fb258b82-fff2-447e-ba34-39976733a7b4
 pkg-pinheader-1x10-d1.0-3d,c871621d-823c-43b7-bdcb-c23b2d916f83
@@ -6893,6 +6901,8 @@ pkg-pinheader-1x10-d1.0-pad-8,d63eed1a-b92f-41b7-8655-fed9f8c0c8fe
 pkg-pinheader-1x10-d1.0-pad-9,fd25d598-98de-4800-927c-ca4c3f38e8a5
 pkg-pinheader-1x10-d1.0-pkg,f17aded1-4bce-45af-9eeb-8f064e4d987f
 pkg-pinheader-1x10-d1.0-polygon-contour,4dd16eab-5f34-434a-8424-a3fbba8acac7
+pkg-pinheader-1x10-d1.0-polygon-courtyard,f3c88b55-3b91-4809-a629-e1f054e8e679
+pkg-pinheader-1x10-d1.0-polygon-outline,11dfa9a0-6901-4b65-becc-fe4d919af2bd
 pkg-pinheader-1x10-d1.0-text-name,95c26bab-bf7f-4c2f-b1f1-51eefa99cd5b
 pkg-pinheader-1x10-d1.0-text-value,4dcbfa16-7cc4-46c4-bef1-5026fb50158b
 pkg-pinheader-1x10-d1.1-3d,1c092ded-a6f8-4c95-bfbd-833207fee1e0
@@ -6909,6 +6919,8 @@ pkg-pinheader-1x10-d1.1-pad-8,0a15832e-fecc-497c-97d1-1a65c9fa319e
 pkg-pinheader-1x10-d1.1-pad-9,52a44172-8883-4875-93b9-1f33e9ee322d
 pkg-pinheader-1x10-d1.1-pkg,5e3d6fb8-59e0-451d-8063-f8bff3143e69
 pkg-pinheader-1x10-d1.1-polygon-contour,5cacf5de-c82f-4043-a97b-55d142fb0350
+pkg-pinheader-1x10-d1.1-polygon-courtyard,739bb3be-e725-45ba-8379-3ead2820fd99
+pkg-pinheader-1x10-d1.1-polygon-outline,8f69db4f-218b-4b38-a663-fc4624438ee7
 pkg-pinheader-1x10-d1.1-text-name,579f22d7-a12f-43ca-a94b-6aa52645ffd6
 pkg-pinheader-1x10-d1.1-text-value,08b40e2f-6de7-45ca-b3f6-82fd9f2a40ad
 pkg-pinheader-1x11-d0.9-3d,6fb60230-d3a5-4faa-a7c8-a80f51656d59
@@ -6926,6 +6938,8 @@ pkg-pinheader-1x11-d0.9-pad-8,68c71761-0f54-40a7-8f86-b732a3cf03f8
 pkg-pinheader-1x11-d0.9-pad-9,1178004f-5cc9-4bde-92cc-af5134bbb900
 pkg-pinheader-1x11-d0.9-pkg,32b4f090-6233-42e1-b9ca-ffca301884e5
 pkg-pinheader-1x11-d0.9-polygon-contour,3996380f-b237-4c09-a598-a588f0bf5380
+pkg-pinheader-1x11-d0.9-polygon-courtyard,8c358823-1edf-43be-b941-d1b236fc4ecd
+pkg-pinheader-1x11-d0.9-polygon-outline,64f436c3-a575-4489-8154-73465144212c
 pkg-pinheader-1x11-d0.9-text-name,17464a13-10f3-4876-beab-19feff8adcde
 pkg-pinheader-1x11-d0.9-text-value,18bec20b-7b25-46a9-a162-57c41ebc5739
 pkg-pinheader-1x11-d1.0-3d,ed415912-822b-4647-ae1c-09fd11b4c917
@@ -6943,6 +6957,8 @@ pkg-pinheader-1x11-d1.0-pad-8,fb32491e-b7a2-4079-aead-5dad0aa183a5
 pkg-pinheader-1x11-d1.0-pad-9,f4f05a39-625e-4869-818e-b3c48c0b60f7
 pkg-pinheader-1x11-d1.0-pkg,ba4f8d52-831e-468c-919b-154f1a6a03ab
 pkg-pinheader-1x11-d1.0-polygon-contour,e9375e09-43ea-4f0e-9df5-aacdeefd86ad
+pkg-pinheader-1x11-d1.0-polygon-courtyard,ad7cae66-510f-4e3d-8484-4b1254200959
+pkg-pinheader-1x11-d1.0-polygon-outline,f03a1423-8c70-4556-a485-a68c8ef69ba2
 pkg-pinheader-1x11-d1.0-text-name,759a5c6a-a99e-4046-b9ef-04928f824001
 pkg-pinheader-1x11-d1.0-text-value,75fb5622-0e9e-4627-9fd5-d06fa99e7495
 pkg-pinheader-1x11-d1.1-3d,3b6d942f-baa3-405c-9264-9f21f8f5dc63
@@ -6960,6 +6976,8 @@ pkg-pinheader-1x11-d1.1-pad-8,867e8976-21cb-4515-846e-ba79419d7c1d
 pkg-pinheader-1x11-d1.1-pad-9,e5fd52ca-b76d-455c-89bb-8298e26ae44b
 pkg-pinheader-1x11-d1.1-pkg,1d1f16bc-b332-4b16-b810-63735deafc93
 pkg-pinheader-1x11-d1.1-polygon-contour,23ceb00a-7363-4c67-8f41-0ccab3a2a2bf
+pkg-pinheader-1x11-d1.1-polygon-courtyard,ad622190-a6f6-40cb-8864-40535758bfaa
+pkg-pinheader-1x11-d1.1-polygon-outline,6a6d4e83-2997-411f-b36c-83ceb17ee3c5
 pkg-pinheader-1x11-d1.1-text-name,3c0fb113-d94a-4388-919b-d9612f7648ab
 pkg-pinheader-1x11-d1.1-text-value,79150599-4d77-46f1-8e59-82e93b2ac282
 pkg-pinheader-1x12-d0.9-3d,1200c346-d194-4333-83eb-90c3d2988d88
@@ -6978,6 +6996,8 @@ pkg-pinheader-1x12-d0.9-pad-8,130b70bf-d799-40fd-ba83-47e10692376a
 pkg-pinheader-1x12-d0.9-pad-9,39092b62-e623-465e-9c46-e6d90f2e87d6
 pkg-pinheader-1x12-d0.9-pkg,4f0bf816-b8d5-4004-8fe8-008752ae42b0
 pkg-pinheader-1x12-d0.9-polygon-contour,a7868bd6-3cef-4c39-a938-61ec846a5714
+pkg-pinheader-1x12-d0.9-polygon-courtyard,b9c01051-0941-4242-b571-6570771ca4e1
+pkg-pinheader-1x12-d0.9-polygon-outline,5515a3cd-b0ff-4d9f-a117-3a24b5dcd630
 pkg-pinheader-1x12-d0.9-text-name,89c7de38-ef48-4ce0-a443-9bcd31127260
 pkg-pinheader-1x12-d0.9-text-value,b4533f1e-56ea-4859-b8cd-8ff7eca14221
 pkg-pinheader-1x12-d1.0-3d,f778a4a6-b814-472b-949b-dd83fa255dcc
@@ -6996,6 +7016,8 @@ pkg-pinheader-1x12-d1.0-pad-8,35c5ae4e-4b88-4f71-9ed7-a00c1b0ba8f4
 pkg-pinheader-1x12-d1.0-pad-9,76d6b9f6-3900-4617-a406-67e1792a317b
 pkg-pinheader-1x12-d1.0-pkg,c380e4c7-23d5-45a0-9ca1-9a005df066d4
 pkg-pinheader-1x12-d1.0-polygon-contour,a67c3c83-e35f-4d2e-ae53-f59069663fa4
+pkg-pinheader-1x12-d1.0-polygon-courtyard,5a35e7b5-8071-4494-a28b-38d6263d71b2
+pkg-pinheader-1x12-d1.0-polygon-outline,da1ed254-cb2c-4711-8507-47137aa32f9d
 pkg-pinheader-1x12-d1.0-text-name,52c11290-16ae-41d2-b0ea-d3ac73e5dadb
 pkg-pinheader-1x12-d1.0-text-value,e04ef475-a795-462e-9dcc-fb9d23d02302
 pkg-pinheader-1x12-d1.1-3d,74b0e631-3643-4cce-bbd1-cf260b1562af
@@ -7014,6 +7036,8 @@ pkg-pinheader-1x12-d1.1-pad-8,e0d3cb65-1a7f-4cfb-bc29-b1bb9fe9ca94
 pkg-pinheader-1x12-d1.1-pad-9,a5a23fe7-9f1f-423f-9cb8-248bb7ceef33
 pkg-pinheader-1x12-d1.1-pkg,3624e466-bbd9-43cc-b974-991fdbb889e3
 pkg-pinheader-1x12-d1.1-polygon-contour,daac7fea-85b9-42fc-82c0-b52c4389d0cb
+pkg-pinheader-1x12-d1.1-polygon-courtyard,a9b059b2-e64d-4a1e-95e6-51b4427ca766
+pkg-pinheader-1x12-d1.1-polygon-outline,f5e9cc41-4d9b-4c77-9682-2972c531afcf
 pkg-pinheader-1x12-d1.1-text-name,d0e094bb-c411-4190-a1e4-6849e2abdf83
 pkg-pinheader-1x12-d1.1-text-value,c4dcb7e6-2e4a-45c7-a620-9e12107a1194
 pkg-pinheader-1x13-d0.9-3d,3ce54150-b1d8-420f-91d4-d54db157603d
@@ -7033,6 +7057,8 @@ pkg-pinheader-1x13-d0.9-pad-8,a6788b98-0e62-4827-9e0f-b34241ff174a
 pkg-pinheader-1x13-d0.9-pad-9,1b90db36-ab63-4e86-b201-955ccf907813
 pkg-pinheader-1x13-d0.9-pkg,d22b8726-ef79-4571-96c4-3ba9d50ec9f5
 pkg-pinheader-1x13-d0.9-polygon-contour,34f38ead-1fdd-4f9a-9142-63bd5598fb15
+pkg-pinheader-1x13-d0.9-polygon-courtyard,7bae24e1-0cc5-4fe4-bee7-5bf039aa9cf5
+pkg-pinheader-1x13-d0.9-polygon-outline,3c9a8368-81d1-471d-be8e-d1407c1ef62a
 pkg-pinheader-1x13-d0.9-text-name,e173b83a-dc0b-4f69-a161-ecb7501c80b7
 pkg-pinheader-1x13-d0.9-text-value,8afab68f-b0b7-417d-8574-d84152e3dc67
 pkg-pinheader-1x13-d1.0-3d,5c84558b-3fd0-40c5-96e9-0bf028f66def
@@ -7052,6 +7078,8 @@ pkg-pinheader-1x13-d1.0-pad-8,62ebfc87-b39c-4c67-968f-8198e9c972fa
 pkg-pinheader-1x13-d1.0-pad-9,c218bc8b-a191-4ebf-9501-4fbeaf688d4b
 pkg-pinheader-1x13-d1.0-pkg,2195fd55-5c94-4165-bea8-106c7423c564
 pkg-pinheader-1x13-d1.0-polygon-contour,fb83af7b-6779-4c95-af5f-ed1bb2d30ec9
+pkg-pinheader-1x13-d1.0-polygon-courtyard,068a2253-7e73-4e01-974b-efe72e06fe23
+pkg-pinheader-1x13-d1.0-polygon-outline,ea624a90-7fe3-48e0-bedc-9704a204d52c
 pkg-pinheader-1x13-d1.0-text-name,9d2da876-0a10-4c56-882b-2d58497c8ade
 pkg-pinheader-1x13-d1.0-text-value,e38e1458-ab2a-4864-a6a5-c4964d5af627
 pkg-pinheader-1x13-d1.1-3d,3722b7ac-7e1e-4454-9c3f-0c21f0dd5861
@@ -7071,6 +7099,8 @@ pkg-pinheader-1x13-d1.1-pad-8,25898aaf-59fb-4c0c-9c12-6e3e9bdfbe64
 pkg-pinheader-1x13-d1.1-pad-9,3c94dd63-6c94-4536-a53a-35b5221d510c
 pkg-pinheader-1x13-d1.1-pkg,682df791-4ce4-46cc-941c-d4d9ac9eab75
 pkg-pinheader-1x13-d1.1-polygon-contour,90f032eb-d251-48f3-a842-bb08793ecca6
+pkg-pinheader-1x13-d1.1-polygon-courtyard,52fbd76f-7ae1-462f-9fd7-6d0b930f55bd
+pkg-pinheader-1x13-d1.1-polygon-outline,e0dd36c5-aeb2-4ea7-a385-13b6f81f1afc
 pkg-pinheader-1x13-d1.1-text-name,46c8faac-9147-4b1a-a23b-ad6b2011f929
 pkg-pinheader-1x13-d1.1-text-value,4a1e5e81-e652-4391-8e1f-43c7d6c827ea
 pkg-pinheader-1x14-d0.9-3d,47508ad7-e7aa-40c3-a303-7f0dbd8bfb5d
@@ -7091,6 +7121,8 @@ pkg-pinheader-1x14-d0.9-pad-8,a0e55518-0ecc-4ba6-b3f1-66aeaa3921af
 pkg-pinheader-1x14-d0.9-pad-9,0a69693f-1186-4244-91ed-1d96c9154e33
 pkg-pinheader-1x14-d0.9-pkg,8c5c10f6-23cd-462d-bd35-968e1a85094a
 pkg-pinheader-1x14-d0.9-polygon-contour,a9f7036d-5a61-447a-80f2-a54a9af512ec
+pkg-pinheader-1x14-d0.9-polygon-courtyard,97c447ae-3f26-4056-9ef3-e22e08379e52
+pkg-pinheader-1x14-d0.9-polygon-outline,6313ee05-e1e6-4ad2-a4f7-f72a4dfcc47c
 pkg-pinheader-1x14-d0.9-text-name,007be9bb-313f-47cf-a52a-1e9aeafd2367
 pkg-pinheader-1x14-d0.9-text-value,484242f1-397b-461b-a09c-9f319dd8ce2e
 pkg-pinheader-1x14-d1.0-3d,ba01adc6-03d1-4afb-8948-e36b22bc1637
@@ -7111,6 +7143,8 @@ pkg-pinheader-1x14-d1.0-pad-8,0baee767-cc9b-4ac7-a3bf-b2e3f3576c17
 pkg-pinheader-1x14-d1.0-pad-9,504371db-7187-442c-92c3-ff59a08f3f2e
 pkg-pinheader-1x14-d1.0-pkg,03677be1-b8aa-4495-9049-36f771cdd860
 pkg-pinheader-1x14-d1.0-polygon-contour,2d269bbf-97a1-4a4e-b03e-629ccfc78b54
+pkg-pinheader-1x14-d1.0-polygon-courtyard,56133efe-6ea3-497d-93bf-5c956f5ebf72
+pkg-pinheader-1x14-d1.0-polygon-outline,e1759f08-21da-46cf-aaa3-e204406a426d
 pkg-pinheader-1x14-d1.0-text-name,674e6402-29ab-4790-bc63-3ec02d9bbfb7
 pkg-pinheader-1x14-d1.0-text-value,d3e1138b-35fb-439c-aad8-8391b849b4a2
 pkg-pinheader-1x14-d1.1-3d,f8b04e82-553e-417b-b5f9-153a899d9250
@@ -7131,6 +7165,8 @@ pkg-pinheader-1x14-d1.1-pad-8,d2c3bf84-cd32-460b-8a5c-250b3a8f1f61
 pkg-pinheader-1x14-d1.1-pad-9,eacc55aa-a4fa-4061-aa0c-1816636f77b1
 pkg-pinheader-1x14-d1.1-pkg,36fc1254-c0e3-4520-82e7-1cbe589edafb
 pkg-pinheader-1x14-d1.1-polygon-contour,1b2bdd14-84d4-4a7d-8228-390e23966d0d
+pkg-pinheader-1x14-d1.1-polygon-courtyard,9f376d72-0489-45f9-868f-817826f131b0
+pkg-pinheader-1x14-d1.1-polygon-outline,052d7269-8e14-4744-ba52-03ab80c0fd6a
 pkg-pinheader-1x14-d1.1-text-name,40a49bfa-5d13-40e2-be0c-814c853d6124
 pkg-pinheader-1x14-d1.1-text-value,a954ca52-2106-4e0b-aa2e-c7452ebd24d8
 pkg-pinheader-1x15-d0.9-3d,f6d17f15-7892-4018-9304-832c7530cc5c
@@ -7152,6 +7188,8 @@ pkg-pinheader-1x15-d0.9-pad-8,90c6fca9-521b-44af-a777-870c60fe2d33
 pkg-pinheader-1x15-d0.9-pad-9,06a7f964-dcbe-4cb8-83df-80e9573aeca2
 pkg-pinheader-1x15-d0.9-pkg,c26ffdfb-e7a6-432e-97c2-3e0605b4d5ae
 pkg-pinheader-1x15-d0.9-polygon-contour,66032e57-0ca4-4e2c-81b2-e93cc5214047
+pkg-pinheader-1x15-d0.9-polygon-courtyard,ab76c9cf-b9e4-4118-836f-627c01100bcc
+pkg-pinheader-1x15-d0.9-polygon-outline,0981c284-8738-4628-96fc-d0ac9626bcaf
 pkg-pinheader-1x15-d0.9-text-name,9b659b13-9c08-4476-b230-c3206a31a4e0
 pkg-pinheader-1x15-d0.9-text-value,1c2ea7fd-3367-485c-ad63-27a265206130
 pkg-pinheader-1x15-d1.0-3d,d8be9fdd-3cb8-47ef-ba88-9a1e88e9e2f2
@@ -7173,6 +7211,8 @@ pkg-pinheader-1x15-d1.0-pad-8,ab0242a2-d733-46bc-9dfb-5a5bc4c16c3c
 pkg-pinheader-1x15-d1.0-pad-9,e2246067-7cf1-49ba-a815-7554a2bd6aa7
 pkg-pinheader-1x15-d1.0-pkg,bd308afd-7fa2-4408-a530-76eeb7296e7c
 pkg-pinheader-1x15-d1.0-polygon-contour,94488ab0-9d83-4b63-954f-3bae0f78423e
+pkg-pinheader-1x15-d1.0-polygon-courtyard,acb2d19d-07b8-49c9-9219-9896ec3f3a6f
+pkg-pinheader-1x15-d1.0-polygon-outline,dd79d9b9-ed69-44d3-9a28-5c916d929a2a
 pkg-pinheader-1x15-d1.0-text-name,72aa6087-b585-4cec-a307-fcf8d38c58b5
 pkg-pinheader-1x15-d1.0-text-value,cbb1515c-898d-4475-823b-f89ff68d9ae7
 pkg-pinheader-1x15-d1.1-3d,fa5ca994-4cdc-441e-989d-9dd9c354ea4d
@@ -7194,6 +7234,8 @@ pkg-pinheader-1x15-d1.1-pad-8,ed5ad493-0a5f-47da-ba62-70e487b8207a
 pkg-pinheader-1x15-d1.1-pad-9,4b2c7d55-a31e-4f6a-9658-da4d6ec6a125
 pkg-pinheader-1x15-d1.1-pkg,88b28433-0b5a-4ccb-8bc8-1367a4668aff
 pkg-pinheader-1x15-d1.1-polygon-contour,d5af4dd3-8c03-4012-addd-4e35bc6d2666
+pkg-pinheader-1x15-d1.1-polygon-courtyard,e6c18bfd-7e69-4024-9db5-2e575ae7362c
+pkg-pinheader-1x15-d1.1-polygon-outline,bca68ea4-9fe8-4b87-8ed2-2268ac27b7d0
 pkg-pinheader-1x15-d1.1-text-name,bd7bc798-2c28-49f1-a3d8-559edcdc2476
 pkg-pinheader-1x15-d1.1-text-value,19048949-79eb-426e-a6dd-86350b7666cd
 pkg-pinheader-1x16-d0.9-3d,102e3de1-792d-401d-9012-d93c5dad2cb4
@@ -7216,6 +7258,8 @@ pkg-pinheader-1x16-d0.9-pad-8,df3e8ab5-2185-4bcb-80f3-a16837f4717b
 pkg-pinheader-1x16-d0.9-pad-9,adf7f35c-59ca-4470-8d91-c5e981b8bacc
 pkg-pinheader-1x16-d0.9-pkg,acf50230-9e93-4a33-8dcc-0e624c942723
 pkg-pinheader-1x16-d0.9-polygon-contour,92df0803-1860-445b-a3ce-aeb61fb2c521
+pkg-pinheader-1x16-d0.9-polygon-courtyard,456249c1-1234-4bbb-9218-c28d12abd93b
+pkg-pinheader-1x16-d0.9-polygon-outline,bab91fb6-4209-4216-8b38-2242086fa0a7
 pkg-pinheader-1x16-d0.9-text-name,4339da7f-724d-4cc0-a36b-3675ff931a7f
 pkg-pinheader-1x16-d0.9-text-value,f5bfc438-bc54-4eea-af1b-cb00bd32ccb0
 pkg-pinheader-1x16-d1.0-3d,d83ed01e-22bb-4cd1-8c7a-0106cfaea325
@@ -7238,6 +7282,8 @@ pkg-pinheader-1x16-d1.0-pad-8,88d662b5-fcde-4bb3-8455-0260e72da061
 pkg-pinheader-1x16-d1.0-pad-9,193e76a0-b8eb-481d-9fc2-7a9c83b48634
 pkg-pinheader-1x16-d1.0-pkg,e4f875f0-8287-4bc9-aa3e-c6ff8e395173
 pkg-pinheader-1x16-d1.0-polygon-contour,a4741ae5-bd58-47ae-afca-f86df4e47eb9
+pkg-pinheader-1x16-d1.0-polygon-courtyard,c012d207-8d40-4ab7-a924-3822a9766c6f
+pkg-pinheader-1x16-d1.0-polygon-outline,141bc439-070c-4cde-bd99-0102a54d9e8d
 pkg-pinheader-1x16-d1.0-text-name,03ec26d4-b6f7-4d8a-85e3-13d2951b37ee
 pkg-pinheader-1x16-d1.0-text-value,5e7509f3-e84b-4b9f-8aa8-4302068fb934
 pkg-pinheader-1x16-d1.1-3d,ad40b708-d9bd-4135-b846-b8c2a1898f35
@@ -7260,6 +7306,8 @@ pkg-pinheader-1x16-d1.1-pad-8,49475d5f-a5a5-497f-b9fd-d1a0abab2d86
 pkg-pinheader-1x16-d1.1-pad-9,71145156-8998-41bc-b1f1-d9bcce4c2566
 pkg-pinheader-1x16-d1.1-pkg,b33a85f5-3282-4595-81a0-797cd52a2246
 pkg-pinheader-1x16-d1.1-polygon-contour,75b6a095-0d09-4938-80ce-f9d345d2ed2c
+pkg-pinheader-1x16-d1.1-polygon-courtyard,2bf24bcf-bcab-4a3c-933b-de9ab5126432
+pkg-pinheader-1x16-d1.1-polygon-outline,d403918d-685c-4e5b-99cd-45cf91464d2d
 pkg-pinheader-1x16-d1.1-text-name,f8ae2466-a156-4d97-9da1-d0a730bc102b
 pkg-pinheader-1x16-d1.1-text-value,d6c1887e-afcd-43f2-9ed9-cc3b7dc8127e
 pkg-pinheader-1x17-d0.9-3d,99115a44-4826-4464-8593-b7ee2bf0b476
@@ -7283,6 +7331,8 @@ pkg-pinheader-1x17-d0.9-pad-8,a584e5e7-0d1d-4039-bf35-d859c19ddbc0
 pkg-pinheader-1x17-d0.9-pad-9,87c46c20-8220-4acf-bb09-3ac092d85240
 pkg-pinheader-1x17-d0.9-pkg,bce062f5-c0fc-4737-8def-77c8eacf0133
 pkg-pinheader-1x17-d0.9-polygon-contour,44b67913-9459-4b18-ac52-c9c4c09eddd9
+pkg-pinheader-1x17-d0.9-polygon-courtyard,45ca05ce-931f-4d29-b37d-be8f53904fc7
+pkg-pinheader-1x17-d0.9-polygon-outline,8dd54d6e-bf16-42ed-b969-382b379ec692
 pkg-pinheader-1x17-d0.9-text-name,b92c47e3-2be6-466c-8dcf-3d223d74f319
 pkg-pinheader-1x17-d0.9-text-value,870552a8-fef6-4d07-891d-1d73ed2447a6
 pkg-pinheader-1x17-d1.0-3d,c932bdb3-10f4-439e-86e0-1e4753793492
@@ -7306,6 +7356,8 @@ pkg-pinheader-1x17-d1.0-pad-8,a9ff88ce-8e75-45e9-bce7-a870d795ee96
 pkg-pinheader-1x17-d1.0-pad-9,1538fba2-f3dc-416f-88ef-09ee8396d4c8
 pkg-pinheader-1x17-d1.0-pkg,d33503ab-5fff-48e3-97ee-d531c2a03b03
 pkg-pinheader-1x17-d1.0-polygon-contour,559813a1-1b6e-451a-831e-7524b82bab05
+pkg-pinheader-1x17-d1.0-polygon-courtyard,d5bf7f45-cf99-43ed-8058-a743fa9eba49
+pkg-pinheader-1x17-d1.0-polygon-outline,f12186ad-b6fb-4391-9999-e046943b4747
 pkg-pinheader-1x17-d1.0-text-name,5c64a8d6-6e98-4094-a255-2f790e2c8132
 pkg-pinheader-1x17-d1.0-text-value,99829a77-7eb4-41a8-ba0e-f1d387a56900
 pkg-pinheader-1x17-d1.1-3d,d0cc82a0-b69f-485c-9985-989e3a9f1e1a
@@ -7329,6 +7381,8 @@ pkg-pinheader-1x17-d1.1-pad-8,a59be6c8-9f61-44dc-9528-eb24c4e6e2ac
 pkg-pinheader-1x17-d1.1-pad-9,42b28a42-21ee-4783-a2f8-dcf5dfcdeb9d
 pkg-pinheader-1x17-d1.1-pkg,69ce8a61-5412-4f36-8d51-6f0afda5731f
 pkg-pinheader-1x17-d1.1-polygon-contour,e31f4aa7-c1f8-4cf2-9bea-9527bd3a4d64
+pkg-pinheader-1x17-d1.1-polygon-courtyard,1005237d-789b-4b81-9fd1-4d68714ddd39
+pkg-pinheader-1x17-d1.1-polygon-outline,899943bf-4d36-4aef-a593-9bfd81df82c3
 pkg-pinheader-1x17-d1.1-text-name,b96f5d80-9543-498e-905f-729300858214
 pkg-pinheader-1x17-d1.1-text-value,11180f35-07e8-4f1d-8f5a-1cbf7b98b848
 pkg-pinheader-1x18-d0.9-3d,40222545-12a4-4f6c-8bde-c179cb70ff1b
@@ -7353,6 +7407,8 @@ pkg-pinheader-1x18-d0.9-pad-8,62ea9ddf-57bb-44c7-9fe6-fbb368d14a7a
 pkg-pinheader-1x18-d0.9-pad-9,6fe5e7cc-2f99-44eb-ba8a-8f916a2b0c09
 pkg-pinheader-1x18-d0.9-pkg,4836e4e3-7dd3-4a52-ad73-d7dfc045b8f3
 pkg-pinheader-1x18-d0.9-polygon-contour,255deab0-7d8a-4035-8795-320aea6b94ef
+pkg-pinheader-1x18-d0.9-polygon-courtyard,0a36a741-fe5f-49e5-8005-15057310ea30
+pkg-pinheader-1x18-d0.9-polygon-outline,3d667c5c-7b9c-4469-abb9-80ae2a96b84d
 pkg-pinheader-1x18-d0.9-text-name,24589c6c-1c41-4624-83a4-9c3b2fbb0d9b
 pkg-pinheader-1x18-d0.9-text-value,2172fc83-1d78-4359-8ddb-4d951efb7651
 pkg-pinheader-1x18-d1.0-3d,c81e9141-5b96-42c8-bcf5-a3d62cbca8d2
@@ -7377,6 +7433,8 @@ pkg-pinheader-1x18-d1.0-pad-8,10d554d3-f67a-4136-8436-ead2925c332f
 pkg-pinheader-1x18-d1.0-pad-9,b25894dc-760f-4fdf-9cc9-1dee51086017
 pkg-pinheader-1x18-d1.0-pkg,15542b6f-7a0d-43bd-9675-ad02885724e9
 pkg-pinheader-1x18-d1.0-polygon-contour,dff76afa-bd6f-4c2f-b13f-3ce5f20def32
+pkg-pinheader-1x18-d1.0-polygon-courtyard,032580cd-70e5-48e2-94fb-e5d3752822bb
+pkg-pinheader-1x18-d1.0-polygon-outline,4e6d2338-2dea-4e71-a121-faf8279ce13c
 pkg-pinheader-1x18-d1.0-text-name,8e11a2fb-d7c0-4567-ba52-5ed75ebaff11
 pkg-pinheader-1x18-d1.0-text-value,085f5b68-ba13-405a-972c-d1c793db54fa
 pkg-pinheader-1x18-d1.1-3d,cbe2f6a7-f02c-48a4-bddb-93fce08d6579
@@ -7401,6 +7459,8 @@ pkg-pinheader-1x18-d1.1-pad-8,f3835b72-ae3b-4ca8-9234-466c42fabc44
 pkg-pinheader-1x18-d1.1-pad-9,5d805434-f782-4817-96eb-820ae7696112
 pkg-pinheader-1x18-d1.1-pkg,3b8d3fb4-6d04-46b6-bc95-15a18de0f9f9
 pkg-pinheader-1x18-d1.1-polygon-contour,feb75bed-d20b-4851-a777-efba370574e9
+pkg-pinheader-1x18-d1.1-polygon-courtyard,f1000194-e318-4672-892a-45ec142aa0b1
+pkg-pinheader-1x18-d1.1-polygon-outline,9546197d-494c-4229-9518-7f45c2df4c1b
 pkg-pinheader-1x18-d1.1-text-name,f5dccc84-a890-4b9a-9313-a1a354c2e81a
 pkg-pinheader-1x18-d1.1-text-value,54046ee5-bfcc-4dd6-b34d-714b50054c6a
 pkg-pinheader-1x19-d0.9-3d,be8941b1-8419-4e64-9057-94640159ed98
@@ -7426,6 +7486,8 @@ pkg-pinheader-1x19-d0.9-pad-8,075a0aaa-edcc-41a6-9056-e5419c953ed5
 pkg-pinheader-1x19-d0.9-pad-9,d212d7d8-81dd-402f-b9f2-f26f0190274f
 pkg-pinheader-1x19-d0.9-pkg,e7a97051-c7ae-49b0-afd9-1bcb7e4db337
 pkg-pinheader-1x19-d0.9-polygon-contour,45be4edc-9342-43a2-9de5-8e4148e025d8
+pkg-pinheader-1x19-d0.9-polygon-courtyard,d46537e5-a5da-4189-9c07-34df3503624e
+pkg-pinheader-1x19-d0.9-polygon-outline,90c9b733-4c45-49a6-997c-bc8053f52a59
 pkg-pinheader-1x19-d0.9-text-name,fd06bb4e-5f12-48af-ad73-e7c112105c08
 pkg-pinheader-1x19-d0.9-text-value,4e970934-952c-45ba-98f5-44adbc874562
 pkg-pinheader-1x19-d1.0-3d,93007802-cfbf-409f-9b4a-324b46b6f6a3
@@ -7451,6 +7513,8 @@ pkg-pinheader-1x19-d1.0-pad-8,773491f4-c06b-48a8-bee8-e569a532d4fd
 pkg-pinheader-1x19-d1.0-pad-9,fd05b5d0-671c-468d-b98f-fe82520af50c
 pkg-pinheader-1x19-d1.0-pkg,02a5b0b7-33f4-4d9e-bb92-6e89e39383fa
 pkg-pinheader-1x19-d1.0-polygon-contour,84e37d86-58a4-4613-aaf4-9c60c05331d5
+pkg-pinheader-1x19-d1.0-polygon-courtyard,d668e5ec-2e6b-4357-829d-8c75c3e14fc4
+pkg-pinheader-1x19-d1.0-polygon-outline,32bcf53a-f28a-4187-8609-eeefc77c814b
 pkg-pinheader-1x19-d1.0-text-name,3afaa47a-cf94-4630-8a15-77d5defdcb0f
 pkg-pinheader-1x19-d1.0-text-value,f180f6f4-5472-4169-80e2-8a26713664b0
 pkg-pinheader-1x19-d1.1-3d,b93d878c-3384-41e3-ae59-32fb46e2dcd2
@@ -7476,6 +7540,8 @@ pkg-pinheader-1x19-d1.1-pad-8,de0bcf99-75e1-4f16-84c7-d62d85f05e52
 pkg-pinheader-1x19-d1.1-pad-9,6a584de6-84e2-4f05-a467-c0a01cb10510
 pkg-pinheader-1x19-d1.1-pkg,e58a1128-0f7b-4383-83e5-b541645d5435
 pkg-pinheader-1x19-d1.1-polygon-contour,8ae9ca72-b971-4a88-a35c-9aabd76203fc
+pkg-pinheader-1x19-d1.1-polygon-courtyard,a80ea79a-201a-4dbf-8513-fc0140932012
+pkg-pinheader-1x19-d1.1-polygon-outline,b14241ba-86fe-45fb-a285-a0b7300c301e
 pkg-pinheader-1x19-d1.1-text-name,6be20d53-734e-432d-9194-a9ad038e3b27
 pkg-pinheader-1x19-d1.1-text-value,2476b23e-377c-4d96-a68e-e6d5f62a3cf2
 pkg-pinheader-1x2-d0.9-3d,be1dd2dc-4ad1-4a28-88a6-8438ea651822
@@ -7484,6 +7550,8 @@ pkg-pinheader-1x2-d0.9-pad-0,f8e03f2f-c368-4b18-bfcb-35e1dcd781cc
 pkg-pinheader-1x2-d0.9-pad-1,61e20af2-9626-407f-af74-3a5a6a1a1002
 pkg-pinheader-1x2-d0.9-pkg,a3259adb-c576-468e-af7e-f1eb853c6bae
 pkg-pinheader-1x2-d0.9-polygon-contour,202748b3-b5c2-496a-b68e-0c70b14209ff
+pkg-pinheader-1x2-d0.9-polygon-courtyard,895cb9f9-f580-4254-8785-9cd01eef2bd1
+pkg-pinheader-1x2-d0.9-polygon-outline,62062f95-1ecc-48ca-8cb3-c5218774f04e
 pkg-pinheader-1x2-d0.9-text-name,64861982-9f61-4560-a3a5-1cf0a94de96c
 pkg-pinheader-1x2-d0.9-text-value,2a0de96a-1ce2-43af-a3e1-61f08c667058
 pkg-pinheader-1x2-d1.0-3d,77156d28-95d6-4c48-9dbd-bd93dcf574c0
@@ -7492,6 +7560,8 @@ pkg-pinheader-1x2-d1.0-pad-0,8a39b6f7-f65d-4bf2-be3a-a51ece174497
 pkg-pinheader-1x2-d1.0-pad-1,0f355158-8047-41b5-a397-fbb9a403f66f
 pkg-pinheader-1x2-d1.0-pkg,4c1c1177-1de5-4b95-83d3-c642f261c65e
 pkg-pinheader-1x2-d1.0-polygon-contour,22830df4-3d48-46de-a7f5-ea4220a96857
+pkg-pinheader-1x2-d1.0-polygon-courtyard,92129537-8bc2-48be-85e0-eae4e6bb179b
+pkg-pinheader-1x2-d1.0-polygon-outline,18257b17-cf1f-4016-ba3e-55f6cd7f9d00
 pkg-pinheader-1x2-d1.0-text-name,77aa62b6-c338-4428-8993-d39c12e5c369
 pkg-pinheader-1x2-d1.0-text-value,558f0d2b-5329-4be0-bd41-308f4ab25266
 pkg-pinheader-1x2-d1.1-3d,9b9f6059-960b-4472-b1a3-14cf0aa91852
@@ -7500,6 +7570,8 @@ pkg-pinheader-1x2-d1.1-pad-0,f3d4e4d2-adce-4935-86bb-43fc9fafe4a8
 pkg-pinheader-1x2-d1.1-pad-1,31a3429a-851c-48fa-b140-b44b04ab32d5
 pkg-pinheader-1x2-d1.1-pkg,2ab92a1c-746e-45ab-8727-722dafb98a5f
 pkg-pinheader-1x2-d1.1-polygon-contour,88ff3ee8-d8c9-443a-9cc7-fd75e2b974f0
+pkg-pinheader-1x2-d1.1-polygon-courtyard,c9807195-53e7-4d1e-82b3-c6c8f7811fa2
+pkg-pinheader-1x2-d1.1-polygon-outline,28e6b958-4465-4d6d-b664-973e66cb2baf
 pkg-pinheader-1x2-d1.1-text-name,24f5a1a3-edd3-4e92-8e4f-7e23cfb5c9da
 pkg-pinheader-1x2-d1.1-text-value,80474d85-5d9e-4ce8-815c-8d0b169a236a
 pkg-pinheader-1x20-d0.9-3d,10a7b0ff-bad1-414c-aa8d-c9eec02c0182
@@ -7526,6 +7598,8 @@ pkg-pinheader-1x20-d0.9-pad-8,28f9817c-3666-4548-a5e4-b31c1010611a
 pkg-pinheader-1x20-d0.9-pad-9,f81b25a4-87ec-4855-990b-cf2af505391c
 pkg-pinheader-1x20-d0.9-pkg,9f280ba6-735e-4413-a896-9b7100e38a51
 pkg-pinheader-1x20-d0.9-polygon-contour,d9814263-4676-4c6d-8a58-61aa8ca6f49c
+pkg-pinheader-1x20-d0.9-polygon-courtyard,33f0058f-fbc8-4229-81a5-a5327ba11a41
+pkg-pinheader-1x20-d0.9-polygon-outline,e9c3f945-b959-4502-ad60-c52f8498cb6e
 pkg-pinheader-1x20-d0.9-text-name,5a21e796-9b2f-438a-bf06-45b6678b641c
 pkg-pinheader-1x20-d0.9-text-value,83208683-17d9-40ba-b0a7-7bb9023f9d39
 pkg-pinheader-1x20-d1.0-3d,4cf91f53-7084-4fb0-80b6-ee25da6cc483
@@ -7552,6 +7626,8 @@ pkg-pinheader-1x20-d1.0-pad-8,caad5311-65b8-4d73-9acf-47f27f8af01f
 pkg-pinheader-1x20-d1.0-pad-9,b9e8d577-0106-4252-8b54-e47f7af8e950
 pkg-pinheader-1x20-d1.0-pkg,60111ff2-bcf6-45a4-88e4-f8df70d92fad
 pkg-pinheader-1x20-d1.0-polygon-contour,43668fa1-0244-4b7f-a9b5-d794a23279d1
+pkg-pinheader-1x20-d1.0-polygon-courtyard,d323e003-cea7-4734-8bcc-2445c0d32861
+pkg-pinheader-1x20-d1.0-polygon-outline,d9149fe7-613b-4d43-9c69-13a6bc705728
 pkg-pinheader-1x20-d1.0-text-name,56b744ff-1bac-4ab4-9d0b-ee4953a0cc3c
 pkg-pinheader-1x20-d1.0-text-value,f18ecc8c-6be9-4c66-a372-9cb5951e0799
 pkg-pinheader-1x20-d1.1-3d,ae17c191-e141-40b9-8ff2-5626e89c219a
@@ -7578,6 +7654,8 @@ pkg-pinheader-1x20-d1.1-pad-8,64fbcd68-b55e-4c18-a0ac-401830f36e8c
 pkg-pinheader-1x20-d1.1-pad-9,79bbc934-50bb-4db0-b833-cc5d34e5f248
 pkg-pinheader-1x20-d1.1-pkg,7d26f2ee-9b71-49df-b917-6b43bafb5e5b
 pkg-pinheader-1x20-d1.1-polygon-contour,0b2ee818-ec81-408c-8f5f-5187c7ca64eb
+pkg-pinheader-1x20-d1.1-polygon-courtyard,28b2a14e-eaf8-4738-ba18-8431145331bc
+pkg-pinheader-1x20-d1.1-polygon-outline,da792c3e-f3d4-45ec-90b0-a063aa013f0b
 pkg-pinheader-1x20-d1.1-text-name,12f48b64-4181-4c53-b2e0-a71b6af5b6a8
 pkg-pinheader-1x20-d1.1-text-value,b257f821-ff26-4199-93e8-888ff9a009d9
 pkg-pinheader-1x21-d0.9-3d,8aeecb3f-050c-4452-9c44-3dab6af7ff91
@@ -7605,6 +7683,8 @@ pkg-pinheader-1x21-d0.9-pad-8,8dfd96d7-2da6-4ddc-b5f8-e9baf687627d
 pkg-pinheader-1x21-d0.9-pad-9,5b385fdf-2197-4a45-9233-ab2c01391cd9
 pkg-pinheader-1x21-d0.9-pkg,8628d701-7c00-4d19-a18a-5c6d8ef677e2
 pkg-pinheader-1x21-d0.9-polygon-contour,4b8fc7ce-8a83-4e32-8524-2d7cd79d98de
+pkg-pinheader-1x21-d0.9-polygon-courtyard,3ebf12be-2cdc-4a8f-8d93-2cca6095e44f
+pkg-pinheader-1x21-d0.9-polygon-outline,d69d7092-ce49-45cd-a2ef-57593c57315a
 pkg-pinheader-1x21-d0.9-text-name,673cf454-7bf1-4a77-8f2b-b673ebbf1f88
 pkg-pinheader-1x21-d0.9-text-value,b3ec9c95-b16b-4f4f-9c23-9aafc3f6091b
 pkg-pinheader-1x21-d1.0-3d,02b31d0f-78cd-4ed7-9468-a08044f188a3
@@ -7632,6 +7712,8 @@ pkg-pinheader-1x21-d1.0-pad-8,0c2d5bce-81dc-474b-9b91-a049caf7240b
 pkg-pinheader-1x21-d1.0-pad-9,be0a7ea1-3b4e-422c-afc6-b0fe682efddc
 pkg-pinheader-1x21-d1.0-pkg,0c3567e2-2dd0-4336-8c85-17dad250a1af
 pkg-pinheader-1x21-d1.0-polygon-contour,9c9a0520-b2a8-4863-98a0-5aa0c2c3c513
+pkg-pinheader-1x21-d1.0-polygon-courtyard,f6503876-330f-477f-97e7-8e16760a8bea
+pkg-pinheader-1x21-d1.0-polygon-outline,16505a83-4ab7-4274-8298-0b102b3d6d53
 pkg-pinheader-1x21-d1.0-text-name,e9750564-d7aa-438c-8ec5-ad264a5efa53
 pkg-pinheader-1x21-d1.0-text-value,3f2339ee-cc6d-4920-b8a3-ecabc9a16a83
 pkg-pinheader-1x21-d1.1-3d,4b052b32-5918-4c22-af52-dbab250c117c
@@ -7659,6 +7741,8 @@ pkg-pinheader-1x21-d1.1-pad-8,55112d43-a82a-43a8-941a-6da6f9d0cdff
 pkg-pinheader-1x21-d1.1-pad-9,4745061e-7b91-4aa2-9c6e-ddda39eb9f6e
 pkg-pinheader-1x21-d1.1-pkg,7aea8b4c-3454-41de-8fd3-fe0c6fc5638e
 pkg-pinheader-1x21-d1.1-polygon-contour,88124961-1e7c-4bd0-9e68-a9f3686002ca
+pkg-pinheader-1x21-d1.1-polygon-courtyard,31cd7bc8-532c-4103-9742-daf23a209cf4
+pkg-pinheader-1x21-d1.1-polygon-outline,2f4dc532-b973-4559-a7ae-2bd14df71e59
 pkg-pinheader-1x21-d1.1-text-name,e6a50a18-d7d6-4a27-beeb-1650fe8cef60
 pkg-pinheader-1x21-d1.1-text-value,9c4b9414-da5b-4634-a524-65b31a8dba21
 pkg-pinheader-1x22-d0.9-3d,096091b7-4efb-4c69-9093-0c771a764895
@@ -7687,6 +7771,8 @@ pkg-pinheader-1x22-d0.9-pad-8,5c96bde9-ff3d-4ac3-81a0-7da4895a2601
 pkg-pinheader-1x22-d0.9-pad-9,349be494-0b95-4f62-84ae-d5d56ad8ab1c
 pkg-pinheader-1x22-d0.9-pkg,68db92ef-91ca-4a40-834c-bce99f226a63
 pkg-pinheader-1x22-d0.9-polygon-contour,c623b773-8907-4e35-8d35-c1a80f5ef156
+pkg-pinheader-1x22-d0.9-polygon-courtyard,8edafaa3-5278-40e4-ac63-acdaf9d12ae9
+pkg-pinheader-1x22-d0.9-polygon-outline,78420b81-63fe-4c31-ad8d-f698c75d5296
 pkg-pinheader-1x22-d0.9-text-name,458121bc-8e7d-4064-9f05-283094748a8a
 pkg-pinheader-1x22-d0.9-text-value,aefab4c5-b3f9-423a-9bb0-f00cd3a4f978
 pkg-pinheader-1x22-d1.0-3d,8e0f9b10-6b67-4b02-8b7b-87671c46cbb6
@@ -7715,6 +7801,8 @@ pkg-pinheader-1x22-d1.0-pad-8,d76ba321-1d37-45da-924d-a29080a05640
 pkg-pinheader-1x22-d1.0-pad-9,ba736065-fb08-49f0-a924-82757e55419b
 pkg-pinheader-1x22-d1.0-pkg,fe438615-fa2d-480c-acd9-39e1014c103e
 pkg-pinheader-1x22-d1.0-polygon-contour,68cc9962-75f0-4b08-b3d9-2b0ce8e34944
+pkg-pinheader-1x22-d1.0-polygon-courtyard,4b8e5f0f-0077-4eb6-a9a5-3d1e9b1b7580
+pkg-pinheader-1x22-d1.0-polygon-outline,8df85fcf-2d73-4ef6-9cbe-ad577c93c22e
 pkg-pinheader-1x22-d1.0-text-name,4683ec58-06e3-4352-8f31-f3d3db61eee7
 pkg-pinheader-1x22-d1.0-text-value,6501361c-9d78-483b-8338-8417bd92ac2d
 pkg-pinheader-1x22-d1.1-3d,ff133dac-3785-4a85-b01f-fafeadc6917d
@@ -7743,6 +7831,8 @@ pkg-pinheader-1x22-d1.1-pad-8,b6876fa4-8abc-4fe1-bf84-358a390e5776
 pkg-pinheader-1x22-d1.1-pad-9,cd95a63c-ee35-4ee2-8876-ee31b4be169e
 pkg-pinheader-1x22-d1.1-pkg,8fd6683b-adcf-41ac-aa3c-6e4fd0820d36
 pkg-pinheader-1x22-d1.1-polygon-contour,c28f5ab9-bd63-4681-a97b-c895158e77b3
+pkg-pinheader-1x22-d1.1-polygon-courtyard,d00f4bf3-0695-4db5-91d3-542f6ab26cb2
+pkg-pinheader-1x22-d1.1-polygon-outline,4c90abb9-dcd8-4ccb-b459-ea7d172572a5
 pkg-pinheader-1x22-d1.1-text-name,0edee5e7-d670-42a5-b973-b538a705aab0
 pkg-pinheader-1x22-d1.1-text-value,3ee59d6b-66aa-44d3-8e6b-a121fe4eb59d
 pkg-pinheader-1x23-d0.9-3d,de581dbe-7a1e-4a18-8509-6b81eebf1b0b
@@ -7772,6 +7862,8 @@ pkg-pinheader-1x23-d0.9-pad-8,e95d7840-9a81-46ce-9567-0f60caa2e993
 pkg-pinheader-1x23-d0.9-pad-9,f458d81f-9d16-4e66-b626-b3e6cd9ccb0d
 pkg-pinheader-1x23-d0.9-pkg,c55cfa8a-e28e-4a25-87e7-fe921d625a2b
 pkg-pinheader-1x23-d0.9-polygon-contour,a3e885ae-f8ef-4b87-9662-41d59cb485bd
+pkg-pinheader-1x23-d0.9-polygon-courtyard,542e8b63-747b-4292-8851-459bad846a4f
+pkg-pinheader-1x23-d0.9-polygon-outline,d8d9f3bc-35d7-4e64-882f-8a49dad70f2d
 pkg-pinheader-1x23-d0.9-text-name,b4c30578-1d2f-4430-9405-9a884a03c701
 pkg-pinheader-1x23-d0.9-text-value,9a734f81-60d4-4e05-91af-41b7db0ef578
 pkg-pinheader-1x23-d1.0-3d,c1bd6861-cbff-4702-a7e2-8cc799f2f331
@@ -7801,6 +7893,8 @@ pkg-pinheader-1x23-d1.0-pad-8,9d89650d-962c-4735-b7a4-219148ab383f
 pkg-pinheader-1x23-d1.0-pad-9,870dd391-cefc-4bcf-af82-4a056636c827
 pkg-pinheader-1x23-d1.0-pkg,b9f97b03-39a3-4317-bbc0-2b0d632fff1e
 pkg-pinheader-1x23-d1.0-polygon-contour,50053a2e-9f99-4f3d-b3e3-f4ecadebf0df
+pkg-pinheader-1x23-d1.0-polygon-courtyard,26c465f5-9795-46a9-a9cf-d9fbab7979ff
+pkg-pinheader-1x23-d1.0-polygon-outline,0b845002-8061-45a3-b1e6-02a23b82b319
 pkg-pinheader-1x23-d1.0-text-name,f28dd9c5-c168-411b-aaef-8ff0e791110a
 pkg-pinheader-1x23-d1.0-text-value,078766b4-b553-4b98-b5bd-60d9b669f851
 pkg-pinheader-1x23-d1.1-3d,655c1d23-22bd-45d7-90dd-e775341d2452
@@ -7830,6 +7924,8 @@ pkg-pinheader-1x23-d1.1-pad-8,2f96dfac-2fba-4a36-9b5a-b23068f1e686
 pkg-pinheader-1x23-d1.1-pad-9,bdad855d-73ec-4841-8ea5-70645960fc29
 pkg-pinheader-1x23-d1.1-pkg,71ac01d6-ee46-4dde-9886-638c95bb4a49
 pkg-pinheader-1x23-d1.1-polygon-contour,1a8f9c73-37f0-4d5e-b5b0-4771a9dfdd30
+pkg-pinheader-1x23-d1.1-polygon-courtyard,4526e0ef-04b9-4d59-858f-27520eed7c10
+pkg-pinheader-1x23-d1.1-polygon-outline,13d237e6-abfa-4fd9-9cce-be05bda28a73
 pkg-pinheader-1x23-d1.1-text-name,75ae7690-8a7e-4caf-a8bd-99929ce305b5
 pkg-pinheader-1x23-d1.1-text-value,f3510c00-533e-47fd-a75b-a471d9305144
 pkg-pinheader-1x24-d0.9-3d,f470b676-ab38-4c01-b29e-797bd35234de
@@ -7860,6 +7956,8 @@ pkg-pinheader-1x24-d0.9-pad-8,f90a0114-84f5-4ff2-ae79-a0a2518ffaff
 pkg-pinheader-1x24-d0.9-pad-9,96393838-6a36-4465-825a-3294138e0f43
 pkg-pinheader-1x24-d0.9-pkg,d03ca066-62ce-4bcf-a13d-1983f75c55da
 pkg-pinheader-1x24-d0.9-polygon-contour,f9aab805-c04c-446f-84f0-32a60a85df1e
+pkg-pinheader-1x24-d0.9-polygon-courtyard,bbb9065b-8ba2-4fba-8523-0c25a7789f20
+pkg-pinheader-1x24-d0.9-polygon-outline,27a0950e-2747-4ed7-a6cc-04712ec7c6d4
 pkg-pinheader-1x24-d0.9-text-name,3a7849b7-8966-4856-9c13-c9d93b48f9a3
 pkg-pinheader-1x24-d0.9-text-value,fb92595b-f7f0-4737-9b7d-54c4bf729cba
 pkg-pinheader-1x24-d1.0-3d,b3582e2b-a71a-4ffa-a053-62a3a2395f56
@@ -7890,6 +7988,8 @@ pkg-pinheader-1x24-d1.0-pad-8,ea7faa66-5d47-4dee-80bc-d37d91b5f0c9
 pkg-pinheader-1x24-d1.0-pad-9,40fd362d-e276-4898-9864-d8a3f5c7e39a
 pkg-pinheader-1x24-d1.0-pkg,b211e43b-3961-48be-bb25-fb54a2958174
 pkg-pinheader-1x24-d1.0-polygon-contour,aad833bb-9e07-4de2-98c3-e29db6672bf5
+pkg-pinheader-1x24-d1.0-polygon-courtyard,ee0dcb44-73c2-475b-9b94-c0729465bfb8
+pkg-pinheader-1x24-d1.0-polygon-outline,233c34d6-3176-4a7b-9095-2f350c2ee980
 pkg-pinheader-1x24-d1.0-text-name,dea64f4e-c631-4800-a7c4-b5e43f6acc5f
 pkg-pinheader-1x24-d1.0-text-value,2000112c-c978-494d-916f-7d72c908e40d
 pkg-pinheader-1x24-d1.1-3d,b36f4e5d-5911-46ae-83e8-1fdf0d2b502a
@@ -7920,6 +8020,8 @@ pkg-pinheader-1x24-d1.1-pad-8,32c48c55-9080-4a51-8201-d650c123ef34
 pkg-pinheader-1x24-d1.1-pad-9,7131b24c-eda6-4728-aa5e-af39e30cd562
 pkg-pinheader-1x24-d1.1-pkg,b189ec3f-657b-4335-afcc-d3e0a6653bfe
 pkg-pinheader-1x24-d1.1-polygon-contour,a9f37202-f450-4233-8419-812f42631b0e
+pkg-pinheader-1x24-d1.1-polygon-courtyard,b221b631-f4b4-4954-a7c4-85fec025d34b
+pkg-pinheader-1x24-d1.1-polygon-outline,1dd0a830-239d-43ca-bf2b-90d61ec62ac6
 pkg-pinheader-1x24-d1.1-text-name,cd53a1b0-a586-4290-97b3-99fd6e575bf4
 pkg-pinheader-1x24-d1.1-text-value,0dc37fc2-c36d-4df7-8383-066acecd3440
 pkg-pinheader-1x25-d0.9-3d,373d9694-a1a0-4589-86b3-90be317927df
@@ -7951,6 +8053,8 @@ pkg-pinheader-1x25-d0.9-pad-8,64b8868a-c0f7-43aa-924a-54a4dbcc8ca2
 pkg-pinheader-1x25-d0.9-pad-9,4bd1b2b5-1a5d-4bf1-bc7b-6a646e753c6d
 pkg-pinheader-1x25-d0.9-pkg,6321a575-c6ea-4896-9516-f0dd96907675
 pkg-pinheader-1x25-d0.9-polygon-contour,6a927fa2-9b34-4347-b9c6-ae109ef2152f
+pkg-pinheader-1x25-d0.9-polygon-courtyard,225d0f81-e1e2-4170-935c-a13fc287788e
+pkg-pinheader-1x25-d0.9-polygon-outline,eb3794c4-f52f-4d5e-90f6-98b9e6b4f770
 pkg-pinheader-1x25-d0.9-text-name,22de28c5-3b6b-448c-8a73-b4a2fcf9e787
 pkg-pinheader-1x25-d0.9-text-value,bbca0bc6-a0ba-44cb-a47c-05eda835e37f
 pkg-pinheader-1x25-d1.0-3d,47973064-e8df-43de-af41-bff0fbd65818
@@ -7982,6 +8086,8 @@ pkg-pinheader-1x25-d1.0-pad-8,7e374549-342e-4c0c-b0a5-de2886d9e0f3
 pkg-pinheader-1x25-d1.0-pad-9,587093da-9fd9-4a05-b59f-8be377fd85d5
 pkg-pinheader-1x25-d1.0-pkg,5f14c8a5-fca0-43d7-92bd-27ab410c09dd
 pkg-pinheader-1x25-d1.0-polygon-contour,f54eb54b-5c51-49c6-8735-d7225dde4d17
+pkg-pinheader-1x25-d1.0-polygon-courtyard,aca04d0e-a981-44ba-8d20-aa5b32fdfe5b
+pkg-pinheader-1x25-d1.0-polygon-outline,acf8cbeb-0572-4303-bcbb-41f4a8f5f473
 pkg-pinheader-1x25-d1.0-text-name,0dabfa78-cf8d-457d-b927-75442dccef12
 pkg-pinheader-1x25-d1.0-text-value,1aa270ea-f1f7-4965-ac41-8ef4aed6373f
 pkg-pinheader-1x25-d1.1-3d,80a77880-62b1-4ff5-bfea-fcb7142ad355
@@ -8013,6 +8119,8 @@ pkg-pinheader-1x25-d1.1-pad-8,82639dda-f9d1-4b3e-9259-e42c8ba507e1
 pkg-pinheader-1x25-d1.1-pad-9,72cafff4-d486-44ae-8a92-c9c070e64767
 pkg-pinheader-1x25-d1.1-pkg,ad50a27f-aa7f-4fa2-82b7-6d732c6058da
 pkg-pinheader-1x25-d1.1-polygon-contour,ada97fe8-ef63-4cec-afb2-fcfbec9ed0d3
+pkg-pinheader-1x25-d1.1-polygon-courtyard,4f044bd5-0c10-4988-893b-00f66807680c
+pkg-pinheader-1x25-d1.1-polygon-outline,d8484a63-8cd7-4623-b67a-f42d57717bcb
 pkg-pinheader-1x25-d1.1-text-name,59c5b25e-e6b1-485c-94fe-6f7e803298e0
 pkg-pinheader-1x25-d1.1-text-value,9b9daaf3-2fe4-4054-839f-d9a2f9b3fda2
 pkg-pinheader-1x26-d0.9-3d,7ca471b6-39eb-425b-a5fa-0330e5b78503
@@ -8045,6 +8153,8 @@ pkg-pinheader-1x26-d0.9-pad-8,321c705f-70b5-472f-b090-4a7f33bcf908
 pkg-pinheader-1x26-d0.9-pad-9,fb318462-6d92-4624-a22b-f4e0da5ca83e
 pkg-pinheader-1x26-d0.9-pkg,b34626a1-8ed7-478f-82d4-f05b0fd895c0
 pkg-pinheader-1x26-d0.9-polygon-contour,df6a36c8-b3d9-427e-b0a7-371dda3dad24
+pkg-pinheader-1x26-d0.9-polygon-courtyard,0f5822b0-2d5d-47df-9d9a-5c58a2ee86e2
+pkg-pinheader-1x26-d0.9-polygon-outline,2ef3bbd6-6e01-4b57-baaa-81c101e2d1e8
 pkg-pinheader-1x26-d0.9-text-name,587e9ea4-fe95-4a72-8f85-3a19a9a749f9
 pkg-pinheader-1x26-d0.9-text-value,d7389827-81a0-4458-acd6-f730e7b3eae8
 pkg-pinheader-1x26-d1.0-3d,bd5eda78-1cc3-4769-bf22-695fe7d430df
@@ -8077,6 +8187,8 @@ pkg-pinheader-1x26-d1.0-pad-8,b32e3819-a8d1-4986-8bb7-c04bd70d7da1
 pkg-pinheader-1x26-d1.0-pad-9,f6309f9c-d2eb-4d67-a260-6bcc383614c4
 pkg-pinheader-1x26-d1.0-pkg,0b1c5573-5dea-494d-a820-5e08d7365486
 pkg-pinheader-1x26-d1.0-polygon-contour,d0694fd1-339f-4194-8535-47f224a61989
+pkg-pinheader-1x26-d1.0-polygon-courtyard,67759a57-a771-446b-b409-3e33ab7089b5
+pkg-pinheader-1x26-d1.0-polygon-outline,04215506-3c4c-4dca-b00a-8b2e2a7abb3f
 pkg-pinheader-1x26-d1.0-text-name,bda550f2-41f4-4598-9225-eb3fe65ed545
 pkg-pinheader-1x26-d1.0-text-value,81f58c4a-384d-4f0a-b831-7826b8f8ff18
 pkg-pinheader-1x26-d1.1-3d,d1053d82-4d52-448e-9c27-7467dd605be7
@@ -8109,6 +8221,8 @@ pkg-pinheader-1x26-d1.1-pad-8,3ea9adc5-7b1e-4d24-b04f-612dd17a6a65
 pkg-pinheader-1x26-d1.1-pad-9,45dea9b5-f0e5-47fb-964a-7e233271bd7e
 pkg-pinheader-1x26-d1.1-pkg,8c117bcb-1794-47eb-b385-81a0e358eda3
 pkg-pinheader-1x26-d1.1-polygon-contour,c38efac5-644a-4391-b79b-e11f3d7e6265
+pkg-pinheader-1x26-d1.1-polygon-courtyard,185c5d37-2608-4c56-bf60-98a2bebca245
+pkg-pinheader-1x26-d1.1-polygon-outline,d3b57623-0df0-4d99-8053-0c9712a6ed74
 pkg-pinheader-1x26-d1.1-text-name,26a2daa9-a302-411a-bfe1-681213cbd42a
 pkg-pinheader-1x26-d1.1-text-value,34e12106-41e5-4b57-b18a-004661428bdc
 pkg-pinheader-1x27-d0.9-3d,a7a00f0d-94ec-41de-aefe-32c1d71c62ff
@@ -8142,6 +8256,8 @@ pkg-pinheader-1x27-d0.9-pad-8,10c04c7a-33a7-484b-ae15-3caab0fa15ff
 pkg-pinheader-1x27-d0.9-pad-9,4edd75a5-63bc-47a3-81c7-d4910bf2c32e
 pkg-pinheader-1x27-d0.9-pkg,96de0a6a-0fc2-4bd6-93e9-b9d2efae8f8a
 pkg-pinheader-1x27-d0.9-polygon-contour,0de46f92-9707-4fae-b72f-dbf57c142c6d
+pkg-pinheader-1x27-d0.9-polygon-courtyard,6973e879-6400-47c1-aa8f-83d834f5e0ef
+pkg-pinheader-1x27-d0.9-polygon-outline,3e819d30-c49c-4bc4-8cbe-e92c41c25100
 pkg-pinheader-1x27-d0.9-text-name,612890d4-e5f3-46be-9add-11a30489c3b7
 pkg-pinheader-1x27-d0.9-text-value,ae7f2410-b617-4a50-a534-fc36edbdd2ae
 pkg-pinheader-1x27-d1.0-3d,b967f27e-fc79-4c4b-ae80-5ec394186752
@@ -8175,6 +8291,8 @@ pkg-pinheader-1x27-d1.0-pad-8,5ca693a7-ba5c-470c-bcff-fb9870d81d14
 pkg-pinheader-1x27-d1.0-pad-9,aaae8d63-8098-439f-b8ca-70641daddff6
 pkg-pinheader-1x27-d1.0-pkg,e91fbe17-220d-4e4e-b389-b1b314559b30
 pkg-pinheader-1x27-d1.0-polygon-contour,fe373ace-29ed-4bbb-8ee9-4df0b86780d1
+pkg-pinheader-1x27-d1.0-polygon-courtyard,77283a28-0948-4d36-9ae2-d14adaaa1aa7
+pkg-pinheader-1x27-d1.0-polygon-outline,5b7f9de5-76d3-442f-bcd2-45fa83e0935b
 pkg-pinheader-1x27-d1.0-text-name,f7dce450-abd1-4efc-92d4-06acadd16de9
 pkg-pinheader-1x27-d1.0-text-value,0fb750bf-7564-4a4d-bab8-3bf3b79b064d
 pkg-pinheader-1x27-d1.1-3d,110ea339-4265-484d-b496-85d5862e4f88
@@ -8208,6 +8326,8 @@ pkg-pinheader-1x27-d1.1-pad-8,99942ccb-87a0-4d15-9980-97a60c8574dc
 pkg-pinheader-1x27-d1.1-pad-9,540085c1-bb50-4fdc-b113-cc3088f16609
 pkg-pinheader-1x27-d1.1-pkg,23614de3-a041-46e9-a557-b40d8ad7fc88
 pkg-pinheader-1x27-d1.1-polygon-contour,84ec7de8-19ec-4671-82d9-21b0ef55d5fd
+pkg-pinheader-1x27-d1.1-polygon-courtyard,94f0f80f-3008-46e6-bcb2-9c8075a75bc6
+pkg-pinheader-1x27-d1.1-polygon-outline,33de125e-e55c-4144-b403-9d5185608f98
 pkg-pinheader-1x27-d1.1-text-name,29948a6c-a8d4-4775-acae-9855c72dc8d4
 pkg-pinheader-1x27-d1.1-text-value,fd8d976a-9a72-4e81-992e-e790b0cb9a8d
 pkg-pinheader-1x28-d0.9-3d,d18b3db3-c235-4e75-96a4-bcb7c7d5b399
@@ -8242,6 +8362,8 @@ pkg-pinheader-1x28-d0.9-pad-8,94cab937-352e-4310-8d97-c6e63e31f5ad
 pkg-pinheader-1x28-d0.9-pad-9,679e19ca-43ab-417c-b8d3-2741f3b2c548
 pkg-pinheader-1x28-d0.9-pkg,e6caa57d-853f-478a-a938-a3ac640b9ff9
 pkg-pinheader-1x28-d0.9-polygon-contour,30a65336-e1af-4dde-8efc-01d7974edbc1
+pkg-pinheader-1x28-d0.9-polygon-courtyard,78961980-6ce5-40f0-9f8d-1ac83ec65ba1
+pkg-pinheader-1x28-d0.9-polygon-outline,6d515f94-b022-4d8f-b6e1-3d02e8735db8
 pkg-pinheader-1x28-d0.9-text-name,f1c9eabc-798b-4351-8967-07687885079d
 pkg-pinheader-1x28-d0.9-text-value,5a973a6d-f23c-4ab5-bd29-b7c5c05471f2
 pkg-pinheader-1x28-d1.0-3d,ce9c5803-da80-49e8-98b9-4dffaa932130
@@ -8276,6 +8398,8 @@ pkg-pinheader-1x28-d1.0-pad-8,51d654b4-e13a-4c09-a7d8-9f49aa39dea4
 pkg-pinheader-1x28-d1.0-pad-9,43451963-c0c4-43cf-9afa-f7350f34bcda
 pkg-pinheader-1x28-d1.0-pkg,514c42b9-905f-4a63-886d-7377cfd85ee4
 pkg-pinheader-1x28-d1.0-polygon-contour,5f4e1fdf-0c72-4a4c-baf2-24e3dfdf33e7
+pkg-pinheader-1x28-d1.0-polygon-courtyard,37a17719-dce2-4165-af86-954bc83dcc4a
+pkg-pinheader-1x28-d1.0-polygon-outline,b3d13f93-2ac0-4465-8efb-9f9abe88bfb4
 pkg-pinheader-1x28-d1.0-text-name,9c63c624-ef4a-432f-954d-8e5a13afbeda
 pkg-pinheader-1x28-d1.0-text-value,ec3e5596-629b-4af8-9367-d27da8f4b1f2
 pkg-pinheader-1x28-d1.1-3d,c0c87182-a1d0-4251-aeda-9dc1180f7792
@@ -8310,6 +8434,8 @@ pkg-pinheader-1x28-d1.1-pad-8,0e50aac2-7aee-4389-babe-d8cf6d847d92
 pkg-pinheader-1x28-d1.1-pad-9,e40198bf-ab76-4331-9b45-f1fba11f6784
 pkg-pinheader-1x28-d1.1-pkg,2ff15833-61d9-45d3-b61e-6b4c81a7d40c
 pkg-pinheader-1x28-d1.1-polygon-contour,74874271-392b-4501-b053-86ae735d98d2
+pkg-pinheader-1x28-d1.1-polygon-courtyard,feed45b2-7a27-45a2-a74d-15f570bcac85
+pkg-pinheader-1x28-d1.1-polygon-outline,7ff67cfd-20c1-4c7a-bf88-cc88803188e5
 pkg-pinheader-1x28-d1.1-text-name,9e993fd8-0c82-4670-9c30-e43a6f3a0096
 pkg-pinheader-1x28-d1.1-text-value,37cc3f6f-39ce-4488-a00e-ee103a19a4a8
 pkg-pinheader-1x29-d0.9-3d,78760199-dc38-403f-8b26-5c745661c2b1
@@ -8345,6 +8471,8 @@ pkg-pinheader-1x29-d0.9-pad-8,64cdca7c-e2a5-4dbd-80bf-2d149173a35c
 pkg-pinheader-1x29-d0.9-pad-9,4f97298b-451b-4bb8-884a-53bcc82e80ca
 pkg-pinheader-1x29-d0.9-pkg,53778cb7-3cf2-416a-9578-5de7e48f0376
 pkg-pinheader-1x29-d0.9-polygon-contour,7b811191-1e10-4c9a-a523-e161239e7e0c
+pkg-pinheader-1x29-d0.9-polygon-courtyard,803a57a5-8a63-40f0-99dd-c64778798aca
+pkg-pinheader-1x29-d0.9-polygon-outline,3bddd631-76be-4eb2-a7a8-ad36444bf960
 pkg-pinheader-1x29-d0.9-text-name,868b71de-355a-4f69-9bb4-81a4d06d677b
 pkg-pinheader-1x29-d0.9-text-value,c31bbe42-e394-4136-9c53-8a690bc04eb1
 pkg-pinheader-1x29-d1.0-3d,f7185eb0-fedd-473e-a201-8d61d0d19065
@@ -8380,6 +8508,8 @@ pkg-pinheader-1x29-d1.0-pad-8,b3536622-245b-420b-a163-b9e764257b1a
 pkg-pinheader-1x29-d1.0-pad-9,dbde21d1-8c67-4a48-9570-7e92df82e204
 pkg-pinheader-1x29-d1.0-pkg,62ce013f-447b-4d42-991e-bdf66e29fb3c
 pkg-pinheader-1x29-d1.0-polygon-contour,2b2906a6-2268-49bf-9349-ac6fe915f7f7
+pkg-pinheader-1x29-d1.0-polygon-courtyard,ff495993-ef3a-47d3-9ec6-c82c72e8c7d0
+pkg-pinheader-1x29-d1.0-polygon-outline,00f3679e-ca67-4fcf-8735-97a94f507781
 pkg-pinheader-1x29-d1.0-text-name,8b595580-d53d-4294-ba88-fc94dc4e0d30
 pkg-pinheader-1x29-d1.0-text-value,1e78c7df-9df2-41ae-9fab-3496110f140a
 pkg-pinheader-1x29-d1.1-3d,3b1ccb0b-30d1-4e62-b4f5-98f075edad24
@@ -8415,6 +8545,8 @@ pkg-pinheader-1x29-d1.1-pad-8,8a489577-9c79-484b-a360-a5dbb5d3287e
 pkg-pinheader-1x29-d1.1-pad-9,327f2821-7f37-4570-ae40-256b9263f138
 pkg-pinheader-1x29-d1.1-pkg,c993770e-54df-460f-8802-755ecc8dc095
 pkg-pinheader-1x29-d1.1-polygon-contour,996c9cfb-b29e-468d-8cab-521ba5775316
+pkg-pinheader-1x29-d1.1-polygon-courtyard,099c3775-89e8-45ed-bb34-804f3c40069c
+pkg-pinheader-1x29-d1.1-polygon-outline,c3b16719-f7a1-4107-9acd-6c05d1a55bd8
 pkg-pinheader-1x29-d1.1-text-name,380ec672-4f8e-44a7-85cb-0f59be5eb98c
 pkg-pinheader-1x29-d1.1-text-value,61226bfb-8620-488e-b8f2-07e480e7cfcc
 pkg-pinheader-1x3-d0.9-3d,e8e1199d-5576-47a0-ad40-263b77248170
@@ -8424,6 +8556,8 @@ pkg-pinheader-1x3-d0.9-pad-1,d4c6ef1f-8b5e-4d4d-a15e-c58ff1ec228a
 pkg-pinheader-1x3-d0.9-pad-2,3121d4b6-09ee-435d-9714-1e91876be880
 pkg-pinheader-1x3-d0.9-pkg,2f81590e-39e7-4d59-a6f6-3fa1fdeeeef5
 pkg-pinheader-1x3-d0.9-polygon-contour,8f13a074-922c-4998-bd4f-4a69633ac015
+pkg-pinheader-1x3-d0.9-polygon-courtyard,6556a018-ca89-4403-be3c-5892b65a3821
+pkg-pinheader-1x3-d0.9-polygon-outline,6e2fecc5-dd0e-4a4b-a137-d952d990afc1
 pkg-pinheader-1x3-d0.9-text-name,e5f9ff74-1f73-4a2d-845b-f53c3b59921a
 pkg-pinheader-1x3-d0.9-text-value,56462569-7b95-4dea-a1d7-ec4bc1c08da2
 pkg-pinheader-1x3-d1.0-3d,35ad7682-4316-4ebb-9ca0-2cf4b9a3cdc9
@@ -8433,6 +8567,8 @@ pkg-pinheader-1x3-d1.0-pad-1,6d96b9cf-730f-4589-9e51-cc7d63358cfb
 pkg-pinheader-1x3-d1.0-pad-2,636617de-2280-4583-8d25-94c961d83f45
 pkg-pinheader-1x3-d1.0-pkg,f4436211-aa5c-4c63-8231-33b80a62afbf
 pkg-pinheader-1x3-d1.0-polygon-contour,507e34e0-0095-4d47-a210-c08708089a59
+pkg-pinheader-1x3-d1.0-polygon-courtyard,fbe5ab5b-9734-441d-a49f-6e03d92da685
+pkg-pinheader-1x3-d1.0-polygon-outline,a1b5757d-a36d-46a9-b4b3-0ecb9c989082
 pkg-pinheader-1x3-d1.0-text-name,d6298f89-9572-4e97-bc84-595bb2122f4d
 pkg-pinheader-1x3-d1.0-text-value,c688f3d6-84cf-4b17-85d4-f1db1b5f918c
 pkg-pinheader-1x3-d1.1-3d,56a04c8d-31c9-4301-b38c-ac62f7056db4
@@ -8442,6 +8578,8 @@ pkg-pinheader-1x3-d1.1-pad-1,14be20de-874b-4a55-87c3-5f6757013563
 pkg-pinheader-1x3-d1.1-pad-2,606833ee-5b12-44e1-9b94-9da46d32ff3f
 pkg-pinheader-1x3-d1.1-pkg,fc1fb77d-4c1e-49fe-851e-b2c7c6d4b709
 pkg-pinheader-1x3-d1.1-polygon-contour,b8a8ad9b-0c79-49fa-a2b1-03e29d4c6e17
+pkg-pinheader-1x3-d1.1-polygon-courtyard,e5a8ec79-6c1b-461f-a474-367a543c18ee
+pkg-pinheader-1x3-d1.1-polygon-outline,2fb41c71-50f5-4590-a04c-e33b280018b4
 pkg-pinheader-1x3-d1.1-text-name,ce2e05b7-703c-4644-b215-d647ccf97a5e
 pkg-pinheader-1x3-d1.1-text-value,3144a47d-45c9-47e0-9881-e25097647f9b
 pkg-pinheader-1x30-d0.9-3d,a9810b0d-67f5-4452-85a2-4f9087862e80
@@ -8478,6 +8616,8 @@ pkg-pinheader-1x30-d0.9-pad-8,d261abba-db5c-4703-baa4-d047e1101932
 pkg-pinheader-1x30-d0.9-pad-9,36eaa777-8763-489e-a2ff-e91df98ff681
 pkg-pinheader-1x30-d0.9-pkg,0bb5525f-0f8d-4ff7-978a-08abd7ccb7a2
 pkg-pinheader-1x30-d0.9-polygon-contour,2eb3e772-07e5-41a2-ac5c-fbb09f06824c
+pkg-pinheader-1x30-d0.9-polygon-courtyard,ebf95779-c85e-4a88-acfd-72469930cf6b
+pkg-pinheader-1x30-d0.9-polygon-outline,34ae8b5a-ac10-4fa9-9658-5bb17d4a3383
 pkg-pinheader-1x30-d0.9-text-name,7b23a284-e973-4d6f-90ca-8e00f8dc12ba
 pkg-pinheader-1x30-d0.9-text-value,82f27a63-7609-4257-b6a6-c2cda7592ca2
 pkg-pinheader-1x30-d1.0-3d,9865d3a1-e79c-4c07-b845-9ff6630b5de7
@@ -8514,6 +8654,8 @@ pkg-pinheader-1x30-d1.0-pad-8,25c06c84-9b50-4546-bcae-05b9a1d2f09c
 pkg-pinheader-1x30-d1.0-pad-9,e51180ec-6b06-4a64-b549-cf746f33b6f0
 pkg-pinheader-1x30-d1.0-pkg,ff60e8d3-937b-4e60-96d4-9e891146d83a
 pkg-pinheader-1x30-d1.0-polygon-contour,be579f6f-dbb3-42dc-b012-9de6cbad8930
+pkg-pinheader-1x30-d1.0-polygon-courtyard,f998c008-9375-453c-a5e8-3298b861f069
+pkg-pinheader-1x30-d1.0-polygon-outline,fb3aa5f5-be69-480c-ba3b-d43a61933536
 pkg-pinheader-1x30-d1.0-text-name,b591fb5c-4d6f-4d41-b7c8-cd68e36ed416
 pkg-pinheader-1x30-d1.0-text-value,1507a984-9d8f-4d1e-9886-d31c89de61d5
 pkg-pinheader-1x30-d1.1-3d,e7601079-3829-435f-913f-722ddf66261e
@@ -8550,6 +8692,8 @@ pkg-pinheader-1x30-d1.1-pad-8,fd232e1e-505f-4673-a93b-7d9f860ed089
 pkg-pinheader-1x30-d1.1-pad-9,5b4d2c13-8e8c-4ca8-a7ad-03c7fe19ad10
 pkg-pinheader-1x30-d1.1-pkg,0ffeb6aa-3e4e-4d14-bec7-1be76cdc6996
 pkg-pinheader-1x30-d1.1-polygon-contour,6374bda5-7550-48ce-b262-81c01a8e5a76
+pkg-pinheader-1x30-d1.1-polygon-courtyard,d49a8877-8e47-42b7-907e-05b7a2dc600d
+pkg-pinheader-1x30-d1.1-polygon-outline,ec26fab4-de5f-4647-80b5-418d996c7480
 pkg-pinheader-1x30-d1.1-text-name,eca48b25-6cfe-4435-b13b-753b3b13216b
 pkg-pinheader-1x30-d1.1-text-value,6f66a976-86c8-4aa6-acc1-b883706f91a3
 pkg-pinheader-1x31-d0.9-3d,ea3dee21-42f5-4357-89fa-e5997aad46a5
@@ -8587,6 +8731,8 @@ pkg-pinheader-1x31-d0.9-pad-8,63ab02ba-c1e3-4d7c-b8e3-89330cfcd27b
 pkg-pinheader-1x31-d0.9-pad-9,eab35927-bd7c-4372-9648-ee812c003e1b
 pkg-pinheader-1x31-d0.9-pkg,9663dfa3-081b-4230-b020-cae9a88c74df
 pkg-pinheader-1x31-d0.9-polygon-contour,dd6a2269-30b6-4791-b80c-33db9f637579
+pkg-pinheader-1x31-d0.9-polygon-courtyard,369c3237-9043-4f9b-af22-21964fa6b817
+pkg-pinheader-1x31-d0.9-polygon-outline,01f2b32a-fa72-4099-bcaf-b3277a5458ae
 pkg-pinheader-1x31-d0.9-text-name,5d10efb1-b396-4ae8-911a-1f154dd56d4a
 pkg-pinheader-1x31-d0.9-text-value,59cc0ae7-c6c9-4156-89c7-b70057addbbf
 pkg-pinheader-1x31-d1.0-3d,bc349a64-9707-44bf-9df1-6936b79eb55d
@@ -8624,6 +8770,8 @@ pkg-pinheader-1x31-d1.0-pad-8,237a3af0-13a7-410f-824d-77c7652151ef
 pkg-pinheader-1x31-d1.0-pad-9,1bbca239-23d7-447c-a60c-5e8064d56c05
 pkg-pinheader-1x31-d1.0-pkg,e6634906-3a53-4c49-8bd6-7ec869aafed6
 pkg-pinheader-1x31-d1.0-polygon-contour,5aaff026-3883-403f-b905-9c9f74bda464
+pkg-pinheader-1x31-d1.0-polygon-courtyard,210c8ed3-0f0c-4438-bcbb-e6158fea41e9
+pkg-pinheader-1x31-d1.0-polygon-outline,69d84137-b173-4ffc-afcd-e4c5bed1ef7a
 pkg-pinheader-1x31-d1.0-text-name,befae728-1f40-4fce-96f2-78a561c738bc
 pkg-pinheader-1x31-d1.0-text-value,7fba39d8-5ecd-456b-a8e3-788984e01cc9
 pkg-pinheader-1x31-d1.1-3d,7bc9037e-fe85-4a13-b1eb-5cb4f38ee5b5
@@ -8661,6 +8809,8 @@ pkg-pinheader-1x31-d1.1-pad-8,378ccc27-47dc-4594-8c33-046f996fc4ba
 pkg-pinheader-1x31-d1.1-pad-9,5e3bf1d7-3a10-4c9b-af37-e4dbcdf42254
 pkg-pinheader-1x31-d1.1-pkg,aa235ee5-2fd7-4be9-8a59-b075f3252091
 pkg-pinheader-1x31-d1.1-polygon-contour,80b46f1a-a5e1-4d0d-b5b0-e25a33255fe7
+pkg-pinheader-1x31-d1.1-polygon-courtyard,7c99b673-b6ab-4dc4-8a4a-9bdfd7bdcd25
+pkg-pinheader-1x31-d1.1-polygon-outline,e7aef149-819e-4c62-a784-5d1703cc46bc
 pkg-pinheader-1x31-d1.1-text-name,27f272b6-41ec-4a66-8cda-a9c4feff6c4b
 pkg-pinheader-1x31-d1.1-text-value,ed1a44d2-103d-4b1f-aa2b-90f7261deffe
 pkg-pinheader-1x32-d0.9-3d,b18e0bea-8135-444e-9c9c-8ac19dfb3acf
@@ -8699,6 +8849,8 @@ pkg-pinheader-1x32-d0.9-pad-8,002cea47-78f9-4e39-88ff-ed90abca1992
 pkg-pinheader-1x32-d0.9-pad-9,c428422c-f2de-4d9d-ae3a-677d2ff5d788
 pkg-pinheader-1x32-d0.9-pkg,0d1c7ea6-915f-4c01-9b6b-7a767522b2a9
 pkg-pinheader-1x32-d0.9-polygon-contour,ca1db202-62d2-41d5-9789-45f0d61fb455
+pkg-pinheader-1x32-d0.9-polygon-courtyard,0ff36180-da4d-46ae-b0ea-dccbf1579de2
+pkg-pinheader-1x32-d0.9-polygon-outline,52ecfd60-90ee-4e24-9e33-191454315304
 pkg-pinheader-1x32-d0.9-text-name,6751a098-e70b-41c7-bb19-374ad822f64f
 pkg-pinheader-1x32-d0.9-text-value,da2809c8-c7d4-4ad1-8717-5b3eebb7a3ea
 pkg-pinheader-1x32-d1.0-3d,28155e5b-5091-4252-a9d8-98c5370021db
@@ -8737,6 +8889,8 @@ pkg-pinheader-1x32-d1.0-pad-8,8b050a04-0a0d-49fe-9f75-fe70429fd96e
 pkg-pinheader-1x32-d1.0-pad-9,72074b31-4651-4723-9630-5e620d06d57c
 pkg-pinheader-1x32-d1.0-pkg,03571601-d204-4b45-b50b-925cfe9f3f69
 pkg-pinheader-1x32-d1.0-polygon-contour,ac1c7e96-b7ee-4aae-b6e5-c8790f2a0525
+pkg-pinheader-1x32-d1.0-polygon-courtyard,822f0d3e-9b40-4e1b-8725-27a9dc1c2aa6
+pkg-pinheader-1x32-d1.0-polygon-outline,15249e24-929b-423b-800d-7338403140c3
 pkg-pinheader-1x32-d1.0-text-name,3fb80731-ca74-48c5-99a8-26229fb1c4fa
 pkg-pinheader-1x32-d1.0-text-value,76c546f2-0734-4d7b-bdbf-04ada9af1b9f
 pkg-pinheader-1x32-d1.1-3d,e5d80129-6da3-44cf-9e08-1c4ffbf3ff8a
@@ -8775,6 +8929,8 @@ pkg-pinheader-1x32-d1.1-pad-8,01d7a8fb-6c18-44ed-a560-6852d9cd2fbf
 pkg-pinheader-1x32-d1.1-pad-9,ec6ef4bd-707a-4c6f-9119-e5fde2f24750
 pkg-pinheader-1x32-d1.1-pkg,4e2db43b-027d-4a3b-900b-e876c27455e6
 pkg-pinheader-1x32-d1.1-polygon-contour,950cb3bb-75b8-4275-a754-80302501a440
+pkg-pinheader-1x32-d1.1-polygon-courtyard,d748df03-e191-4da0-8bd1-52319dc38c48
+pkg-pinheader-1x32-d1.1-polygon-outline,38218453-5fb5-47f3-9152-3d46f5ec8778
 pkg-pinheader-1x32-d1.1-text-name,dc70d046-9425-42be-bc26-8251b2d840f5
 pkg-pinheader-1x32-d1.1-text-value,9b4b5780-6ba0-4e45-8622-37de8c0855ae
 pkg-pinheader-1x33-d0.9-3d,abc75ef3-3792-46e8-87dd-4da9c3892f2d
@@ -8814,6 +8970,8 @@ pkg-pinheader-1x33-d0.9-pad-8,6a508ea6-a344-49bd-a48a-11cd2cbef58f
 pkg-pinheader-1x33-d0.9-pad-9,70dc9bc4-6b58-4b96-8e75-ecbfe70e8159
 pkg-pinheader-1x33-d0.9-pkg,482d1557-1819-4724-950c-a167a17b1525
 pkg-pinheader-1x33-d0.9-polygon-contour,5fd3703e-2df7-4284-9711-31bef4495890
+pkg-pinheader-1x33-d0.9-polygon-courtyard,2e4efda9-0d87-4edf-8f55-a84a8707d33f
+pkg-pinheader-1x33-d0.9-polygon-outline,b125ae97-4e0a-4f19-8a2c-196c1ae359a5
 pkg-pinheader-1x33-d0.9-text-name,28d6a2b5-62c0-4a23-bd19-6b8c2db5849e
 pkg-pinheader-1x33-d0.9-text-value,b7cded1c-d92e-48cb-ac66-bb37c22e99a8
 pkg-pinheader-1x33-d1.0-3d,d13c3a77-262f-4dcc-8602-4f9938fb3019
@@ -8853,6 +9011,8 @@ pkg-pinheader-1x33-d1.0-pad-8,c8b4826c-fe78-420e-a8d1-b87570ca6d35
 pkg-pinheader-1x33-d1.0-pad-9,d168afc0-e61e-4d9f-92f7-07da5f6db6b5
 pkg-pinheader-1x33-d1.0-pkg,bb1f7475-0c40-4067-946d-97d8c0c2f57e
 pkg-pinheader-1x33-d1.0-polygon-contour,f4e441a0-b265-4af5-a59c-80ac63d527bf
+pkg-pinheader-1x33-d1.0-polygon-courtyard,2d77e81b-92e9-4d43-a08c-840099cec5a8
+pkg-pinheader-1x33-d1.0-polygon-outline,57433354-8238-4914-af78-96f566e481c1
 pkg-pinheader-1x33-d1.0-text-name,43a3f45d-c876-47ef-bd40-450646134630
 pkg-pinheader-1x33-d1.0-text-value,ec0191d0-29d3-40f3-8474-da3022ae7b2e
 pkg-pinheader-1x33-d1.1-3d,48d23fe7-1a30-4203-916f-f987af3c2a9b
@@ -8892,6 +9052,8 @@ pkg-pinheader-1x33-d1.1-pad-8,6535eef7-d316-4158-81aa-e42d3992943e
 pkg-pinheader-1x33-d1.1-pad-9,8336788b-6610-4db9-900d-7dc95f71a347
 pkg-pinheader-1x33-d1.1-pkg,cf7ea5f0-f1e9-4689-8cfb-05c144d742fd
 pkg-pinheader-1x33-d1.1-polygon-contour,95bf12bc-68f6-47e5-8e34-b1892c2063a4
+pkg-pinheader-1x33-d1.1-polygon-courtyard,53e14db9-e5d1-4575-b2b0-9217370ef1d6
+pkg-pinheader-1x33-d1.1-polygon-outline,a2b782ef-4361-4ec4-bb09-ffcfa4e5af00
 pkg-pinheader-1x33-d1.1-text-name,eaa6ff17-87f6-42cf-b105-68c5091b19ca
 pkg-pinheader-1x33-d1.1-text-value,5236846b-2347-4773-aaac-631af6e9d43d
 pkg-pinheader-1x34-d0.9-3d,f065dd64-8cdc-417c-bb6c-5b8ec89db18c
@@ -8932,6 +9094,8 @@ pkg-pinheader-1x34-d0.9-pad-8,e3f6a26d-f295-4c4a-b961-be2965dd4c1f
 pkg-pinheader-1x34-d0.9-pad-9,8560eefc-eeed-4132-84f8-86c54fef4021
 pkg-pinheader-1x34-d0.9-pkg,77e08697-fd87-4974-b575-f527177bf4bf
 pkg-pinheader-1x34-d0.9-polygon-contour,858060a2-3426-41a6-8c33-ca9dc1d02810
+pkg-pinheader-1x34-d0.9-polygon-courtyard,92365c66-63ab-471d-924e-8c185574afb7
+pkg-pinheader-1x34-d0.9-polygon-outline,de9c289d-8f50-4d32-8f01-62d53540fbd4
 pkg-pinheader-1x34-d0.9-text-name,c738234c-302f-4611-ad01-5f7f16528d0f
 pkg-pinheader-1x34-d0.9-text-value,f4a0cb3a-2973-4053-9835-ad5276d58303
 pkg-pinheader-1x34-d1.0-3d,90d44436-ae74-4412-afe1-55ad7dfced9b
@@ -8972,6 +9136,8 @@ pkg-pinheader-1x34-d1.0-pad-8,1ec2e2f1-bc87-483c-84fb-3910ac4babf2
 pkg-pinheader-1x34-d1.0-pad-9,445f0ff7-1ce6-468e-8983-65dc10ee3e0b
 pkg-pinheader-1x34-d1.0-pkg,01cfdcb1-5efa-4f40-84ba-0d6038d4612e
 pkg-pinheader-1x34-d1.0-polygon-contour,59b861cc-ae71-404d-af5e-ddbce0f82ccb
+pkg-pinheader-1x34-d1.0-polygon-courtyard,9373418c-0b3b-4e5f-ad4e-0721f4a0535b
+pkg-pinheader-1x34-d1.0-polygon-outline,ed8353c1-4115-4f23-af9a-4cce636a3d2e
 pkg-pinheader-1x34-d1.0-text-name,ee68d886-e022-4a3b-b4ea-07954ba240cb
 pkg-pinheader-1x34-d1.0-text-value,9b10fff8-95b4-47de-ad07-e73b304457ca
 pkg-pinheader-1x34-d1.1-3d,fd9246ac-a198-47b2-887e-ba97a8cd0a59
@@ -9012,6 +9178,8 @@ pkg-pinheader-1x34-d1.1-pad-8,76ca638d-0fd0-4b52-9c27-51c552c73731
 pkg-pinheader-1x34-d1.1-pad-9,85b431c2-4da0-42fa-a496-dd9eaa47aec9
 pkg-pinheader-1x34-d1.1-pkg,2eb091b4-0e85-4605-add5-5169ead820bf
 pkg-pinheader-1x34-d1.1-polygon-contour,aa4a15db-a3f2-4194-9eac-05d52bd4c827
+pkg-pinheader-1x34-d1.1-polygon-courtyard,6beb4ca4-8dbe-4682-813c-e38599ef5edc
+pkg-pinheader-1x34-d1.1-polygon-outline,3ed4c47e-5cc8-4ab4-a300-e1ba531974ea
 pkg-pinheader-1x34-d1.1-text-name,4442309a-49d0-4c5d-ad03-738e85760e22
 pkg-pinheader-1x34-d1.1-text-value,94136ec7-1bd7-4069-8af9-025496f2442e
 pkg-pinheader-1x35-d0.9-3d,25deb9c2-fab2-4fba-87b9-6be12ae3ca77
@@ -9053,6 +9221,8 @@ pkg-pinheader-1x35-d0.9-pad-8,b6703886-e906-4c45-a7c6-e1d4ab2c20a8
 pkg-pinheader-1x35-d0.9-pad-9,f533b730-7323-44ee-ae60-bb6b754bb941
 pkg-pinheader-1x35-d0.9-pkg,2f0c62be-8e76-4206-b58a-9eeb0c6a189b
 pkg-pinheader-1x35-d0.9-polygon-contour,397e6957-04ff-4d87-95b0-4af656a8d96f
+pkg-pinheader-1x35-d0.9-polygon-courtyard,11e5aab5-1e14-445a-bb38-bb41c27c7bf0
+pkg-pinheader-1x35-d0.9-polygon-outline,5d96eea2-e643-4e43-b315-6107d10c6584
 pkg-pinheader-1x35-d0.9-text-name,c893a466-c859-4890-8c7a-4201dd2bd604
 pkg-pinheader-1x35-d0.9-text-value,727ca38f-be11-4fe5-a0be-8c6a03902889
 pkg-pinheader-1x35-d1.0-3d,0a0f7b84-dae3-4736-97f8-938eb223272d
@@ -9094,6 +9264,8 @@ pkg-pinheader-1x35-d1.0-pad-8,8a8f0927-d4ee-42d1-9fa1-bbdf8ae60891
 pkg-pinheader-1x35-d1.0-pad-9,cb7a3eb8-204e-4c84-90b2-e21411b4e927
 pkg-pinheader-1x35-d1.0-pkg,b0392091-b13b-4955-adb3-84c0c5427e40
 pkg-pinheader-1x35-d1.0-polygon-contour,f0e8f9e6-269a-4145-9a26-012d6cc261e0
+pkg-pinheader-1x35-d1.0-polygon-courtyard,840576b5-41d5-4e26-9027-10cd33afe692
+pkg-pinheader-1x35-d1.0-polygon-outline,5f28626f-a9cb-4596-aa45-b76871f8e692
 pkg-pinheader-1x35-d1.0-text-name,793e9b8f-5dd1-4f3b-8bfe-27de06265312
 pkg-pinheader-1x35-d1.0-text-value,493e5bc9-847f-4e9d-aa76-f3589e043b97
 pkg-pinheader-1x35-d1.1-3d,7e018ebc-6d24-4d27-bdb2-8cacef441236
@@ -9135,6 +9307,8 @@ pkg-pinheader-1x35-d1.1-pad-8,86a5a1ba-e9f5-4a25-b8e5-c0c6528688d7
 pkg-pinheader-1x35-d1.1-pad-9,99c86389-b1b9-45ad-9517-6dee5ac3d8cb
 pkg-pinheader-1x35-d1.1-pkg,b542497e-21b8-4434-8a7d-3afcce630fcc
 pkg-pinheader-1x35-d1.1-polygon-contour,ac043a98-8a04-48a2-9a27-931ffa841a93
+pkg-pinheader-1x35-d1.1-polygon-courtyard,6e299d2a-fdb9-4736-9ca8-21db2955d606
+pkg-pinheader-1x35-d1.1-polygon-outline,c694aab7-9d73-4b58-a4a7-2c45f916b459
 pkg-pinheader-1x35-d1.1-text-name,961b9ccc-83fb-450e-8ac5-e9df0506b127
 pkg-pinheader-1x35-d1.1-text-value,885cc7c9-207e-4028-99b0-cc9ce810d13b
 pkg-pinheader-1x36-d0.9-3d,d71ffd06-c2f3-4b40-84bc-4ce7a38b6160
@@ -9177,6 +9351,8 @@ pkg-pinheader-1x36-d0.9-pad-8,ab383c9b-271e-4bdd-8aa9-3105e041c684
 pkg-pinheader-1x36-d0.9-pad-9,6d1a36f0-31b6-464f-87b1-85e27196eee5
 pkg-pinheader-1x36-d0.9-pkg,6a0aa058-229c-4065-965f-46cb56eff7ac
 pkg-pinheader-1x36-d0.9-polygon-contour,7a01e01b-66ae-4d3d-bba3-4eea6ab93898
+pkg-pinheader-1x36-d0.9-polygon-courtyard,fc060b96-6285-4896-a2e9-4d722be9db18
+pkg-pinheader-1x36-d0.9-polygon-outline,3812522b-752d-463a-bdb6-7f46643b2923
 pkg-pinheader-1x36-d0.9-text-name,188404b2-719b-4997-90f3-8b64d3a97ea6
 pkg-pinheader-1x36-d0.9-text-value,e268be04-f866-4f49-99c6-f04f1903136e
 pkg-pinheader-1x36-d1.0-3d,51305246-5799-4a7e-b160-bba975aab08d
@@ -9219,6 +9395,8 @@ pkg-pinheader-1x36-d1.0-pad-8,f818d596-968b-487f-895c-b4394043a25c
 pkg-pinheader-1x36-d1.0-pad-9,1314abe7-b213-48e3-a067-211e07fd9dc9
 pkg-pinheader-1x36-d1.0-pkg,85bf29b4-e0a1-4a30-b129-c4db330630c8
 pkg-pinheader-1x36-d1.0-polygon-contour,a952d8f8-9bb6-46e4-99b4-6af9d1e0d44d
+pkg-pinheader-1x36-d1.0-polygon-courtyard,907c9cf7-2870-4c44-a110-4f00dcf7c8f2
+pkg-pinheader-1x36-d1.0-polygon-outline,9e76c19e-41be-4962-9178-b56ad2461e09
 pkg-pinheader-1x36-d1.0-text-name,3541eb13-1a24-43b6-86dd-29b16dbed12c
 pkg-pinheader-1x36-d1.0-text-value,93c731f5-70c2-41a8-8440-3a9427f1822f
 pkg-pinheader-1x36-d1.1-3d,74cff1c3-f8ce-4dd3-9c0f-b756b2df095c
@@ -9261,6 +9439,8 @@ pkg-pinheader-1x36-d1.1-pad-8,c3b8bfe6-82c0-4fdc-b578-44bfc6ecffca
 pkg-pinheader-1x36-d1.1-pad-9,2008e78e-aa35-4673-ab1a-caa99037e82e
 pkg-pinheader-1x36-d1.1-pkg,3652cc96-71ac-4bf8-a891-f6944a9d95b2
 pkg-pinheader-1x36-d1.1-polygon-contour,b00c8a78-488d-45d3-bae3-1e16d500a31a
+pkg-pinheader-1x36-d1.1-polygon-courtyard,6dc1907d-9d13-46e1-a413-5925a518b184
+pkg-pinheader-1x36-d1.1-polygon-outline,a6485c13-0558-4b98-8d01-b4cd1e168e23
 pkg-pinheader-1x36-d1.1-text-name,15b74507-08ab-4a09-b3bd-de2ebfe10ba6
 pkg-pinheader-1x36-d1.1-text-value,e26b6abf-5b88-458b-8089-b64b6dccdb80
 pkg-pinheader-1x37-d0.9-3d,a67e22e7-bb7a-4a3d-82a6-cd552cbc5cdf
@@ -9304,6 +9484,8 @@ pkg-pinheader-1x37-d0.9-pad-8,6019e5d5-3865-40c4-8f7a-172231d606b0
 pkg-pinheader-1x37-d0.9-pad-9,5aeb15dd-609d-493e-b5ee-8eb7e4a90ed2
 pkg-pinheader-1x37-d0.9-pkg,23d6a6c0-1aa2-41a5-bc41-8f1df9b6f467
 pkg-pinheader-1x37-d0.9-polygon-contour,d552b7a5-aa93-44e4-90e1-36fd9c1525a5
+pkg-pinheader-1x37-d0.9-polygon-courtyard,4dc15967-d0ba-49c3-98d6-e8645ca88a0e
+pkg-pinheader-1x37-d0.9-polygon-outline,fe3791cc-f2d7-47d8-a6b6-20f06baf285e
 pkg-pinheader-1x37-d0.9-text-name,b34601cb-5f44-4fed-8c50-90980601f4ce
 pkg-pinheader-1x37-d0.9-text-value,6582d0ab-5a3d-47ce-971b-d63258bd901e
 pkg-pinheader-1x37-d1.0-3d,ca27457e-51f9-4295-8b4a-eb032b3f2d1c
@@ -9347,6 +9529,8 @@ pkg-pinheader-1x37-d1.0-pad-8,d6ab50d4-bca7-4024-a366-f7261c66f820
 pkg-pinheader-1x37-d1.0-pad-9,3e10f172-3258-406f-a3c8-9f31175a5ad2
 pkg-pinheader-1x37-d1.0-pkg,1121c77f-3d77-4242-bbd0-c4493bf6e764
 pkg-pinheader-1x37-d1.0-polygon-contour,d8088c65-b872-422b-87d0-aeccb558a0c2
+pkg-pinheader-1x37-d1.0-polygon-courtyard,496416c0-b2f9-4df2-b500-394c68f02926
+pkg-pinheader-1x37-d1.0-polygon-outline,f277d993-c092-4705-a4f0-3d8079124cdb
 pkg-pinheader-1x37-d1.0-text-name,d27fc920-7f10-43f2-bfcf-70d35df6cc3d
 pkg-pinheader-1x37-d1.0-text-value,318a23c0-1ca6-4ef6-813c-def921e96869
 pkg-pinheader-1x37-d1.1-3d,cff25856-7df1-4f2a-8887-40683185b057
@@ -9390,6 +9574,8 @@ pkg-pinheader-1x37-d1.1-pad-8,e148a3d7-a079-4e27-9887-01b926e3aeb2
 pkg-pinheader-1x37-d1.1-pad-9,4335d939-b761-4a83-ba3d-da7b37bdc0f8
 pkg-pinheader-1x37-d1.1-pkg,fe5b5db0-7e57-487c-b1e6-06522c4a2d3c
 pkg-pinheader-1x37-d1.1-polygon-contour,75629261-7932-44fa-9ad7-c53a4204b525
+pkg-pinheader-1x37-d1.1-polygon-courtyard,56bf2d7e-0ca8-40e0-bf9c-28233ec1e842
+pkg-pinheader-1x37-d1.1-polygon-outline,8031953e-5ffd-4653-9e6f-acb6e29dc958
 pkg-pinheader-1x37-d1.1-text-name,d809c2cb-6cae-4c41-a5b0-dcc98f199809
 pkg-pinheader-1x37-d1.1-text-value,05d9d8de-96ce-4aa6-93d9-bcddbf42ba6d
 pkg-pinheader-1x38-d0.9-3d,5adeb883-566a-4625-b909-061eaf937444
@@ -9434,6 +9620,8 @@ pkg-pinheader-1x38-d0.9-pad-8,33fd8aef-f86c-4d98-b37d-eb7cad3598c4
 pkg-pinheader-1x38-d0.9-pad-9,44081752-bf93-413f-ad5c-7a226de3c3ca
 pkg-pinheader-1x38-d0.9-pkg,437e826f-7dd4-4baf-8120-b49881e4d2f2
 pkg-pinheader-1x38-d0.9-polygon-contour,9775c1d6-dfe1-4307-be29-c405aa18e919
+pkg-pinheader-1x38-d0.9-polygon-courtyard,7c951bf3-4479-4136-b160-5f51197f6e06
+pkg-pinheader-1x38-d0.9-polygon-outline,ac780ec6-372d-428e-9739-c84891943765
 pkg-pinheader-1x38-d0.9-text-name,7a98afc4-1998-4f8a-8bde-524921bb6ebc
 pkg-pinheader-1x38-d0.9-text-value,9c067640-e031-45b3-ae42-2471e1fa1763
 pkg-pinheader-1x38-d1.0-3d,45d83943-2b00-4c98-924c-7e7fa7019530
@@ -9478,6 +9666,8 @@ pkg-pinheader-1x38-d1.0-pad-8,4e816c96-2c30-412e-9960-7157a16a7e23
 pkg-pinheader-1x38-d1.0-pad-9,85f675fb-f1d3-433e-bbb9-24385f40d33c
 pkg-pinheader-1x38-d1.0-pkg,135c9d70-51af-4415-8ff9-0ab8443ee9d2
 pkg-pinheader-1x38-d1.0-polygon-contour,a3e14e6c-075b-4fff-a5a1-a7a820857894
+pkg-pinheader-1x38-d1.0-polygon-courtyard,c9328e6e-b0e7-4cc4-9fdc-e4563626fcc5
+pkg-pinheader-1x38-d1.0-polygon-outline,f793d8b9-53a2-4b16-a98e-c58166227397
 pkg-pinheader-1x38-d1.0-text-name,7b895027-11b5-45c3-be37-a28b6cd26d68
 pkg-pinheader-1x38-d1.0-text-value,799e5177-e30e-4b1f-9cc8-9c9a1becaa2c
 pkg-pinheader-1x38-d1.1-3d,b36d6fc6-ebc8-40c2-b7a5-7e9371e2459b
@@ -9522,6 +9712,8 @@ pkg-pinheader-1x38-d1.1-pad-8,21e234a1-4119-42f2-838f-864791466427
 pkg-pinheader-1x38-d1.1-pad-9,b43d702e-efcb-49af-96f9-8d2ff68d168d
 pkg-pinheader-1x38-d1.1-pkg,76b0ba54-3016-4306-adbc-df53337366bb
 pkg-pinheader-1x38-d1.1-polygon-contour,1723ead2-0153-4824-8275-7171b8b916bf
+pkg-pinheader-1x38-d1.1-polygon-courtyard,f4933edb-0417-49f0-8db0-57d484f2569b
+pkg-pinheader-1x38-d1.1-polygon-outline,1d4f0417-6a44-4d93-bda6-d0a7e0af0a6e
 pkg-pinheader-1x38-d1.1-text-name,9f8bc5dc-6d6e-47dd-b7fc-23ea78870599
 pkg-pinheader-1x38-d1.1-text-value,4ac82adc-65c3-4e94-9136-903ee8966029
 pkg-pinheader-1x39-d0.9-3d,8a7e9738-9fbd-416a-b854-a51157bb9a94
@@ -9567,6 +9759,8 @@ pkg-pinheader-1x39-d0.9-pad-8,ae7384f7-4112-449e-9ca9-0f9f4d416715
 pkg-pinheader-1x39-d0.9-pad-9,ff638d6c-7687-4975-889d-b76e6b089b2d
 pkg-pinheader-1x39-d0.9-pkg,f5af81eb-0f1a-4a4e-be7f-b9bf9e3dc9a2
 pkg-pinheader-1x39-d0.9-polygon-contour,43fc77e3-7e9b-48fe-bf3c-44d1b445acef
+pkg-pinheader-1x39-d0.9-polygon-courtyard,e477b4d9-4c40-4d0a-a786-39e3f1272a0c
+pkg-pinheader-1x39-d0.9-polygon-outline,61f00b0b-9e44-4fd4-afe1-6ba992868f73
 pkg-pinheader-1x39-d0.9-text-name,9c2b4aea-2807-4826-8538-bb6175c1e2fb
 pkg-pinheader-1x39-d0.9-text-value,945f38c1-8c9e-40cb-a06e-d4b9af046ed3
 pkg-pinheader-1x39-d1.0-3d,1647564c-1376-4861-a1e7-65ec3c02e5f0
@@ -9612,6 +9806,8 @@ pkg-pinheader-1x39-d1.0-pad-8,2423a767-11c0-4467-84ad-ed7f9bbbf13e
 pkg-pinheader-1x39-d1.0-pad-9,204a86db-33a1-46a8-b39f-767675f2910e
 pkg-pinheader-1x39-d1.0-pkg,5dcec5c6-4afd-4920-a5c2-374f01780f72
 pkg-pinheader-1x39-d1.0-polygon-contour,1a60ea0d-24ef-446b-b11a-ff568dddd0d8
+pkg-pinheader-1x39-d1.0-polygon-courtyard,0f22dda8-c604-4334-bfa7-2b667f8c88ff
+pkg-pinheader-1x39-d1.0-polygon-outline,432ac782-fb76-4ce3-93c1-310238cb2c89
 pkg-pinheader-1x39-d1.0-text-name,19522c1b-1c5e-4584-8ca9-d20d49a3c96f
 pkg-pinheader-1x39-d1.0-text-value,1b394071-8b28-464b-aca0-984bb4a78798
 pkg-pinheader-1x39-d1.1-3d,ed7fa662-ddb5-4ee4-aac9-d1280cbe9619
@@ -9657,6 +9853,8 @@ pkg-pinheader-1x39-d1.1-pad-8,6c9d2e52-2ae5-4727-90bd-c918bcf5fdeb
 pkg-pinheader-1x39-d1.1-pad-9,945ad630-43dd-4586-ac58-7405d27578d2
 pkg-pinheader-1x39-d1.1-pkg,ddbd7c32-2e74-4358-a0ea-8ffdb204fb5d
 pkg-pinheader-1x39-d1.1-polygon-contour,4c4fe064-8196-49ed-8391-d5b271f056d6
+pkg-pinheader-1x39-d1.1-polygon-courtyard,f883630f-e8c7-408e-940f-03e98abd75a5
+pkg-pinheader-1x39-d1.1-polygon-outline,a5974b1c-862f-49a4-aaa0-0dc599a03766
 pkg-pinheader-1x39-d1.1-text-name,060ae0d3-6fe3-4cf0-aa2b-67e168a0ef9d
 pkg-pinheader-1x39-d1.1-text-value,b9cfaa52-97dc-4ea0-80e7-ff95c36ff048
 pkg-pinheader-1x4-d0.9-3d,86d188d3-a898-4ae7-9264-7201ccdc0e3c
@@ -9667,6 +9865,8 @@ pkg-pinheader-1x4-d0.9-pad-2,d5504b35-e3d8-4123-95b5-aab02cca6227
 pkg-pinheader-1x4-d0.9-pad-3,77a723bf-0e1c-4ab1-9e90-2ce0a059af9c
 pkg-pinheader-1x4-d0.9-pkg,6388c7e7-eadf-4f43-934d-864878e2c976
 pkg-pinheader-1x4-d0.9-polygon-contour,e15e7ca3-da22-4894-bf60-161d3af01a39
+pkg-pinheader-1x4-d0.9-polygon-courtyard,7c7fa71c-bba9-4df3-9ada-5262b61d63c5
+pkg-pinheader-1x4-d0.9-polygon-outline,dea1d515-1c05-48ec-aead-5cecc2f54698
 pkg-pinheader-1x4-d0.9-text-name,96c2d33d-f68c-482f-9268-2e70769a9c65
 pkg-pinheader-1x4-d0.9-text-value,29c6836e-d9cb-49f8-929e-0e276d668547
 pkg-pinheader-1x4-d1.0-3d,bfe48fd1-7dc7-4995-8aed-1b6bbc7e7a0d
@@ -9677,6 +9877,8 @@ pkg-pinheader-1x4-d1.0-pad-2,ffe70828-ccb9-4f55-be74-67d150be40d5
 pkg-pinheader-1x4-d1.0-pad-3,d4b56f68-4850-4c68-86e7-2168c586de50
 pkg-pinheader-1x4-d1.0-pkg,9e2a9a04-6216-47b0-857d-a9417c3961f3
 pkg-pinheader-1x4-d1.0-polygon-contour,293b6707-29a4-4acb-9f88-2d0fe84eacdd
+pkg-pinheader-1x4-d1.0-polygon-courtyard,71042f98-26e2-4c42-bc8f-d97936601f01
+pkg-pinheader-1x4-d1.0-polygon-outline,c12d7db1-9a84-40c7-922b-0073df9ac78f
 pkg-pinheader-1x4-d1.0-text-name,c4bc0122-bc70-407b-9af0-687d1fea4feb
 pkg-pinheader-1x4-d1.0-text-value,abf7f8a3-de65-4210-a997-24fe515daf33
 pkg-pinheader-1x4-d1.1-3d,7f53e368-f911-4836-b4e4-9430ca028991
@@ -9687,6 +9889,8 @@ pkg-pinheader-1x4-d1.1-pad-2,9ef92e57-b572-4ed6-bc37-33915071ff95
 pkg-pinheader-1x4-d1.1-pad-3,b50abc62-9951-4252-98f7-7e1da40c23d7
 pkg-pinheader-1x4-d1.1-pkg,f9c9569c-2e03-4f03-909a-9fa6b0847750
 pkg-pinheader-1x4-d1.1-polygon-contour,e8312ede-b0e4-4430-ab54-d15edb59d833
+pkg-pinheader-1x4-d1.1-polygon-courtyard,7e17d117-7c94-4513-b8d3-c52d1c0dc0de
+pkg-pinheader-1x4-d1.1-polygon-outline,fe8d2621-3828-40a9-bfcf-4c40c2a8f4a8
 pkg-pinheader-1x4-d1.1-text-name,86433180-af84-48cf-8665-f136945d5580
 pkg-pinheader-1x4-d1.1-text-value,8b181cd7-b136-4a42-8120-007c4d0bd00f
 pkg-pinheader-1x40-d0.9-3d,4677078d-8ba8-4498-a255-4445bc41f326
@@ -9733,6 +9937,8 @@ pkg-pinheader-1x40-d0.9-pad-8,afbc9392-f796-4027-a0d0-9945ce7ff6f7
 pkg-pinheader-1x40-d0.9-pad-9,fa798442-564f-49d6-bad7-641080761540
 pkg-pinheader-1x40-d0.9-pkg,44f33d90-248d-4286-8124-11450adc1ac4
 pkg-pinheader-1x40-d0.9-polygon-contour,b432d605-8967-4bc7-bfeb-876810213030
+pkg-pinheader-1x40-d0.9-polygon-courtyard,3697debc-f748-42cd-8efa-0ddcdf81686e
+pkg-pinheader-1x40-d0.9-polygon-outline,b6c9231b-b2c1-4af5-8d97-f93f85f5e62d
 pkg-pinheader-1x40-d0.9-text-name,47fc6015-fadc-4671-b97e-5240af74fde8
 pkg-pinheader-1x40-d0.9-text-value,b5c5b240-d0cf-48d0-90da-82e4bd7b37d5
 pkg-pinheader-1x40-d1.0-3d,1e48cd26-17d0-4667-8aca-b7b9b6fa8b1a
@@ -9779,6 +9985,8 @@ pkg-pinheader-1x40-d1.0-pad-8,857c5fb5-5faf-40ef-b5ca-c93ce70d03d2
 pkg-pinheader-1x40-d1.0-pad-9,07afe61d-d7c8-4ebd-a452-3c611c3631a8
 pkg-pinheader-1x40-d1.0-pkg,5da566f3-8182-4183-891a-27beaed0f71c
 pkg-pinheader-1x40-d1.0-polygon-contour,d3dcf73c-78a8-46ad-b540-60c41248d97f
+pkg-pinheader-1x40-d1.0-polygon-courtyard,72d22977-9d23-48ac-931f-cf3fafe3098a
+pkg-pinheader-1x40-d1.0-polygon-outline,aac3f016-eb20-40a9-a33e-de88adda4ea1
 pkg-pinheader-1x40-d1.0-text-name,08226424-2884-4c06-8d72-fb289628f92f
 pkg-pinheader-1x40-d1.0-text-value,556f59be-2ae2-4741-836c-c262dc4993d4
 pkg-pinheader-1x40-d1.1-3d,e52a1ce9-43fe-46a1-ae02-43ba65e31cd9
@@ -9825,6 +10033,8 @@ pkg-pinheader-1x40-d1.1-pad-8,06210e3b-15fd-4c1a-a4f2-18244a27d334
 pkg-pinheader-1x40-d1.1-pad-9,42caed54-fd49-45b8-bc0f-9a0af09d8537
 pkg-pinheader-1x40-d1.1-pkg,c4cea26b-40eb-42d1-88b0-98f0b7d65744
 pkg-pinheader-1x40-d1.1-polygon-contour,6054c8a6-acef-4af7-beff-f4a249d7505a
+pkg-pinheader-1x40-d1.1-polygon-courtyard,46abba8c-ddd6-49aa-b16a-5af43fd21ef4
+pkg-pinheader-1x40-d1.1-polygon-outline,be4246a5-1de3-4f9c-b8bd-b82eee8bfe4c
 pkg-pinheader-1x40-d1.1-text-name,bab4bf98-dd6c-4ac5-8c4d-c4bb5fc7f03b
 pkg-pinheader-1x40-d1.1-text-value,a0ceaf68-d152-4e71-8545-963cca87dd9d
 pkg-pinheader-1x5-d0.9-3d,2714cc1f-0e64-4e10-b46d-2c17dac0f309
@@ -9836,6 +10046,8 @@ pkg-pinheader-1x5-d0.9-pad-3,d2017c88-7ef2-4910-806a-55e501a7ba40
 pkg-pinheader-1x5-d0.9-pad-4,c55b8953-8008-410d-84a4-758c248de330
 pkg-pinheader-1x5-d0.9-pkg,8ef061d6-1163-46d0-87d4-6d05878efa17
 pkg-pinheader-1x5-d0.9-polygon-contour,0dd5d79d-f9f3-4896-9a13-b433e6a1be86
+pkg-pinheader-1x5-d0.9-polygon-courtyard,753a6f0c-c7c2-431e-b80a-b2afd8343dca
+pkg-pinheader-1x5-d0.9-polygon-outline,32a77e17-0c27-425c-bb62-b832a8352145
 pkg-pinheader-1x5-d0.9-text-name,b95d5e7c-e1c2-455d-b248-e715cb9e2da3
 pkg-pinheader-1x5-d0.9-text-value,3bf65a2c-fb96-4921-a528-cac29fe61a70
 pkg-pinheader-1x5-d1.0-3d,bca8132b-11ba-4d03-8567-c379a8ca2afd
@@ -9847,6 +10059,8 @@ pkg-pinheader-1x5-d1.0-pad-3,a710dfcd-b548-4d4d-b25d-4d79ef7e7346
 pkg-pinheader-1x5-d1.0-pad-4,38929d7d-3137-4254-90d5-b3d7c7381649
 pkg-pinheader-1x5-d1.0-pkg,066e45b3-dc12-4d95-9b69-d65a681271ce
 pkg-pinheader-1x5-d1.0-polygon-contour,483c7300-21af-4478-b5a9-95b3565487da
+pkg-pinheader-1x5-d1.0-polygon-courtyard,45c370c9-4ea7-4bd5-a01a-f22863c36c2e
+pkg-pinheader-1x5-d1.0-polygon-outline,d4df046c-6849-4b0f-84c4-3d3bbb776710
 pkg-pinheader-1x5-d1.0-text-name,7b00f84c-ae79-445b-8bba-86b3c48e589e
 pkg-pinheader-1x5-d1.0-text-value,045a0463-3423-4131-848f-eca93856c698
 pkg-pinheader-1x5-d1.1-3d,b773d4d9-481b-47c4-87a1-41f4c69f6609
@@ -9858,6 +10072,8 @@ pkg-pinheader-1x5-d1.1-pad-3,070eb08c-1100-4802-a3fd-152770c1b524
 pkg-pinheader-1x5-d1.1-pad-4,bc744bd6-c371-4291-a5b4-1c2358d3393b
 pkg-pinheader-1x5-d1.1-pkg,7bd47163-bc11-4e3f-a879-67d75f1bdf5d
 pkg-pinheader-1x5-d1.1-polygon-contour,4a2c9ed3-d166-4fe3-9598-2e61da68d963
+pkg-pinheader-1x5-d1.1-polygon-courtyard,37cc0d31-7073-4c87-b7dc-36592e11be15
+pkg-pinheader-1x5-d1.1-polygon-outline,8e86078e-76ad-4d8b-9cae-0fcc589afe80
 pkg-pinheader-1x5-d1.1-text-name,12203908-52f5-42b0-a033-6fcecf3dda71
 pkg-pinheader-1x5-d1.1-text-value,6655bcac-9b7c-40ce-aad2-85665e8f4f79
 pkg-pinheader-1x6-d0.9-3d,842cbb85-9f34-4a65-8013-4b912b364d25
@@ -9870,6 +10086,8 @@ pkg-pinheader-1x6-d0.9-pad-4,2e18f2ff-d90a-4307-82cb-29d833c7e93f
 pkg-pinheader-1x6-d0.9-pad-5,0b900119-aa59-45e9-92ed-6bb09228f6d0
 pkg-pinheader-1x6-d0.9-pkg,193a71e7-d857-4746-9a52-efd55e762711
 pkg-pinheader-1x6-d0.9-polygon-contour,2bc2722f-4afc-4ed1-9443-5e43a4244fd0
+pkg-pinheader-1x6-d0.9-polygon-courtyard,30e3b159-09b9-404f-a837-265f81596c42
+pkg-pinheader-1x6-d0.9-polygon-outline,d2704b6f-d26f-43c9-aa33-50b35ff2fb4e
 pkg-pinheader-1x6-d0.9-text-name,796ff3ba-f60d-4d83-8b90-de0ad322c524
 pkg-pinheader-1x6-d0.9-text-value,e938f73a-2989-4d09-b641-848b7df7d1de
 pkg-pinheader-1x6-d1.0-3d,2eb79f62-4be0-4e89-bf72-168a652139e0
@@ -9882,6 +10100,8 @@ pkg-pinheader-1x6-d1.0-pad-4,f3ba57e8-a2ef-4a8e-9f88-49178cb919b3
 pkg-pinheader-1x6-d1.0-pad-5,cd2a6488-1c97-47a3-9291-6204848fbbc1
 pkg-pinheader-1x6-d1.0-pkg,a37802e4-825d-4983-ac82-33a33e3f4b85
 pkg-pinheader-1x6-d1.0-polygon-contour,4d5b1e29-b9d2-4c73-b1c4-c81a2a2a4679
+pkg-pinheader-1x6-d1.0-polygon-courtyard,846d10ca-7cb9-44d5-9ab1-eb0e162f62c1
+pkg-pinheader-1x6-d1.0-polygon-outline,5b8c4bac-3db5-4fcd-8f72-892f680ab405
 pkg-pinheader-1x6-d1.0-text-name,80af6d02-1082-4660-b1e3-cbc0f1c4176e
 pkg-pinheader-1x6-d1.0-text-value,f9d795c0-b1d2-4226-af0e-703c294f5a4f
 pkg-pinheader-1x6-d1.1-3d,3e97e207-6cd0-4da7-a8df-be4df9961933
@@ -9894,6 +10114,8 @@ pkg-pinheader-1x6-d1.1-pad-4,944cfe90-ae7f-4118-b63a-2d39c21b2c8a
 pkg-pinheader-1x6-d1.1-pad-5,c6607492-2132-4dd3-b67f-4cd40944e2ac
 pkg-pinheader-1x6-d1.1-pkg,0b8cc9c1-98f8-40d9-a881-d08b709fccc7
 pkg-pinheader-1x6-d1.1-polygon-contour,129e21ed-8c9b-42dc-9286-c86a27af44ac
+pkg-pinheader-1x6-d1.1-polygon-courtyard,bef8ec75-1e5d-42e7-bc33-cba0d6bac173
+pkg-pinheader-1x6-d1.1-polygon-outline,cc9b02e7-ec6f-4642-ab26-a949cc49ea6a
 pkg-pinheader-1x6-d1.1-text-name,281befcd-a579-4a52-b41e-14a221148a6b
 pkg-pinheader-1x6-d1.1-text-value,23b51a00-ebd9-4ca9-a8ce-abfa1ab102e2
 pkg-pinheader-1x7-d0.9-3d,d227510c-3ba0-4c31-8e22-ec553411ab29
@@ -9907,6 +10129,8 @@ pkg-pinheader-1x7-d0.9-pad-5,f8cdfc7a-0efd-45d6-aa0a-2f9c0dc8d975
 pkg-pinheader-1x7-d0.9-pad-6,3e12c0df-f604-457a-8425-64c8a8954e1d
 pkg-pinheader-1x7-d0.9-pkg,177cb068-19d0-4ac9-b79c-4237fed80d5a
 pkg-pinheader-1x7-d0.9-polygon-contour,bf74bf21-20e6-4900-b22e-4d607059ffee
+pkg-pinheader-1x7-d0.9-polygon-courtyard,9a63e5ae-1418-47fc-8e87-e6c8cb8e1810
+pkg-pinheader-1x7-d0.9-polygon-outline,7bec712a-f4da-457b-ab6e-97482943d503
 pkg-pinheader-1x7-d0.9-text-name,a9c75d35-b477-4e6a-8520-a30cc9253853
 pkg-pinheader-1x7-d0.9-text-value,2bb5d3fd-2fbc-4fb1-8f47-e6ed100b3337
 pkg-pinheader-1x7-d1.0-3d,b6abfff4-e645-40af-b9ec-004dd4cca62a
@@ -9920,6 +10144,8 @@ pkg-pinheader-1x7-d1.0-pad-5,ef2a759a-f88f-4540-a01b-cd3964296e00
 pkg-pinheader-1x7-d1.0-pad-6,6694ef71-8ab8-4c0e-a9a1-4212d6a67f7b
 pkg-pinheader-1x7-d1.0-pkg,e57405db-61fb-4df9-9204-12d580f2c3c6
 pkg-pinheader-1x7-d1.0-polygon-contour,896a7f21-6bfd-4100-b2a6-d45640480f6f
+pkg-pinheader-1x7-d1.0-polygon-courtyard,1bb7d74f-aa81-42ad-a130-e04eaadde1b4
+pkg-pinheader-1x7-d1.0-polygon-outline,156d65c0-b288-414a-96f1-e9f3b62c240f
 pkg-pinheader-1x7-d1.0-text-name,8969f4ac-29fe-4201-a67b-1cc17fef5002
 pkg-pinheader-1x7-d1.0-text-value,d112a146-205d-4811-a985-ea59cb2ff70e
 pkg-pinheader-1x7-d1.1-3d,b37a0022-7854-4856-b5d0-ed4eb0351fe8
@@ -9933,6 +10159,8 @@ pkg-pinheader-1x7-d1.1-pad-5,9b9b13e7-7051-4f21-83ca-72c1472a2451
 pkg-pinheader-1x7-d1.1-pad-6,99f89434-1644-4b39-80a1-7cdb7a63b326
 pkg-pinheader-1x7-d1.1-pkg,56b49b9b-52ed-4704-bf0c-fc74cad3c7af
 pkg-pinheader-1x7-d1.1-polygon-contour,69dfe2b3-ceb6-4f75-b9ed-a3b520b60fbe
+pkg-pinheader-1x7-d1.1-polygon-courtyard,a6a94bf7-4263-4e26-ba13-259b395fd290
+pkg-pinheader-1x7-d1.1-polygon-outline,e79c6203-fa0a-4752-b3e4-3dbecae4f37b
 pkg-pinheader-1x7-d1.1-text-name,0362311d-5368-44b8-91c5-695b803dfccb
 pkg-pinheader-1x7-d1.1-text-value,a7205886-88a5-4b06-a06c-7e9e98b20136
 pkg-pinheader-1x8-d0.9-3d,7ac39577-08ae-448f-9d03-d16b9f324750
@@ -9947,6 +10175,8 @@ pkg-pinheader-1x8-d0.9-pad-6,d7df4b53-37d7-4dea-821d-f6c6310e21b4
 pkg-pinheader-1x8-d0.9-pad-7,21821721-3ba3-4a4a-83cf-f26dbf19c726
 pkg-pinheader-1x8-d0.9-pkg,bda30a31-657b-48b3-82c7-ce2a6cfea564
 pkg-pinheader-1x8-d0.9-polygon-contour,4d890b1a-efa0-4e86-b368-400e4f7319a7
+pkg-pinheader-1x8-d0.9-polygon-courtyard,92557b3a-e55c-4c6f-8625-5d95f06e4efd
+pkg-pinheader-1x8-d0.9-polygon-outline,56fe1c86-9e99-49a1-80b3-d9ecbcd8310e
 pkg-pinheader-1x8-d0.9-text-name,2a49c5a6-66a9-4df7-a64d-8d94691ef20a
 pkg-pinheader-1x8-d0.9-text-value,1856a5f4-de23-42ab-9b6c-e31d76a7eb05
 pkg-pinheader-1x8-d1.0-3d,7085d2d0-7b93-4a0b-b4c1-24b03554bf42
@@ -9961,6 +10191,8 @@ pkg-pinheader-1x8-d1.0-pad-6,f0f2bca2-49cd-4323-8e99-03a0bbc45707
 pkg-pinheader-1x8-d1.0-pad-7,26a4a246-a608-4920-8392-0631e72801a6
 pkg-pinheader-1x8-d1.0-pkg,b4a05ab7-3900-4eb3-9530-f1cb0e4c0027
 pkg-pinheader-1x8-d1.0-polygon-contour,aef48ae7-7bff-4678-b701-da6273dd471f
+pkg-pinheader-1x8-d1.0-polygon-courtyard,e2503efa-5cd7-4e59-af02-4a7f599300ad
+pkg-pinheader-1x8-d1.0-polygon-outline,b82d26c8-ca97-4df2-9515-35a623543a23
 pkg-pinheader-1x8-d1.0-text-name,ff1bd1c8-a81e-4b27-80ae-0cbe5dbda688
 pkg-pinheader-1x8-d1.0-text-value,c475b577-311a-401f-86d1-f1f48d965ad2
 pkg-pinheader-1x8-d1.1-3d,8524597f-6048-4008-a9ae-514443795c0e
@@ -9975,6 +10207,8 @@ pkg-pinheader-1x8-d1.1-pad-6,afcf3195-1c5a-4858-beca-dae04e57612f
 pkg-pinheader-1x8-d1.1-pad-7,a6c0acda-fa80-43b5-bded-78a683b66889
 pkg-pinheader-1x8-d1.1-pkg,25ea91b9-705f-4180-b3b9-88f58473d6b4
 pkg-pinheader-1x8-d1.1-polygon-contour,c2751915-f75c-4fa9-adef-ce57efb887d2
+pkg-pinheader-1x8-d1.1-polygon-courtyard,a7d17d50-6a61-4911-8d50-e61ec5d2e0aa
+pkg-pinheader-1x8-d1.1-polygon-outline,afc9ae23-72c1-4136-b369-d2982c8e0520
 pkg-pinheader-1x8-d1.1-text-name,012efafd-656b-4ebc-bee1-3b2925e322ca
 pkg-pinheader-1x8-d1.1-text-value,0bbf8419-7f39-4992-ada7-feeefd644046
 pkg-pinheader-1x9-d0.9-3d,0604ba92-9735-4528-a42f-f6aaba4daeee
@@ -9990,6 +10224,8 @@ pkg-pinheader-1x9-d0.9-pad-7,e6220e6a-9d6b-4869-8f9c-5f26ec05ec93
 pkg-pinheader-1x9-d0.9-pad-8,dbd6f8b8-be6f-46f1-8a7e-3bd2b8eca473
 pkg-pinheader-1x9-d0.9-pkg,64653a7d-11ac-4952-b361-3d94d633a74e
 pkg-pinheader-1x9-d0.9-polygon-contour,073cc1e7-d1d3-4939-9850-95c5a20d6131
+pkg-pinheader-1x9-d0.9-polygon-courtyard,dc665b8f-5699-40f8-8282-4830c9981a4a
+pkg-pinheader-1x9-d0.9-polygon-outline,666667ae-9956-42b2-a8d8-3d5410b18493
 pkg-pinheader-1x9-d0.9-text-name,419d3f64-e923-47ef-8876-d4ca1d5587a8
 pkg-pinheader-1x9-d0.9-text-value,fa7362f8-2ed6-4014-a4b0-f642e42d5823
 pkg-pinheader-1x9-d1.0-3d,2685540b-da87-4d35-a3e2-6253b560b259
@@ -10005,6 +10241,8 @@ pkg-pinheader-1x9-d1.0-pad-7,1bc4c2d6-2389-4e89-87e8-7e8a79b4969d
 pkg-pinheader-1x9-d1.0-pad-8,a856fb8c-d6b7-4a4e-8ce2-96a0a61208cc
 pkg-pinheader-1x9-d1.0-pkg,b71a418e-d597-4bd0-a20b-fe7ebc084746
 pkg-pinheader-1x9-d1.0-polygon-contour,a47a2768-e037-4732-b7a9-fd4c679cd290
+pkg-pinheader-1x9-d1.0-polygon-courtyard,531e9c35-38da-424a-998f-08e53595bed0
+pkg-pinheader-1x9-d1.0-polygon-outline,af5401a0-43da-40ad-84a0-197c8b9daf01
 pkg-pinheader-1x9-d1.0-text-name,fe2e7c4a-ceb2-4d2f-a758-620d25dbdcbc
 pkg-pinheader-1x9-d1.0-text-value,28554e18-9caa-47a7-b29d-9652a1611984
 pkg-pinheader-1x9-d1.1-3d,a0d08a56-0a21-4e83-af39-04a7d6c18e16
@@ -10020,6 +10258,8 @@ pkg-pinheader-1x9-d1.1-pad-7,1fd42ea4-62ad-43d5-a0d5-398511ad7f6a
 pkg-pinheader-1x9-d1.1-pad-8,8b3b8643-3111-48e4-907d-88416be77a5b
 pkg-pinheader-1x9-d1.1-pkg,a715e03b-9277-4ca9-aeeb-a41f800b5a52
 pkg-pinheader-1x9-d1.1-polygon-contour,604969c9-e037-4424-ba2e-c5f87fdad23f
+pkg-pinheader-1x9-d1.1-polygon-courtyard,11f7453d-808f-4b15-9692-c06c821b9bb3
+pkg-pinheader-1x9-d1.1-polygon-outline,03e6f3a1-c752-48cb-bbdd-ad7e5649ddbc
 pkg-pinheader-1x9-d1.1-text-name,610ed4a9-c263-401c-8b9b-f883bbd39dbf
 pkg-pinheader-1x9-d1.1-text-value,19f60fd2-e6b3-4e36-9b63-daa193bb2bce
 pkg-pinheader-2x10-d0.9-3d,1b8f7548-c465-4535-86fd-1db21b36e2c6
@@ -10046,6 +10286,8 @@ pkg-pinheader-2x10-d0.9-pad-8,275a03cc-0beb-4fa2-a9ff-c8f1a5d7a1eb
 pkg-pinheader-2x10-d0.9-pad-9,b25aeee5-5231-411e-a996-0105dfdc6f08
 pkg-pinheader-2x10-d0.9-pkg,1ad89aca-a7ef-4fd4-8d3f-0dede438481b
 pkg-pinheader-2x10-d0.9-polygon-contour,f0a4bba0-f1f5-49a7-8a08-da7647712c14
+pkg-pinheader-2x10-d0.9-polygon-courtyard,4a341ba9-cd10-4b0c-86ff-7c8f8d737452
+pkg-pinheader-2x10-d0.9-polygon-outline,7acf8d0b-bef2-47a5-a008-ecead1cef7ac
 pkg-pinheader-2x10-d0.9-text-name,3734b9a2-76b4-434c-813b-807687b39eea
 pkg-pinheader-2x10-d0.9-text-value,d6416ba7-c0de-468a-9c68-4a6639bd7f59
 pkg-pinheader-2x10-d1.0-3d,ca15061f-ee22-4dd7-916f-5c70c46400e6
@@ -10072,6 +10314,8 @@ pkg-pinheader-2x10-d1.0-pad-8,7350a480-49ec-48a0-b7f7-71d25edcca9f
 pkg-pinheader-2x10-d1.0-pad-9,b4e8903b-b52d-44d1-95e7-7be825d86f40
 pkg-pinheader-2x10-d1.0-pkg,3527f491-ea5f-473f-9037-19e291445b82
 pkg-pinheader-2x10-d1.0-polygon-contour,7ec9571e-bdd1-4301-84b9-89b684b9a4e6
+pkg-pinheader-2x10-d1.0-polygon-courtyard,f383a735-1405-4e23-b59e-5b770daff767
+pkg-pinheader-2x10-d1.0-polygon-outline,ab479858-377b-45a5-8c34-4185974c97d3
 pkg-pinheader-2x10-d1.0-text-name,9c757055-5d47-4822-8d9e-0e27a5b6baa9
 pkg-pinheader-2x10-d1.0-text-value,b0911e47-8b3f-4036-8f81-1f5c8c83488f
 pkg-pinheader-2x10-d1.1-3d,6607b475-a613-4e3d-a1dc-9000e1899b33
@@ -10098,6 +10342,8 @@ pkg-pinheader-2x10-d1.1-pad-8,1e6eec5f-597c-4659-8f67-131a3e9c07a6
 pkg-pinheader-2x10-d1.1-pad-9,cdd3a400-d680-4425-8eb0-1f08ea32f418
 pkg-pinheader-2x10-d1.1-pkg,939298f6-9702-4837-99cb-46f6c3b223ca
 pkg-pinheader-2x10-d1.1-polygon-contour,5dbe3ce3-754c-40a4-932f-8045b03b40cf
+pkg-pinheader-2x10-d1.1-polygon-courtyard,dff0ed7a-b81f-4642-a4e2-c9d79805f283
+pkg-pinheader-2x10-d1.1-polygon-outline,c4f1ea5e-9cdd-45a7-8d0f-8d5b343d7a4e
 pkg-pinheader-2x10-d1.1-text-name,7bf29bf5-3034-4f02-b51b-f4a541b3a683
 pkg-pinheader-2x10-d1.1-text-value,5a37bd49-3e3c-495e-8619-0ca823abb505
 pkg-pinheader-2x11-d0.9-3d,e11effa8-fc9f-4e52-a326-de3ff381d83b
@@ -10126,6 +10372,8 @@ pkg-pinheader-2x11-d0.9-pad-8,7b0792c3-0e2f-401e-9586-23dd693f2757
 pkg-pinheader-2x11-d0.9-pad-9,fe3868ad-38eb-454e-a6ae-d9e52d8f2b6e
 pkg-pinheader-2x11-d0.9-pkg,7523ab06-fff0-4498-8546-56e9bbdb163a
 pkg-pinheader-2x11-d0.9-polygon-contour,3208bd58-da36-41fd-a2e3-fed7eb41cea0
+pkg-pinheader-2x11-d0.9-polygon-courtyard,1b461e54-8a83-4c5d-9d5a-9cab5efa5306
+pkg-pinheader-2x11-d0.9-polygon-outline,8b3d15be-9dbf-424c-9f49-d496ee2def1d
 pkg-pinheader-2x11-d0.9-text-name,307725bb-42e9-4fd0-810f-c5cf26df52f2
 pkg-pinheader-2x11-d0.9-text-value,39696370-cb80-4741-b4fd-ea8e1fba53a0
 pkg-pinheader-2x11-d1.0-3d,ea2ca506-63ee-4508-b034-71bea943243a
@@ -10154,6 +10402,8 @@ pkg-pinheader-2x11-d1.0-pad-8,0dfa514a-780e-4869-81ad-32becc5c3381
 pkg-pinheader-2x11-d1.0-pad-9,6e00294e-9969-465f-b6de-0d3ae91c571f
 pkg-pinheader-2x11-d1.0-pkg,5a12aeee-2082-45a4-ad0e-c55de4de925f
 pkg-pinheader-2x11-d1.0-polygon-contour,5c5bee11-ef85-4293-ad7a-d4148e1d3aa7
+pkg-pinheader-2x11-d1.0-polygon-courtyard,b52b038f-dbaa-4ac1-8299-1b0022f906c7
+pkg-pinheader-2x11-d1.0-polygon-outline,dc6a1637-cb5a-4e61-9b2b-1f98c5011c39
 pkg-pinheader-2x11-d1.0-text-name,7d37c12a-cdb9-472a-a06a-ac9c24f38da8
 pkg-pinheader-2x11-d1.0-text-value,0637eccf-c1af-4153-8e95-9bf127faa5bb
 pkg-pinheader-2x11-d1.1-3d,e31d5b08-3b62-4cc2-a29e-0b63e6e76496
@@ -10182,6 +10432,8 @@ pkg-pinheader-2x11-d1.1-pad-8,d3331305-9d04-4d45-8bd7-71352ad13809
 pkg-pinheader-2x11-d1.1-pad-9,76600f8b-d591-41a0-b621-0aebca30c70e
 pkg-pinheader-2x11-d1.1-pkg,503b3ca5-67eb-4507-afb4-483e59df09b0
 pkg-pinheader-2x11-d1.1-polygon-contour,db6c2fd4-186c-4e30-9684-7e4267250b5e
+pkg-pinheader-2x11-d1.1-polygon-courtyard,393f814d-28d5-4e48-af73-6d5df1457814
+pkg-pinheader-2x11-d1.1-polygon-outline,e28c1a83-e4e7-41cf-bc91-43e69b87bd24
 pkg-pinheader-2x11-d1.1-text-name,6ce088ab-3607-45ce-b1ac-206c183254dc
 pkg-pinheader-2x11-d1.1-text-value,c3007824-956c-4e8a-8797-452505851e74
 pkg-pinheader-2x12-d0.9-3d,1f450999-35c7-49fc-b8b2-42fb4e4ca4da
@@ -10212,6 +10464,8 @@ pkg-pinheader-2x12-d0.9-pad-8,a868bad4-9035-47e6-b82d-c30dc1726776
 pkg-pinheader-2x12-d0.9-pad-9,14325df8-78ae-45da-a743-f07142282b99
 pkg-pinheader-2x12-d0.9-pkg,e24e84c0-068d-4363-b573-19fc698687a0
 pkg-pinheader-2x12-d0.9-polygon-contour,86523c10-e5b2-45cc-8437-1215d6945c03
+pkg-pinheader-2x12-d0.9-polygon-courtyard,5c7bf5ff-e4fb-4afd-b9de-ba3f0fe2f17d
+pkg-pinheader-2x12-d0.9-polygon-outline,9b525ada-6cd2-47d3-a0d8-5d393d9ea55b
 pkg-pinheader-2x12-d0.9-text-name,26992bad-c5c8-463a-b018-47e26fec093a
 pkg-pinheader-2x12-d0.9-text-value,4cf4a07a-8dc8-49df-93c1-0378e8588245
 pkg-pinheader-2x12-d1.0-3d,82ba1f0a-e8b3-433b-9ab7-4dbd56d20d66
@@ -10242,6 +10496,8 @@ pkg-pinheader-2x12-d1.0-pad-8,4ce14885-caa6-4baf-bad4-80352fa15341
 pkg-pinheader-2x12-d1.0-pad-9,6042dd4d-fbb7-4657-8043-9e5031b9e246
 pkg-pinheader-2x12-d1.0-pkg,ffc7f4e4-83fe-4d9a-8779-2878ae440431
 pkg-pinheader-2x12-d1.0-polygon-contour,7bc823e2-dd94-4369-86dd-48b2582b34e8
+pkg-pinheader-2x12-d1.0-polygon-courtyard,3e8cbc33-7f39-40c0-85b7-5cfd29c003a2
+pkg-pinheader-2x12-d1.0-polygon-outline,ca28e7e8-41b5-40af-ba8f-56789781e092
 pkg-pinheader-2x12-d1.0-text-name,69525d2a-6ab9-4d60-85b8-b3b05c5eb199
 pkg-pinheader-2x12-d1.0-text-value,b24b4206-b1ed-4d37-a32e-5a8c12587b67
 pkg-pinheader-2x12-d1.1-3d,abcb6848-2431-4480-946b-7dbec1f89b57
@@ -10272,6 +10528,8 @@ pkg-pinheader-2x12-d1.1-pad-8,9e7aa35d-b56a-40eb-a032-57220379e207
 pkg-pinheader-2x12-d1.1-pad-9,deb7cb87-bd7c-4c6a-9d9a-a2e2027d4e39
 pkg-pinheader-2x12-d1.1-pkg,2e7c9747-952d-4858-bb9f-96a7675423e9
 pkg-pinheader-2x12-d1.1-polygon-contour,d7d735b1-be2e-4597-a9f2-d7f4258d561b
+pkg-pinheader-2x12-d1.1-polygon-courtyard,635715a0-4498-4d26-8665-0a595f21ba7a
+pkg-pinheader-2x12-d1.1-polygon-outline,ad1b6847-963e-4293-ae72-921ed48f72f1
 pkg-pinheader-2x12-d1.1-text-name,3d23beb2-0f39-48df-85b2-525914795df0
 pkg-pinheader-2x12-d1.1-text-value,a2df5580-5045-4a32-9a38-d891faf21020
 pkg-pinheader-2x13-d0.9-3d,a2108841-92bc-4d4f-bda1-6b2b2f85550e
@@ -10304,6 +10562,8 @@ pkg-pinheader-2x13-d0.9-pad-8,ca6ba1c6-ca71-4f03-b5bc-b3ab96a2c088
 pkg-pinheader-2x13-d0.9-pad-9,6f2e74a2-7a81-4067-8faa-a09073efa4dc
 pkg-pinheader-2x13-d0.9-pkg,9d6598a3-ca2e-4ba2-8201-71184e1aaeaa
 pkg-pinheader-2x13-d0.9-polygon-contour,68517cc6-cc82-4f33-80fd-9be94c6336ea
+pkg-pinheader-2x13-d0.9-polygon-courtyard,24e8e549-e154-4ba7-88b2-2f398d7bad8b
+pkg-pinheader-2x13-d0.9-polygon-outline,4710e5fb-ec08-4cca-b48b-c24c5964c906
 pkg-pinheader-2x13-d0.9-text-name,a2712281-db20-4a92-8a9c-807225f61cba
 pkg-pinheader-2x13-d0.9-text-value,1dff29e3-142b-4afd-825c-8cbe912dffc3
 pkg-pinheader-2x13-d1.0-3d,886fc8f9-2e9d-4873-8687-f32919347712
@@ -10336,6 +10596,8 @@ pkg-pinheader-2x13-d1.0-pad-8,3c04afcf-ce76-4b08-a919-6cf7fa014d8c
 pkg-pinheader-2x13-d1.0-pad-9,cbc162d3-e1c1-4150-9a9d-1389d44c2789
 pkg-pinheader-2x13-d1.0-pkg,4eccf87c-16fd-4313-b4f4-dc3f8d83ca53
 pkg-pinheader-2x13-d1.0-polygon-contour,1bb9e4a8-b01f-468a-9b07-ffe171f76fa5
+pkg-pinheader-2x13-d1.0-polygon-courtyard,fdd9c726-023f-4fda-a5f3-44145ee987ae
+pkg-pinheader-2x13-d1.0-polygon-outline,12853267-0f70-4e63-bc11-2a842f2c2f38
 pkg-pinheader-2x13-d1.0-text-name,1a61bb38-8d81-4da0-9ba5-3ca5756eaea3
 pkg-pinheader-2x13-d1.0-text-value,d5831014-af1d-44b6-afba-637a0eb3049a
 pkg-pinheader-2x13-d1.1-3d,9a3288a5-b07e-4f0f-a32c-6964bf059371
@@ -10368,6 +10630,8 @@ pkg-pinheader-2x13-d1.1-pad-8,ad2b2890-cf3b-4e5d-85b1-ab1740dda350
 pkg-pinheader-2x13-d1.1-pad-9,b3f0b74a-188e-45f9-b62a-24655716d88b
 pkg-pinheader-2x13-d1.1-pkg,718a7169-90d1-4219-a026-6fe1c0b11bfa
 pkg-pinheader-2x13-d1.1-polygon-contour,d2ce211a-5362-426c-847f-b50df600b08e
+pkg-pinheader-2x13-d1.1-polygon-courtyard,b57ada8d-afa7-41ba-850b-ea1272939c93
+pkg-pinheader-2x13-d1.1-polygon-outline,33065feb-9db9-4ab7-9303-4c77e27c176b
 pkg-pinheader-2x13-d1.1-text-name,786949e4-2ced-4316-9cae-e1542cb4e0d5
 pkg-pinheader-2x13-d1.1-text-value,4fe90299-0ab3-4e05-8de8-e6a0e4dc6945
 pkg-pinheader-2x14-d0.9-3d,cd5c1d39-05cf-4942-9375-8ce9f7f445d2
@@ -10402,6 +10666,8 @@ pkg-pinheader-2x14-d0.9-pad-8,33fa617d-8b8b-4145-b241-59486b68815c
 pkg-pinheader-2x14-d0.9-pad-9,8319fbcc-22f0-46f2-bfc0-4be296b382c0
 pkg-pinheader-2x14-d0.9-pkg,0ee4d584-57e1-40e1-8270-50de98ac38b0
 pkg-pinheader-2x14-d0.9-polygon-contour,5c5e3cfd-07ef-42f7-9db1-bddcef660176
+pkg-pinheader-2x14-d0.9-polygon-courtyard,b82fb479-8825-4520-be58-69500b0326f7
+pkg-pinheader-2x14-d0.9-polygon-outline,50d72281-531b-4c02-b93e-6631f1719bf5
 pkg-pinheader-2x14-d0.9-text-name,214fa2ae-fb8b-42be-b8b6-592ec4265f73
 pkg-pinheader-2x14-d0.9-text-value,e2dcd8f4-9800-427f-a767-d5838b6a4141
 pkg-pinheader-2x14-d1.0-3d,cb366257-eed1-4330-a4a1-4d289814c083
@@ -10436,6 +10702,8 @@ pkg-pinheader-2x14-d1.0-pad-8,74033f1e-0d4e-4e18-a293-b5e2d5bbb824
 pkg-pinheader-2x14-d1.0-pad-9,47431f1c-0f95-40b2-a1b8-8fdf6dce0d70
 pkg-pinheader-2x14-d1.0-pkg,f5ff3a5c-41d2-4999-b030-c14a8753fc30
 pkg-pinheader-2x14-d1.0-polygon-contour,0f5567e6-8d36-467a-b9ab-33b796552704
+pkg-pinheader-2x14-d1.0-polygon-courtyard,f92441ef-21d0-43f6-8d11-0f0e71fe15f4
+pkg-pinheader-2x14-d1.0-polygon-outline,edbc455f-a53d-455e-931b-7a0f6f313495
 pkg-pinheader-2x14-d1.0-text-name,4f399164-0dde-4692-8299-81739b3f007a
 pkg-pinheader-2x14-d1.0-text-value,856ec6ce-3d42-4c0c-b646-9c4e9cf4c137
 pkg-pinheader-2x14-d1.1-3d,6af98700-d7ca-4b65-b477-d630f1894958
@@ -10470,6 +10738,8 @@ pkg-pinheader-2x14-d1.1-pad-8,643573fb-467a-41a0-a7f9-5904a5ce19e1
 pkg-pinheader-2x14-d1.1-pad-9,bc94681c-961d-41bd-bf42-091c6cc31f18
 pkg-pinheader-2x14-d1.1-pkg,2ebc37ee-4210-454e-8443-96bdec36e5b5
 pkg-pinheader-2x14-d1.1-polygon-contour,20960d86-9d40-4c83-9fbb-28ff79ada433
+pkg-pinheader-2x14-d1.1-polygon-courtyard,0c37a4b4-dbde-4fe3-9e57-bbf283aef4fa
+pkg-pinheader-2x14-d1.1-polygon-outline,cacceb7e-eb08-4a0f-8804-7d09adf54dc2
 pkg-pinheader-2x14-d1.1-text-name,1b92a24e-09cc-4847-84cb-10481c661434
 pkg-pinheader-2x14-d1.1-text-value,5fda982a-458b-4f51-b3fa-351a9dfb9c3c
 pkg-pinheader-2x15-d0.9-3d,2437fe22-8bcc-47e6-84d9-eb61cbceed8a
@@ -10506,6 +10776,8 @@ pkg-pinheader-2x15-d0.9-pad-8,eb16f04c-75ba-460b-8c70-0621e02f32f9
 pkg-pinheader-2x15-d0.9-pad-9,f47a450c-1cd3-4410-8d66-933c4c2c2242
 pkg-pinheader-2x15-d0.9-pkg,00fefb8d-950d-4486-ad51-98b21350dbae
 pkg-pinheader-2x15-d0.9-polygon-contour,1a6cdf53-dd52-416b-9ccb-1000a7e487d5
+pkg-pinheader-2x15-d0.9-polygon-courtyard,ea9bc5ba-014a-4a93-bbf7-c36927cfe299
+pkg-pinheader-2x15-d0.9-polygon-outline,396e0e06-c8aa-4a2c-b066-e651958bc935
 pkg-pinheader-2x15-d0.9-text-name,be72252a-b08d-4861-bed0-5ec46accabae
 pkg-pinheader-2x15-d0.9-text-value,ae063140-fa55-4f84-8c97-3e5152df1d8c
 pkg-pinheader-2x15-d1.0-3d,fc89b2d5-38b8-452f-9d6d-94b90648c216
@@ -10542,6 +10814,8 @@ pkg-pinheader-2x15-d1.0-pad-8,6ef3a054-6531-4590-a79b-3de447c8bd3f
 pkg-pinheader-2x15-d1.0-pad-9,f04c199d-b73a-4360-bc83-4a4c2f6e1e7d
 pkg-pinheader-2x15-d1.0-pkg,af3513f8-99ad-439b-9d5e-d95b3c8a24a0
 pkg-pinheader-2x15-d1.0-polygon-contour,42d6599d-ad7b-4a12-a609-7fca34d36f9d
+pkg-pinheader-2x15-d1.0-polygon-courtyard,9003f970-7192-4445-ad60-e55d7db2af12
+pkg-pinheader-2x15-d1.0-polygon-outline,886ca9a4-f94a-4262-b355-15a93cddbe7e
 pkg-pinheader-2x15-d1.0-text-name,b4d354d0-5636-4f0d-9718-19e35332fde4
 pkg-pinheader-2x15-d1.0-text-value,30cbe48b-5003-47d4-b4f5-6a7a2349e2c2
 pkg-pinheader-2x15-d1.1-3d,fd6e52d9-be90-4126-a0f3-ac4b7dbc7715
@@ -10578,6 +10852,8 @@ pkg-pinheader-2x15-d1.1-pad-8,3339b8a8-41c3-4cf5-be9d-7244cdc0ed0f
 pkg-pinheader-2x15-d1.1-pad-9,d75012b0-47c0-4022-aa7a-9f7e96c4ef9f
 pkg-pinheader-2x15-d1.1-pkg,54493cb6-c940-4acb-beee-ab5330b065ee
 pkg-pinheader-2x15-d1.1-polygon-contour,47845707-5406-4883-ac11-d1a742da1a2c
+pkg-pinheader-2x15-d1.1-polygon-courtyard,0377ed0c-a100-44c3-a7e6-33b9c0c8b989
+pkg-pinheader-2x15-d1.1-polygon-outline,3517caf3-3246-42c4-ae81-872bc5d8098c
 pkg-pinheader-2x15-d1.1-text-name,06867add-efe1-4922-be68-c09466e6dac4
 pkg-pinheader-2x15-d1.1-text-value,2d49018c-4a5f-4bbd-824e-be1b4392c90e
 pkg-pinheader-2x16-d0.9-3d,efbfc080-ddcf-4ac6-94a6-4ee820eecedf
@@ -10616,6 +10892,8 @@ pkg-pinheader-2x16-d0.9-pad-8,815c51b7-9ba3-4f65-a024-cd38b411846d
 pkg-pinheader-2x16-d0.9-pad-9,e5938c96-eb11-48c3-86c7-6d1d20035520
 pkg-pinheader-2x16-d0.9-pkg,11d27f26-e286-4bcf-83d8-20073d6067fa
 pkg-pinheader-2x16-d0.9-polygon-contour,f18f168d-b97a-4d36-9bb6-b1d8752411bf
+pkg-pinheader-2x16-d0.9-polygon-courtyard,ee0325f5-d962-4412-823f-e5d2dbd7a6ab
+pkg-pinheader-2x16-d0.9-polygon-outline,bd7deda6-8ca0-4e3a-b147-486e20834170
 pkg-pinheader-2x16-d0.9-text-name,17c31302-1b4e-4a22-a4b8-1a6ef03f6b45
 pkg-pinheader-2x16-d0.9-text-value,572c5f21-495a-451b-85de-6476fc3fc8ee
 pkg-pinheader-2x16-d1.0-3d,f2120095-1bdb-41a9-b361-516f1be23d20
@@ -10654,6 +10932,8 @@ pkg-pinheader-2x16-d1.0-pad-8,4ac3e1da-17dc-4c18-9809-f370addacbaf
 pkg-pinheader-2x16-d1.0-pad-9,de5b513c-4c7b-4f1b-a9f9-7517c79ca873
 pkg-pinheader-2x16-d1.0-pkg,6d03bef6-7a3b-414d-badf-73f7072a5859
 pkg-pinheader-2x16-d1.0-polygon-contour,402647cc-6985-41ee-9bbb-9ccb5ccc3513
+pkg-pinheader-2x16-d1.0-polygon-courtyard,c8ee6e5f-b980-499d-a145-eb272015e78b
+pkg-pinheader-2x16-d1.0-polygon-outline,e60b575e-bc14-492e-bc8f-92d7f92fdf2d
 pkg-pinheader-2x16-d1.0-text-name,aabc9cef-6e72-4983-bd0a-32ce1127f3b6
 pkg-pinheader-2x16-d1.0-text-value,56aafb28-d14a-480d-a001-65930844997d
 pkg-pinheader-2x16-d1.1-3d,e6d4ddb9-9973-488d-988f-caf0ddd252dd
@@ -10692,6 +10972,8 @@ pkg-pinheader-2x16-d1.1-pad-8,30e7d13f-4a1b-4a78-81f3-e99c03c64785
 pkg-pinheader-2x16-d1.1-pad-9,5f82aac8-9638-40aa-99af-62e9de61169d
 pkg-pinheader-2x16-d1.1-pkg,85160369-1f1f-446c-90a4-b0c5c7bcc321
 pkg-pinheader-2x16-d1.1-polygon-contour,2279f438-2320-479e-9346-a20ebe6c1ff8
+pkg-pinheader-2x16-d1.1-polygon-courtyard,4d2f87c7-5def-49c3-9d7b-13993732e8ab
+pkg-pinheader-2x16-d1.1-polygon-outline,0547fe01-16c2-4122-96dd-1bbb56c66cde
 pkg-pinheader-2x16-d1.1-text-name,62e21d20-8da5-4c30-bd0c-581112d3302b
 pkg-pinheader-2x16-d1.1-text-value,bff719d7-5c93-4119-a05b-7c3fb1bdc25c
 pkg-pinheader-2x17-d0.9-3d,cb936863-a43c-43a0-a1d6-d3266261f3a2
@@ -10732,6 +11014,8 @@ pkg-pinheader-2x17-d0.9-pad-8,b7496e82-19f4-4801-8402-0d9ae0ffd2a8
 pkg-pinheader-2x17-d0.9-pad-9,14e01dae-80ef-4cf7-af4e-0a7d8f459024
 pkg-pinheader-2x17-d0.9-pkg,028c8e84-1117-4de7-948d-0d75621c27a9
 pkg-pinheader-2x17-d0.9-polygon-contour,92dc74e1-4438-4950-8d98-c15e41dcb9c0
+pkg-pinheader-2x17-d0.9-polygon-courtyard,e376a703-65b3-478b-b26e-7e91521e2889
+pkg-pinheader-2x17-d0.9-polygon-outline,70790ba9-0dc6-44d0-9cb3-e484cbdb9431
 pkg-pinheader-2x17-d0.9-text-name,ad8a89ca-6068-4eaf-bac5-a67934ccc636
 pkg-pinheader-2x17-d0.9-text-value,02dfe60e-8adf-410a-b904-3d4024491611
 pkg-pinheader-2x17-d1.0-3d,86dd5bd3-21fc-4bab-b4d7-8559a87b5507
@@ -10772,6 +11056,8 @@ pkg-pinheader-2x17-d1.0-pad-8,15726031-3ddf-4a2c-9459-a3d55baf0e51
 pkg-pinheader-2x17-d1.0-pad-9,ce2b0301-fc58-4f11-abb8-b9b6078726e2
 pkg-pinheader-2x17-d1.0-pkg,0d914b00-a265-4b9a-8562-001a24fe7882
 pkg-pinheader-2x17-d1.0-polygon-contour,1be29398-b79f-44b6-b196-ee1c07123b2d
+pkg-pinheader-2x17-d1.0-polygon-courtyard,2d39a58d-1958-4b30-8a1f-5688288e7cf0
+pkg-pinheader-2x17-d1.0-polygon-outline,24d15a51-3edd-4e39-b150-c83f604a23cb
 pkg-pinheader-2x17-d1.0-text-name,9562e067-fb42-4439-87c1-6e6bcdc32996
 pkg-pinheader-2x17-d1.0-text-value,13628b20-435a-4d45-839a-74a3d28df475
 pkg-pinheader-2x17-d1.1-3d,4e5f4473-1bad-4b58-bd4f-121aabb12bcd
@@ -10812,6 +11098,8 @@ pkg-pinheader-2x17-d1.1-pad-8,ffdca425-1ed8-4260-920c-baba0452b586
 pkg-pinheader-2x17-d1.1-pad-9,fb69e9ea-3ad3-404e-b991-6b26c94369aa
 pkg-pinheader-2x17-d1.1-pkg,38377a55-6f58-48af-ae4c-59477b54323f
 pkg-pinheader-2x17-d1.1-polygon-contour,1dcfb9c9-07a2-425e-9db9-b2f82b954470
+pkg-pinheader-2x17-d1.1-polygon-courtyard,26c99a99-d7c1-49fe-b183-91dfb4bf7745
+pkg-pinheader-2x17-d1.1-polygon-outline,3cafa82e-1233-46a7-8aab-19c6544bdfa2
 pkg-pinheader-2x17-d1.1-text-name,48d117ad-ed70-4d46-a4e5-38225d60fdba
 pkg-pinheader-2x17-d1.1-text-value,400cdb12-a15b-4a80-bef8-e41fb7d73504
 pkg-pinheader-2x18-d0.9-3d,16319dc6-5857-44de-a85b-04812c5df0e1
@@ -10854,6 +11142,8 @@ pkg-pinheader-2x18-d0.9-pad-8,3b292bff-e521-4f67-9ed8-2fe94ef3dd23
 pkg-pinheader-2x18-d0.9-pad-9,47fdf388-44f3-4124-b75a-783e72881bec
 pkg-pinheader-2x18-d0.9-pkg,d6815b84-941d-4b7d-a0e0-324694c469a9
 pkg-pinheader-2x18-d0.9-polygon-contour,88872ae5-1a47-4a76-bf2b-a80abda3cb45
+pkg-pinheader-2x18-d0.9-polygon-courtyard,9b3c2683-f47d-4034-9289-73c43b83079c
+pkg-pinheader-2x18-d0.9-polygon-outline,0afee0b7-9fc5-4e8c-b10b-fb9489da1a03
 pkg-pinheader-2x18-d0.9-text-name,10719ebd-4234-4c5c-8a93-5de614fd21a9
 pkg-pinheader-2x18-d0.9-text-value,f4747624-b030-4d27-8a6c-b229a527a7cb
 pkg-pinheader-2x18-d1.0-3d,0316427a-f34c-410b-bb15-5d11cc11337d
@@ -10896,6 +11186,8 @@ pkg-pinheader-2x18-d1.0-pad-8,dd59e5db-d82c-4d19-b9f3-13c658e57150
 pkg-pinheader-2x18-d1.0-pad-9,0b2796eb-0551-4aff-b700-a8d04e6cfb00
 pkg-pinheader-2x18-d1.0-pkg,b5cf42b5-364e-436d-b960-95a57929eb94
 pkg-pinheader-2x18-d1.0-polygon-contour,9e279c16-afa1-4348-8469-cec4b721200c
+pkg-pinheader-2x18-d1.0-polygon-courtyard,fd35e239-6e01-4b17-8524-d6dff05329d4
+pkg-pinheader-2x18-d1.0-polygon-outline,e77da851-ebf2-4af9-a2bb-291f7602faa5
 pkg-pinheader-2x18-d1.0-text-name,7b1c9c38-6b9e-4ea9-90a1-7cc20d2eef9e
 pkg-pinheader-2x18-d1.0-text-value,d1e932a3-c03e-4e79-b16f-16706f2762ac
 pkg-pinheader-2x18-d1.1-3d,c0ac6697-d537-45bc-a019-cf0908d18c20
@@ -10938,6 +11230,8 @@ pkg-pinheader-2x18-d1.1-pad-8,81e21443-a210-4299-a4f8-fa2c65199142
 pkg-pinheader-2x18-d1.1-pad-9,4c55c268-9c7e-408f-a63e-c55ea3e7cb2e
 pkg-pinheader-2x18-d1.1-pkg,6642924e-c240-4cf1-be79-f065b0dc82fd
 pkg-pinheader-2x18-d1.1-polygon-contour,a85272c0-9718-40c5-91fb-3892f7a76380
+pkg-pinheader-2x18-d1.1-polygon-courtyard,cd221e13-972e-4dd4-9cdf-89643d1f5df7
+pkg-pinheader-2x18-d1.1-polygon-outline,89262609-4bb4-4eaf-b73d-7b75a04a235f
 pkg-pinheader-2x18-d1.1-text-name,c18c92aa-176d-43fb-a240-197dc091e908
 pkg-pinheader-2x18-d1.1-text-value,b79e5303-686e-4857-91a0-81e314173691
 pkg-pinheader-2x19-d0.9-3d,b427624d-cf39-4fb4-842e-99c4eb7b5082
@@ -10982,6 +11276,8 @@ pkg-pinheader-2x19-d0.9-pad-8,6d8705b2-49da-4a70-a303-12812070f0d4
 pkg-pinheader-2x19-d0.9-pad-9,7d0b0bd8-ee46-4e89-8e6a-550177751436
 pkg-pinheader-2x19-d0.9-pkg,bde3a7c1-fe8c-4687-a132-68eacdf09da5
 pkg-pinheader-2x19-d0.9-polygon-contour,372d5663-efd8-48f6-8c41-6992c961f1fd
+pkg-pinheader-2x19-d0.9-polygon-courtyard,dfecc706-c32e-45f8-9ad6-9f5d6ccf260a
+pkg-pinheader-2x19-d0.9-polygon-outline,da011605-4adb-4adc-b441-b7f47bd3c7d4
 pkg-pinheader-2x19-d0.9-text-name,b579b46e-cbd4-42da-b337-fb83af1a9e24
 pkg-pinheader-2x19-d0.9-text-value,f9ebe868-69f9-49df-92ae-9fda29f6c456
 pkg-pinheader-2x19-d1.0-3d,50e44c96-5d07-4d19-babf-fdf1a887965a
@@ -11026,6 +11322,8 @@ pkg-pinheader-2x19-d1.0-pad-8,98d5d681-429e-4677-b1cd-4c19b8ddd3b9
 pkg-pinheader-2x19-d1.0-pad-9,9e505c3d-2283-49b8-b4dc-32329467555a
 pkg-pinheader-2x19-d1.0-pkg,0a939517-92b4-4a97-86fe-0abd5216c160
 pkg-pinheader-2x19-d1.0-polygon-contour,0bca8f5e-ce0e-46db-a8f5-dacbab830e20
+pkg-pinheader-2x19-d1.0-polygon-courtyard,3686cf5e-edef-4337-932c-a95366cc21bb
+pkg-pinheader-2x19-d1.0-polygon-outline,f1a9e729-2815-4da9-87f5-aa652cc1db76
 pkg-pinheader-2x19-d1.0-text-name,0aa06adf-d7b0-4f89-ad45-0d5348481aa9
 pkg-pinheader-2x19-d1.0-text-value,707735bf-3d8e-4b26-baa6-1c2644ac93e0
 pkg-pinheader-2x19-d1.1-3d,bd9ce08d-328d-4125-b463-b0de2ac90be7
@@ -11070,6 +11368,8 @@ pkg-pinheader-2x19-d1.1-pad-8,594fb5ca-21e0-477c-a8e2-cac8d7573985
 pkg-pinheader-2x19-d1.1-pad-9,cfcb3de8-da46-40ae-8b44-164604677551
 pkg-pinheader-2x19-d1.1-pkg,363b447d-1bae-4f68-96df-1239362a1749
 pkg-pinheader-2x19-d1.1-polygon-contour,1399999d-3e51-477f-a5b9-c6fd094e31c2
+pkg-pinheader-2x19-d1.1-polygon-courtyard,c24c4b11-af15-4d98-b119-4ca272195692
+pkg-pinheader-2x19-d1.1-polygon-outline,fc8e1f4e-2bf1-49a1-8215-2e7caa0616a0
 pkg-pinheader-2x19-d1.1-text-name,c7e56d64-4795-45a3-b0d8-84f8cf80c653
 pkg-pinheader-2x19-d1.1-text-value,011e14d7-84d0-45b7-8113-0f28dbc56028
 pkg-pinheader-2x2-d0.9-3d,876056b7-f951-4eb9-a494-fd063f5d3463
@@ -11080,6 +11380,8 @@ pkg-pinheader-2x2-d0.9-pad-2,0090b843-5d31-46d1-ac8f-f0db3bc265ee
 pkg-pinheader-2x2-d0.9-pad-3,3c3ac43b-9b50-41a5-9506-c04d279da2ec
 pkg-pinheader-2x2-d0.9-pkg,eb753b94-695d-4760-a649-f9c03d5cfb5f
 pkg-pinheader-2x2-d0.9-polygon-contour,47ad0de3-3530-42df-8130-ec0324e462ea
+pkg-pinheader-2x2-d0.9-polygon-courtyard,bf30f50f-adef-43a0-8703-c2537da607b0
+pkg-pinheader-2x2-d0.9-polygon-outline,392f7875-71ea-4cab-83d7-38dcb08c237f
 pkg-pinheader-2x2-d0.9-text-name,edfbb45f-01f9-470c-9612-1a0ad232a3c4
 pkg-pinheader-2x2-d0.9-text-value,cc8585e3-bcc7-41c7-8bc5-408f084868f6
 pkg-pinheader-2x2-d1.0-3d,4744852b-956b-43c1-8de9-d10f8b4fc904
@@ -11090,6 +11392,8 @@ pkg-pinheader-2x2-d1.0-pad-2,57f27e43-dd82-4aa5-9793-7591bb3cde83
 pkg-pinheader-2x2-d1.0-pad-3,e8f86a45-3422-4a42-93dc-e25a8ed6a066
 pkg-pinheader-2x2-d1.0-pkg,ae2c62d9-0352-411c-beb9-2efdaa5f72f3
 pkg-pinheader-2x2-d1.0-polygon-contour,044a2be1-ef3f-4f35-bfb6-cdb723375187
+pkg-pinheader-2x2-d1.0-polygon-courtyard,83f1bea8-c434-4fb2-8618-a2aeb40a5362
+pkg-pinheader-2x2-d1.0-polygon-outline,a033937e-fe56-420e-a0a7-926575fe8b29
 pkg-pinheader-2x2-d1.0-text-name,e9f815dc-00fb-4066-b54c-3603a3ffdb08
 pkg-pinheader-2x2-d1.0-text-value,e8e69b7e-f30c-401f-9edc-237c829320a9
 pkg-pinheader-2x2-d1.1-3d,54a5d935-0306-46e4-b3d4-e1b3500db108
@@ -11100,6 +11404,8 @@ pkg-pinheader-2x2-d1.1-pad-2,bba302c8-9315-4b9c-8549-6a9c8fb3362f
 pkg-pinheader-2x2-d1.1-pad-3,58b3275f-32d2-48db-8f54-1bd87ba763eb
 pkg-pinheader-2x2-d1.1-pkg,15f973ca-efdf-4892-9478-e4ac7086d63c
 pkg-pinheader-2x2-d1.1-polygon-contour,fd1a855d-a812-4c84-be6e-e27c33dd0510
+pkg-pinheader-2x2-d1.1-polygon-courtyard,e32417e4-b533-4560-a2ec-6791cb3f612d
+pkg-pinheader-2x2-d1.1-polygon-outline,6b6f5eb2-d4dc-41ea-8add-f7ec2cfe2c31
 pkg-pinheader-2x2-d1.1-text-name,d79a6920-c48e-4c77-928f-64f8e89e27d4
 pkg-pinheader-2x2-d1.1-text-value,f10da608-5aa0-4710-aa00-63a52fa306be
 pkg-pinheader-2x20-d0.9-3d,b8dba779-0e50-4062-ac5d-f2be4c0731a0
@@ -11146,6 +11452,8 @@ pkg-pinheader-2x20-d0.9-pad-8,1d89884c-21a6-44f4-953e-8604159f9bf7
 pkg-pinheader-2x20-d0.9-pad-9,441b50a6-7a5f-4587-b122-e914b6c10330
 pkg-pinheader-2x20-d0.9-pkg,2506de6c-371b-40be-8424-d32ca9ed493f
 pkg-pinheader-2x20-d0.9-polygon-contour,033cccd3-0ba6-4ebe-a797-6813ec7cb4e8
+pkg-pinheader-2x20-d0.9-polygon-courtyard,2c64b69c-af60-45fa-8dc5-c581d1cba4bf
+pkg-pinheader-2x20-d0.9-polygon-outline,7d0964f5-68e1-4557-a31d-0ba3517d906a
 pkg-pinheader-2x20-d0.9-text-name,cbc3e63c-f2f4-4b35-91a7-b3b1ad8113ae
 pkg-pinheader-2x20-d0.9-text-value,81af9a11-7f67-4e94-853d-a73d81ca29f6
 pkg-pinheader-2x20-d1.0-3d,a7fdeea1-0ac5-4aca-acf4-21169d5acbbd
@@ -11192,6 +11500,8 @@ pkg-pinheader-2x20-d1.0-pad-8,cdac10b0-1318-45f6-b1c5-976a7675d447
 pkg-pinheader-2x20-d1.0-pad-9,b164931a-433a-40b8-b822-acc91112d1c6
 pkg-pinheader-2x20-d1.0-pkg,0e7f9139-750d-4d15-baf9-01889abade42
 pkg-pinheader-2x20-d1.0-polygon-contour,7ffcdb01-07e1-47cf-82f3-96dc4aa7add3
+pkg-pinheader-2x20-d1.0-polygon-courtyard,1068d298-c744-4284-ad98-f8fb06b01a77
+pkg-pinheader-2x20-d1.0-polygon-outline,5442c42d-4d74-4fd3-aaf0-ac26b09dfa27
 pkg-pinheader-2x20-d1.0-text-name,e2dff824-3ae3-4560-9f9e-9781795c14b6
 pkg-pinheader-2x20-d1.0-text-value,d2f97bb4-21c8-471d-8979-cc3e1b40f5b0
 pkg-pinheader-2x20-d1.1-3d,8bc610cf-a75f-4047-ab0c-a32586944c1d
@@ -11238,6 +11548,8 @@ pkg-pinheader-2x20-d1.1-pad-8,00ac0ccb-1cf4-4ca2-b2e8-b9764f5eb843
 pkg-pinheader-2x20-d1.1-pad-9,fbfb51fb-d3f3-464f-8a54-23629b3da804
 pkg-pinheader-2x20-d1.1-pkg,8568889d-b7b1-489e-91e1-9c109328637d
 pkg-pinheader-2x20-d1.1-polygon-contour,5730c607-b94f-4043-9d76-1de7d10779af
+pkg-pinheader-2x20-d1.1-polygon-courtyard,1e1b30b7-a6ad-4fad-b513-7b3f116aea81
+pkg-pinheader-2x20-d1.1-polygon-outline,840259ae-26dc-44d3-aa18-2e8a4cd569cf
 pkg-pinheader-2x20-d1.1-text-name,16401f80-1a0f-4989-812c-99bd027d9701
 pkg-pinheader-2x20-d1.1-text-value,0a60ddcf-0da1-40fa-baa5-a180072181d5
 pkg-pinheader-2x21-d0.9-3d,21a90013-cebf-4dd7-8838-a06a6a0ddb5f
@@ -11286,6 +11598,8 @@ pkg-pinheader-2x21-d0.9-pad-8,d3efa56b-0c9b-4c1f-8884-fcc4b39f2df4
 pkg-pinheader-2x21-d0.9-pad-9,aeb8a8bd-ade3-49de-90da-e115ebd62bd8
 pkg-pinheader-2x21-d0.9-pkg,965ff2c0-2f95-4593-a7ee-eafbf0b5378c
 pkg-pinheader-2x21-d0.9-polygon-contour,a0ffdc9e-c0d4-4906-9c2f-df2702e3677a
+pkg-pinheader-2x21-d0.9-polygon-courtyard,6bb59b6c-4060-4512-8764-2f6d85a6f294
+pkg-pinheader-2x21-d0.9-polygon-outline,e7fb59c7-b230-41aa-8b78-e8718859b44c
 pkg-pinheader-2x21-d0.9-text-name,03160622-709d-43cf-811a-eb8aeb8c131e
 pkg-pinheader-2x21-d0.9-text-value,8501a2ee-4c56-46c1-bee6-131e34848cc3
 pkg-pinheader-2x21-d1.0-3d,c3241aa1-eb7d-4153-8766-42e885e4c88d
@@ -11334,6 +11648,8 @@ pkg-pinheader-2x21-d1.0-pad-8,0d5b795f-8cbe-4207-b0d8-cc06551ab85d
 pkg-pinheader-2x21-d1.0-pad-9,b9425dbc-eaa5-4467-a389-a1cc616b06d0
 pkg-pinheader-2x21-d1.0-pkg,73134daf-d278-47b4-bb1b-f1d325096198
 pkg-pinheader-2x21-d1.0-polygon-contour,8ea87630-b38f-4705-adc4-cbc88f07107f
+pkg-pinheader-2x21-d1.0-polygon-courtyard,1d1c33e8-b287-475a-bc20-4d5c1f6e1e32
+pkg-pinheader-2x21-d1.0-polygon-outline,ae5cc0d3-773e-4207-bbe7-e121f8f2c535
 pkg-pinheader-2x21-d1.0-text-name,8e16bef3-7b7a-42a1-81c9-49d2c9ed217d
 pkg-pinheader-2x21-d1.0-text-value,e0171aac-1839-413e-8eaf-b6f2be157331
 pkg-pinheader-2x21-d1.1-3d,60f77826-ada1-4109-ad52-286a167f897f
@@ -11382,6 +11698,8 @@ pkg-pinheader-2x21-d1.1-pad-8,64e5198d-0afc-47da-a66e-839ce01bb5de
 pkg-pinheader-2x21-d1.1-pad-9,fab3fcdc-ba99-41f8-93f8-e028c5aa986e
 pkg-pinheader-2x21-d1.1-pkg,fa7303c1-a1ef-4445-b492-b6832a5d8076
 pkg-pinheader-2x21-d1.1-polygon-contour,50054457-ba02-4e7f-bf84-fc2a6b25ac73
+pkg-pinheader-2x21-d1.1-polygon-courtyard,6904e738-e9d4-4fa4-86ce-0f0e8adf7a42
+pkg-pinheader-2x21-d1.1-polygon-outline,b95c853d-1fc2-4d15-a435-8df57fdfbdbc
 pkg-pinheader-2x21-d1.1-text-name,1286ab7c-1459-4f06-b70b-dd258f0c0939
 pkg-pinheader-2x21-d1.1-text-value,65bea526-5077-4d78-883d-6c730a0a4540
 pkg-pinheader-2x22-d0.9-3d,2231db0f-e5b1-4f94-8fb0-2eea559f8149
@@ -11432,6 +11750,8 @@ pkg-pinheader-2x22-d0.9-pad-8,0ec76db8-9e9d-40ab-8c7f-21dfafec8096
 pkg-pinheader-2x22-d0.9-pad-9,9ec376da-b096-43d5-8fa8-ba13322b8224
 pkg-pinheader-2x22-d0.9-pkg,de45437e-fa61-4050-96d0-b926e3302461
 pkg-pinheader-2x22-d0.9-polygon-contour,fd1a5d0e-ab13-4585-a75f-4ee4d498bc61
+pkg-pinheader-2x22-d0.9-polygon-courtyard,3f22cb71-c672-4d12-bb5b-a27fb4be92e1
+pkg-pinheader-2x22-d0.9-polygon-outline,094c96a1-1624-4baa-be1e-f2ffc74033cc
 pkg-pinheader-2x22-d0.9-text-name,afefa0ca-312c-4c2c-a044-d494282674a2
 pkg-pinheader-2x22-d0.9-text-value,0c5e1990-e74a-4c4a-b7e2-167d91f3cb58
 pkg-pinheader-2x22-d1.0-3d,1323e5d8-7d59-40b5-9593-8817ba568af8
@@ -11482,6 +11802,8 @@ pkg-pinheader-2x22-d1.0-pad-8,06c1b3fe-63fa-4a90-a82a-51c59c197bdc
 pkg-pinheader-2x22-d1.0-pad-9,ff3ff6f7-b011-495e-9258-e33177757719
 pkg-pinheader-2x22-d1.0-pkg,c89d659a-d158-4df4-96c6-9f0999e37e9b
 pkg-pinheader-2x22-d1.0-polygon-contour,f44acd82-c187-483c-8003-79a0e06664b4
+pkg-pinheader-2x22-d1.0-polygon-courtyard,e777a15b-b166-41fb-9b54-f589dd2d0b1b
+pkg-pinheader-2x22-d1.0-polygon-outline,2475d4d7-ddf9-4aa7-b69a-cb1edd531d95
 pkg-pinheader-2x22-d1.0-text-name,d4b666bb-64eb-4d5d-96d1-c345b70c5338
 pkg-pinheader-2x22-d1.0-text-value,74a97c5d-499c-461e-bae7-16008b041867
 pkg-pinheader-2x22-d1.1-3d,0fc3f7a5-ee34-49bb-91d3-cf07cb80120c
@@ -11532,6 +11854,8 @@ pkg-pinheader-2x22-d1.1-pad-8,1e3703e6-69a2-4cad-a3bb-5110892c5f12
 pkg-pinheader-2x22-d1.1-pad-9,ca241c07-8893-4646-b9c5-be2551ab5290
 pkg-pinheader-2x22-d1.1-pkg,061e2637-937e-472c-ba97-c6f900138386
 pkg-pinheader-2x22-d1.1-polygon-contour,4445d0ae-aeb0-4717-8aca-48eadcf9774b
+pkg-pinheader-2x22-d1.1-polygon-courtyard,4a9faabd-7c14-47f1-af07-538f1ecc7035
+pkg-pinheader-2x22-d1.1-polygon-outline,9d8c29db-4093-476a-96fc-24c9fa31544b
 pkg-pinheader-2x22-d1.1-text-name,3fd26bc5-82db-40a3-b3be-cb332c384ac7
 pkg-pinheader-2x22-d1.1-text-value,f8580531-b735-48d8-92a5-f0a179824d5d
 pkg-pinheader-2x23-d0.9-3d,f3a0d4be-2596-4abd-82d7-591457f078a6
@@ -11584,6 +11908,8 @@ pkg-pinheader-2x23-d0.9-pad-8,41861175-67a8-4e64-bbc5-4e2d8299dc30
 pkg-pinheader-2x23-d0.9-pad-9,ae281330-63c9-45fa-90ae-5eb1f6610410
 pkg-pinheader-2x23-d0.9-pkg,54352943-acf6-48e1-8ae9-e359e689de66
 pkg-pinheader-2x23-d0.9-polygon-contour,12eaba23-8830-4a96-a7e7-7350f903c542
+pkg-pinheader-2x23-d0.9-polygon-courtyard,47717190-33ce-4f0b-9dae-ddf53d18e6d0
+pkg-pinheader-2x23-d0.9-polygon-outline,ec910705-2fc8-42a3-973a-567817510e8b
 pkg-pinheader-2x23-d0.9-text-name,f24fba5d-2964-4269-8712-e6a0c379a766
 pkg-pinheader-2x23-d0.9-text-value,d60aff32-b917-4808-8a55-a9c950380e80
 pkg-pinheader-2x23-d1.0-3d,0e6f7de8-030d-4a6c-b068-7b88ff6a8654
@@ -11636,6 +11962,8 @@ pkg-pinheader-2x23-d1.0-pad-8,d2e76aa3-8617-470f-9e18-50694ce29af8
 pkg-pinheader-2x23-d1.0-pad-9,70c33436-8e6a-4c0a-a191-3375e3bc080c
 pkg-pinheader-2x23-d1.0-pkg,a197e2e6-2597-4110-b184-05c55724c3c9
 pkg-pinheader-2x23-d1.0-polygon-contour,448817bf-67f8-47c2-a66d-09d7fa28377f
+pkg-pinheader-2x23-d1.0-polygon-courtyard,379fce79-a3d4-458a-a193-304546ab2237
+pkg-pinheader-2x23-d1.0-polygon-outline,11ffb40e-8c52-4022-a050-065b88cb17c2
 pkg-pinheader-2x23-d1.0-text-name,1b6dfce7-d24c-48e3-94e0-90f6b5223e83
 pkg-pinheader-2x23-d1.0-text-value,b4a02010-c970-4b0a-9582-f5a8e58d0ea0
 pkg-pinheader-2x23-d1.1-3d,e7c61610-b91a-492d-8878-dd241bc088c0
@@ -11688,6 +12016,8 @@ pkg-pinheader-2x23-d1.1-pad-8,cd7a5f30-5265-4ff0-8aa0-4537b8d51bc9
 pkg-pinheader-2x23-d1.1-pad-9,f7633f95-7556-41c8-a5ac-3a81689b9378
 pkg-pinheader-2x23-d1.1-pkg,4dfe6b3f-5d8e-40ac-aae6-33b34d665d25
 pkg-pinheader-2x23-d1.1-polygon-contour,2de9e32b-03ad-4473-9d72-86fae381f5c0
+pkg-pinheader-2x23-d1.1-polygon-courtyard,3202d67a-63b0-4618-b87e-fef15eb38752
+pkg-pinheader-2x23-d1.1-polygon-outline,2322dd6c-0f85-49bc-acc0-ea69e3d42b92
 pkg-pinheader-2x23-d1.1-text-name,5daeb262-9e0c-4e47-811c-d5733948e87e
 pkg-pinheader-2x23-d1.1-text-value,3611a5b3-b17a-45cd-8b4e-669a6efb1c68
 pkg-pinheader-2x24-d0.9-3d,3043922d-37bc-41cf-aa93-cc89d9546db2
@@ -11742,6 +12072,8 @@ pkg-pinheader-2x24-d0.9-pad-8,c0d75d0e-4eaa-4a11-87f7-e6935f995fa5
 pkg-pinheader-2x24-d0.9-pad-9,c63a0561-0a7a-46e6-85b4-f8b2dd8584b7
 pkg-pinheader-2x24-d0.9-pkg,62054666-b4ac-4559-a8ca-95d173e5386e
 pkg-pinheader-2x24-d0.9-polygon-contour,4073b029-a342-4cf3-b0cd-401aa2f8fa54
+pkg-pinheader-2x24-d0.9-polygon-courtyard,fe9a25b1-59f5-4de4-a08c-2fa5536c095a
+pkg-pinheader-2x24-d0.9-polygon-outline,bba83d72-ab7e-4d65-9501-9d3b6a4a1ccd
 pkg-pinheader-2x24-d0.9-text-name,16d86037-f73c-4037-b68d-ae3add44da98
 pkg-pinheader-2x24-d0.9-text-value,585e282b-9093-4698-80ca-e522c42a18d1
 pkg-pinheader-2x24-d1.0-3d,dabfecab-4872-47f4-bff4-5a7deb8eca72
@@ -11796,6 +12128,8 @@ pkg-pinheader-2x24-d1.0-pad-8,09d92361-018d-4240-9dcf-a52994e56bc6
 pkg-pinheader-2x24-d1.0-pad-9,16237a22-cdb6-48ea-a9dc-f613934216da
 pkg-pinheader-2x24-d1.0-pkg,6093099e-945f-472a-ba11-66bae1659b35
 pkg-pinheader-2x24-d1.0-polygon-contour,41203c9d-400a-454d-9343-4b3c0317681b
+pkg-pinheader-2x24-d1.0-polygon-courtyard,2e63feb7-d847-4560-9e89-9a3095e417a9
+pkg-pinheader-2x24-d1.0-polygon-outline,8b6d18dd-82d0-4385-a7c6-28a370139acc
 pkg-pinheader-2x24-d1.0-text-name,9478051a-337a-4c36-9a20-c040526c7bd2
 pkg-pinheader-2x24-d1.0-text-value,38cbdd3c-e903-4e35-a77c-414bcbcf9e90
 pkg-pinheader-2x24-d1.1-3d,dae7f9a9-bb76-462f-b5d8-dfb625407dbc
@@ -11850,6 +12184,8 @@ pkg-pinheader-2x24-d1.1-pad-8,b47af448-149a-4c26-8a8c-ca873e052506
 pkg-pinheader-2x24-d1.1-pad-9,a098cb07-14fe-4ea2-bae2-2f6e7987017e
 pkg-pinheader-2x24-d1.1-pkg,0e77af3e-e621-4ea6-8842-ca9196eb3435
 pkg-pinheader-2x24-d1.1-polygon-contour,54a4399b-86c3-4a1a-87e5-85dafeb2210b
+pkg-pinheader-2x24-d1.1-polygon-courtyard,0850911a-4b17-4ba1-9ffe-b2050907a7b0
+pkg-pinheader-2x24-d1.1-polygon-outline,777f0818-219a-44e3-bd52-313f491a0e02
 pkg-pinheader-2x24-d1.1-text-name,d700c0f7-bdf0-4230-8c2a-8d889acf257d
 pkg-pinheader-2x24-d1.1-text-value,5daa28f3-0ef8-4e38-a5b9-23b8afe4c193
 pkg-pinheader-2x25-d0.9-3d,61243a5b-32d0-451c-ab0e-d4ad25bd647c
@@ -11906,6 +12242,8 @@ pkg-pinheader-2x25-d0.9-pad-8,0639378e-57a6-4f73-9566-91cda06a2aaa
 pkg-pinheader-2x25-d0.9-pad-9,340b7f5f-c43e-4034-8776-8848862ff8ed
 pkg-pinheader-2x25-d0.9-pkg,91be729f-607a-4f20-a31b-baf92251c5ab
 pkg-pinheader-2x25-d0.9-polygon-contour,dbab9591-89d6-4104-b141-4a1533cc2583
+pkg-pinheader-2x25-d0.9-polygon-courtyard,8f4ebd7b-1412-4551-8baa-07d28f84723e
+pkg-pinheader-2x25-d0.9-polygon-outline,ab54be57-3cf4-4848-bf0a-5f9f31664d0b
 pkg-pinheader-2x25-d0.9-text-name,20197195-f123-4ef7-b37e-39573ddc2f10
 pkg-pinheader-2x25-d0.9-text-value,99febdd2-457a-4669-b638-296090470f6e
 pkg-pinheader-2x25-d1.0-3d,ef8d2e7f-db34-4e4e-a0bf-56b6c5099be0
@@ -11962,6 +12300,8 @@ pkg-pinheader-2x25-d1.0-pad-8,20b13326-1c1c-4f17-b739-66c5f2c072cb
 pkg-pinheader-2x25-d1.0-pad-9,40e37156-217b-43e6-8908-29e24a97f6c4
 pkg-pinheader-2x25-d1.0-pkg,20d2b65c-5342-437c-8474-fdb7aa71f8be
 pkg-pinheader-2x25-d1.0-polygon-contour,9b13bc13-2c17-4ffc-879b-8bbfb1b267da
+pkg-pinheader-2x25-d1.0-polygon-courtyard,78e958a6-a85a-4ea3-9c6c-d74ac6f6dcab
+pkg-pinheader-2x25-d1.0-polygon-outline,058c60d8-3500-4490-a322-ba0d037e2fb8
 pkg-pinheader-2x25-d1.0-text-name,afd74e02-d15f-40ef-83bc-ac1b4494aad1
 pkg-pinheader-2x25-d1.0-text-value,51420272-0ff2-404f-8332-be542c663164
 pkg-pinheader-2x25-d1.1-3d,7f3fbfcf-2a5e-4074-b40f-a44d444df014
@@ -12018,6 +12358,8 @@ pkg-pinheader-2x25-d1.1-pad-8,b63a8330-aba8-4ea0-aee3-449d3967a9f4
 pkg-pinheader-2x25-d1.1-pad-9,c234fd2a-03bc-4df7-8941-6d8ee4104c0f
 pkg-pinheader-2x25-d1.1-pkg,658e84fb-e352-4239-abc5-a072d04ba2a9
 pkg-pinheader-2x25-d1.1-polygon-contour,5b993c06-317c-4bdc-8a70-319e3ad691ba
+pkg-pinheader-2x25-d1.1-polygon-courtyard,899f152d-95e8-4e3d-b584-00ccfc88a7e0
+pkg-pinheader-2x25-d1.1-polygon-outline,062946eb-5933-4392-bd4e-bb0a2a75685c
 pkg-pinheader-2x25-d1.1-text-name,09d66923-23f7-4c51-8128-0f370c663f4e
 pkg-pinheader-2x25-d1.1-text-value,7c9cc66c-25c1-4f71-aed3-d5a4c9dfe6d8
 pkg-pinheader-2x26-d0.9-3d,7a7372db-6510-454f-abab-c6c2edc7ab6c
@@ -12076,6 +12418,8 @@ pkg-pinheader-2x26-d0.9-pad-8,cbf31639-2db5-4675-8813-157c08115d85
 pkg-pinheader-2x26-d0.9-pad-9,f6bcdc54-f60c-4621-b6ba-10985af4897d
 pkg-pinheader-2x26-d0.9-pkg,4df880f0-11e9-43ec-ad15-aba6692ac180
 pkg-pinheader-2x26-d0.9-polygon-contour,86b50933-3328-40d4-89ca-46501f0e5b51
+pkg-pinheader-2x26-d0.9-polygon-courtyard,1d9b408b-98de-4cfe-bb66-a6ef4a8423f5
+pkg-pinheader-2x26-d0.9-polygon-outline,3ee10135-4775-4e5a-9aa5-6b8dfd381c68
 pkg-pinheader-2x26-d0.9-text-name,9deffc17-0e11-4d62-b535-b466fdbe6594
 pkg-pinheader-2x26-d0.9-text-value,2543f0b4-3ad7-4f48-854d-1bd179850be7
 pkg-pinheader-2x26-d1.0-3d,e0b058ec-a0f9-4bd8-b11e-737ec9a305e7
@@ -12134,6 +12478,8 @@ pkg-pinheader-2x26-d1.0-pad-8,8eee1645-e4be-485f-97ee-135bd3e0c17a
 pkg-pinheader-2x26-d1.0-pad-9,f63288e5-6ab0-42a7-a1d9-4489b629cf4c
 pkg-pinheader-2x26-d1.0-pkg,aa421d07-01ab-4465-b218-c43838d900ed
 pkg-pinheader-2x26-d1.0-polygon-contour,278fe74e-fea2-4c74-bcfe-d96eb91fb8d5
+pkg-pinheader-2x26-d1.0-polygon-courtyard,79617df2-d7ba-4f2e-ab35-7351a07ac144
+pkg-pinheader-2x26-d1.0-polygon-outline,0039e9c9-36cf-4ec7-b7f7-6973b4182eb0
 pkg-pinheader-2x26-d1.0-text-name,c7234483-0b0f-4afb-9f4b-5f70dbe6f697
 pkg-pinheader-2x26-d1.0-text-value,fcb78833-7b0e-47b9-a9d3-37ea44e19cb4
 pkg-pinheader-2x26-d1.1-3d,5ec7309d-c445-4249-9eb4-fe9941e31b2e
@@ -12192,6 +12538,8 @@ pkg-pinheader-2x26-d1.1-pad-8,aeeb59cc-7219-4077-9daa-ef984db4abfa
 pkg-pinheader-2x26-d1.1-pad-9,3204f5bc-6c3d-40ad-82b5-c69cfcbd993d
 pkg-pinheader-2x26-d1.1-pkg,8743f9ae-fdaf-48fb-84e2-9830536d4d56
 pkg-pinheader-2x26-d1.1-polygon-contour,343394a8-3042-44e6-9526-933c801372fc
+pkg-pinheader-2x26-d1.1-polygon-courtyard,a997ac22-ac9e-4b8e-999d-cee187d59d93
+pkg-pinheader-2x26-d1.1-polygon-outline,89f7bfb8-8acd-4a19-842a-b25b3ac6d282
 pkg-pinheader-2x26-d1.1-text-name,b31d6243-2f08-42c6-9d78-59f0f299e42b
 pkg-pinheader-2x26-d1.1-text-value,ca5da9c5-23e1-40e5-a2dc-f14c5f5b7ece
 pkg-pinheader-2x27-d0.9-3d,61488d7e-0c07-4f14-a54a-482b2c8cbc23
@@ -12252,6 +12600,8 @@ pkg-pinheader-2x27-d0.9-pad-8,8abc6d0f-0823-4ee2-92b3-e33e14d24fa4
 pkg-pinheader-2x27-d0.9-pad-9,ed0351b9-720b-4048-9197-4e663e4b6113
 pkg-pinheader-2x27-d0.9-pkg,bcedb8f6-e667-4fe9-a545-60919854b8e7
 pkg-pinheader-2x27-d0.9-polygon-contour,715dd03e-7e54-4e19-9e62-52e3d8888f5d
+pkg-pinheader-2x27-d0.9-polygon-courtyard,6f27cb75-44e2-4d12-9454-1b086068d9e5
+pkg-pinheader-2x27-d0.9-polygon-outline,bb3ca344-8faa-4775-b3b8-2bbaa36d5399
 pkg-pinheader-2x27-d0.9-text-name,fed384e2-b78e-4688-b58b-4ffcba3b167a
 pkg-pinheader-2x27-d0.9-text-value,28615eb6-c6ff-4ffb-9fd2-20ea2dcda25f
 pkg-pinheader-2x27-d1.0-3d,f16be86e-ea3b-4183-a9fc-49343ea84131
@@ -12312,6 +12662,8 @@ pkg-pinheader-2x27-d1.0-pad-8,a8e4cabc-423a-4fec-8056-0164b4024850
 pkg-pinheader-2x27-d1.0-pad-9,fdd71316-ea2d-410b-8645-e3b6285b8b29
 pkg-pinheader-2x27-d1.0-pkg,5621586d-8f49-4ffd-9aaa-dfa8dce4791e
 pkg-pinheader-2x27-d1.0-polygon-contour,9356d595-62ca-45e3-b8f3-276046f8f93a
+pkg-pinheader-2x27-d1.0-polygon-courtyard,4711a69f-13db-4a1f-beb1-beb9b3cbc439
+pkg-pinheader-2x27-d1.0-polygon-outline,c9c00050-8538-4019-87d0-21d20fbe29fb
 pkg-pinheader-2x27-d1.0-text-name,c7273446-6ee9-40a0-8d5f-6b68ae902f7d
 pkg-pinheader-2x27-d1.0-text-value,848d1c94-bd36-4ad2-8384-4cc6256af148
 pkg-pinheader-2x27-d1.1-3d,eb25f44d-a110-4d53-8bc0-5aacf97b01e5
@@ -12372,6 +12724,8 @@ pkg-pinheader-2x27-d1.1-pad-8,7538f928-61f6-449a-8a5f-2770e5c62a51
 pkg-pinheader-2x27-d1.1-pad-9,b4ab7303-309f-44d0-9f09-971cef8438ff
 pkg-pinheader-2x27-d1.1-pkg,a0602949-bc68-4e1e-855f-96b1bb94c6ee
 pkg-pinheader-2x27-d1.1-polygon-contour,e964c844-a5c0-47f2-b75f-4ee27ffcfbe1
+pkg-pinheader-2x27-d1.1-polygon-courtyard,0aa0b9ae-15ff-4a90-a685-2b4e51a5e81e
+pkg-pinheader-2x27-d1.1-polygon-outline,f214bda2-9726-4168-abe7-2d9c4d58c97a
 pkg-pinheader-2x27-d1.1-text-name,768f12fe-a3dc-4d84-a340-8279e079eee1
 pkg-pinheader-2x27-d1.1-text-value,44a188af-d1fb-418c-82b5-cbe307101756
 pkg-pinheader-2x28-d0.9-3d,542c0783-2fa8-4ddd-9e95-dcbc6ecb6808
@@ -12434,6 +12788,8 @@ pkg-pinheader-2x28-d0.9-pad-8,41b25e93-8fe1-4446-9d5b-93ba50096394
 pkg-pinheader-2x28-d0.9-pad-9,a8a2d5a6-b0a9-418f-81fb-3a9f90f68628
 pkg-pinheader-2x28-d0.9-pkg,699aa71f-9c6e-4b2d-b4c0-46f8e8361c35
 pkg-pinheader-2x28-d0.9-polygon-contour,5343e7b9-ee01-452e-bfb2-23e769a22da9
+pkg-pinheader-2x28-d0.9-polygon-courtyard,10645ff6-9783-40f9-a53c-ec1bb44b467e
+pkg-pinheader-2x28-d0.9-polygon-outline,557b84ca-b2a6-4098-b7e5-4ce41c34e974
 pkg-pinheader-2x28-d0.9-text-name,342fff56-5af8-4e2c-aafd-55b73593aaf8
 pkg-pinheader-2x28-d0.9-text-value,00c2259e-a983-4f66-8d2a-fa6a6e9f37a1
 pkg-pinheader-2x28-d1.0-3d,5d019cfd-5298-4d57-af30-024bcddfc495
@@ -12496,6 +12852,8 @@ pkg-pinheader-2x28-d1.0-pad-8,5c4a693b-7f30-4b01-ae15-52dfc012fc1c
 pkg-pinheader-2x28-d1.0-pad-9,86d29b4b-3013-44c5-a8f2-5ae657f9f04f
 pkg-pinheader-2x28-d1.0-pkg,a530e22f-cc3f-4d20-a2a7-fefedae8d4f5
 pkg-pinheader-2x28-d1.0-polygon-contour,0426e088-9055-4eae-91d0-86c8731b324d
+pkg-pinheader-2x28-d1.0-polygon-courtyard,55533fbe-609d-4fd6-873b-0255e12d9184
+pkg-pinheader-2x28-d1.0-polygon-outline,e537ba55-9908-40e9-bd86-32761401377b
 pkg-pinheader-2x28-d1.0-text-name,c1a1ef67-419c-410a-8a8b-f3dd0e9c3e8e
 pkg-pinheader-2x28-d1.0-text-value,58700536-888f-4051-abdf-d1030ae48f16
 pkg-pinheader-2x28-d1.1-3d,b60a5777-3c3d-454f-a3e8-6f2fcd18d197
@@ -12558,6 +12916,8 @@ pkg-pinheader-2x28-d1.1-pad-8,56072327-3437-4aeb-aaf1-3f673c1f1fe5
 pkg-pinheader-2x28-d1.1-pad-9,beb6db8e-4e22-472d-85c2-343950bbe7bd
 pkg-pinheader-2x28-d1.1-pkg,7a54d080-ee52-47af-817a-8fa59373f6fe
 pkg-pinheader-2x28-d1.1-polygon-contour,fa7e976e-3b18-4bf5-b54c-dfdb0b4f611a
+pkg-pinheader-2x28-d1.1-polygon-courtyard,40a1495b-c017-4d35-aec3-0d7b1521fb50
+pkg-pinheader-2x28-d1.1-polygon-outline,d8062c8b-d839-4ef7-af5f-a4ac1f3c90c1
 pkg-pinheader-2x28-d1.1-text-name,9189b051-094e-49e1-a32d-d0bbe69d2ed3
 pkg-pinheader-2x28-d1.1-text-value,a7d465d3-45d1-4892-9a8e-c19b84f739c9
 pkg-pinheader-2x29-d0.9-3d,e535559c-35a3-4fae-9a95-02d0bc8d6b17
@@ -12622,6 +12982,8 @@ pkg-pinheader-2x29-d0.9-pad-8,88d55366-faca-425e-ad45-9339ea24d4c3
 pkg-pinheader-2x29-d0.9-pad-9,fd642bf3-a56c-4113-aba3-daf8b7d2951d
 pkg-pinheader-2x29-d0.9-pkg,c46710f2-f269-4274-a076-92c1ac56b2f8
 pkg-pinheader-2x29-d0.9-polygon-contour,8b0dc0a0-498a-4fd2-b9b3-79ef9e208fab
+pkg-pinheader-2x29-d0.9-polygon-courtyard,b4918c35-cad4-478f-9b96-7e93e8e22ada
+pkg-pinheader-2x29-d0.9-polygon-outline,568bf9c0-581c-456e-b42d-a8bfb392b568
 pkg-pinheader-2x29-d0.9-text-name,8553ccb6-2ba1-4032-af42-d0e0f6ee9659
 pkg-pinheader-2x29-d0.9-text-value,27ce3c91-a15f-403f-9757-9fbd73c30598
 pkg-pinheader-2x29-d1.0-3d,ff2faac6-6364-4a9a-bb27-f6d339488c65
@@ -12686,6 +13048,8 @@ pkg-pinheader-2x29-d1.0-pad-8,39323a65-d0fc-4c49-9c21-7c67dcfcccd1
 pkg-pinheader-2x29-d1.0-pad-9,b9e8a107-8ecf-46a2-a925-a8a3b5dcc1ae
 pkg-pinheader-2x29-d1.0-pkg,ae92a2f0-0768-410d-a56e-51d6afe1c080
 pkg-pinheader-2x29-d1.0-polygon-contour,898cfde0-4428-4c6f-b101-503c1c20c835
+pkg-pinheader-2x29-d1.0-polygon-courtyard,b8291ffa-ed84-47db-b168-51f89866727a
+pkg-pinheader-2x29-d1.0-polygon-outline,17991762-8ad3-410b-b328-7770614d5efc
 pkg-pinheader-2x29-d1.0-text-name,d29a5739-e17e-44ab-b83e-aa21f16a432a
 pkg-pinheader-2x29-d1.0-text-value,db7cafb8-3b93-479a-836e-048ded65c84e
 pkg-pinheader-2x29-d1.1-3d,7446583e-dcfe-4e68-8eac-b6fd759c7abf
@@ -12750,6 +13114,8 @@ pkg-pinheader-2x29-d1.1-pad-8,153a48a5-3264-49d7-a4e2-5f6f50b200a5
 pkg-pinheader-2x29-d1.1-pad-9,689fcd07-a636-4a93-b8d0-f172f3be5182
 pkg-pinheader-2x29-d1.1-pkg,9514dc62-9f15-40c5-80b6-f12e952a2393
 pkg-pinheader-2x29-d1.1-polygon-contour,4f38b216-e9da-4185-8be7-7221f50580d3
+pkg-pinheader-2x29-d1.1-polygon-courtyard,381409b3-bd92-45fc-b4fb-2e0101d7ef26
+pkg-pinheader-2x29-d1.1-polygon-outline,d78f0f75-936f-434f-8709-0b706b8c0b4c
 pkg-pinheader-2x29-d1.1-text-name,049d5116-830c-4108-b722-3affb9ba3144
 pkg-pinheader-2x29-d1.1-text-value,59dac5e6-52d1-4f8f-9871-38b17968a1eb
 pkg-pinheader-2x3-d0.9-3d,17ededfe-7e50-41d6-896f-52981608d9ce
@@ -12762,6 +13128,8 @@ pkg-pinheader-2x3-d0.9-pad-4,361d554e-14c0-405f-bd50-d6dad47fc4c7
 pkg-pinheader-2x3-d0.9-pad-5,6f3352b6-fe0e-48df-b68e-7c1713fb1acb
 pkg-pinheader-2x3-d0.9-pkg,9f12d856-a10e-47e7-a516-8063ecc74d69
 pkg-pinheader-2x3-d0.9-polygon-contour,39f872ea-15a1-465d-bbb1-8c4b22efd233
+pkg-pinheader-2x3-d0.9-polygon-courtyard,a44ea518-5ab9-4c2d-9582-244c3a5de5a7
+pkg-pinheader-2x3-d0.9-polygon-outline,6f50c9e6-a47a-4323-a6cb-7d1b322dd402
 pkg-pinheader-2x3-d0.9-text-name,db0a1cca-0441-4a9f-8401-b539ab5dd5aa
 pkg-pinheader-2x3-d0.9-text-value,07993294-86e1-42d0-8cd6-bc5807bc3c2d
 pkg-pinheader-2x3-d1.0-3d,2b4a570f-b558-4086-9dbf-a1842a430e0a
@@ -12774,6 +13142,8 @@ pkg-pinheader-2x3-d1.0-pad-4,0965057b-230c-4122-b441-64ca77888a46
 pkg-pinheader-2x3-d1.0-pad-5,86c0c0c5-e174-44de-8cb8-4bb2ada8cac1
 pkg-pinheader-2x3-d1.0-pkg,99768a41-2ef6-4911-afa2-a75ef1471d0c
 pkg-pinheader-2x3-d1.0-polygon-contour,47e4e9bd-d9dd-4f6d-ade0-caacf3807868
+pkg-pinheader-2x3-d1.0-polygon-courtyard,7b0830c8-d545-4ff1-9aea-340b97023e6d
+pkg-pinheader-2x3-d1.0-polygon-outline,2a60ca6a-d13b-4e6c-8eb4-f89092de8a7e
 pkg-pinheader-2x3-d1.0-text-name,89ddcfd4-0c3d-404d-9cf7-736df0ce522d
 pkg-pinheader-2x3-d1.0-text-value,9817ab51-a8f6-46c5-b1e8-ae596ae38f56
 pkg-pinheader-2x3-d1.1-3d,6164f6b5-41ab-4003-9b00-299e2412f62f
@@ -12786,6 +13156,8 @@ pkg-pinheader-2x3-d1.1-pad-4,08dbe436-0cdd-47ff-b0df-1491748b07c7
 pkg-pinheader-2x3-d1.1-pad-5,5b84d330-7679-46be-87ae-6aa4a81f7409
 pkg-pinheader-2x3-d1.1-pkg,615646b5-fee5-452e-8fc1-61eb87284b6d
 pkg-pinheader-2x3-d1.1-polygon-contour,d88b9b38-35bb-43fe-8804-9fea21326662
+pkg-pinheader-2x3-d1.1-polygon-courtyard,4daf667e-0cc8-4fef-8910-16ca926b904e
+pkg-pinheader-2x3-d1.1-polygon-outline,ff1a3ba0-255a-4f92-993e-c2ce45524fb1
 pkg-pinheader-2x3-d1.1-text-name,86e75706-14d2-495b-b213-2fa0def33d9f
 pkg-pinheader-2x3-d1.1-text-value,d85a53a7-67db-46d5-a808-7096337b1d8a
 pkg-pinheader-2x30-d0.9-3d,3e347c36-9e6e-4ffd-875d-2b2806ddd17e
@@ -12852,6 +13224,8 @@ pkg-pinheader-2x30-d0.9-pad-8,0613a43c-5be5-405c-8fa6-901d58a45cdb
 pkg-pinheader-2x30-d0.9-pad-9,3da98462-c77f-44ac-b762-9ec88ed0fa05
 pkg-pinheader-2x30-d0.9-pkg,03e3a848-a9de-4d78-bc7e-98247cb44d1d
 pkg-pinheader-2x30-d0.9-polygon-contour,25368807-a105-45ac-ac65-610eac975a38
+pkg-pinheader-2x30-d0.9-polygon-courtyard,3a44402f-20d9-48c8-b1a9-3fcea9d63f28
+pkg-pinheader-2x30-d0.9-polygon-outline,89098e50-8501-4bf1-ba52-2fe21599d91f
 pkg-pinheader-2x30-d0.9-text-name,d5da6ae5-fdad-40a2-8043-29a33c2729ce
 pkg-pinheader-2x30-d0.9-text-value,9b40ceb4-0a42-42db-a1b7-a825ceacc81f
 pkg-pinheader-2x30-d1.0-3d,ccc58e30-6865-4421-ba46-8f686c2b8aad
@@ -12918,6 +13292,8 @@ pkg-pinheader-2x30-d1.0-pad-8,f2a574e8-7332-4fff-bf89-970e5c9b6564
 pkg-pinheader-2x30-d1.0-pad-9,e17bbbdb-1628-4bfc-82f0-cd88c77f5fd0
 pkg-pinheader-2x30-d1.0-pkg,dd2e7e04-8cc8-4faa-bb2a-2efa15e79536
 pkg-pinheader-2x30-d1.0-polygon-contour,1ffaee7b-7ad1-45e6-8b27-443509da226a
+pkg-pinheader-2x30-d1.0-polygon-courtyard,8b47e6b1-278d-4f05-9a56-bcb05bbacc9b
+pkg-pinheader-2x30-d1.0-polygon-outline,95a6296a-a33f-4e2f-a131-caf7cae9f2c8
 pkg-pinheader-2x30-d1.0-text-name,a465a3c1-ebbb-4951-b019-5f674218b759
 pkg-pinheader-2x30-d1.0-text-value,fc4437f9-7cdd-47f9-b01b-a8bdb26fb5b7
 pkg-pinheader-2x30-d1.1-3d,e2a66f05-74b1-47ac-836f-ff0c7fd639f8
@@ -12984,6 +13360,8 @@ pkg-pinheader-2x30-d1.1-pad-8,7604521e-6274-40ad-9fbb-27ab786b8e59
 pkg-pinheader-2x30-d1.1-pad-9,e24280b6-c1d0-46ea-bfe9-5b43eeb90a3d
 pkg-pinheader-2x30-d1.1-pkg,a9011e93-4ebd-443f-86f4-2999b707603c
 pkg-pinheader-2x30-d1.1-polygon-contour,64fe051d-30e3-426c-9eb7-ec29b89a71dd
+pkg-pinheader-2x30-d1.1-polygon-courtyard,06d0effc-6dea-495b-bf77-125c60d5890b
+pkg-pinheader-2x30-d1.1-polygon-outline,cb911221-02cb-4d57-aeef-ced1c8bdfbcb
 pkg-pinheader-2x30-d1.1-text-name,52f3fd65-cd03-47fa-8e99-18aaebc5edd5
 pkg-pinheader-2x30-d1.1-text-value,8094be30-dedf-4bbd-bc6d-3c8059365de8
 pkg-pinheader-2x31-d0.9-3d,4df4d079-7a80-42d9-96fd-5a263f3d9dc3
@@ -13052,6 +13430,8 @@ pkg-pinheader-2x31-d0.9-pad-8,96f9d541-a21a-4857-837d-fefded336324
 pkg-pinheader-2x31-d0.9-pad-9,82dcc757-e4f2-47ad-8f95-493e5b4b87be
 pkg-pinheader-2x31-d0.9-pkg,e9552c7b-dd55-4104-8a6e-74c759f58c81
 pkg-pinheader-2x31-d0.9-polygon-contour,2e9ebbc9-a511-4038-9a38-2dc793ff2f6c
+pkg-pinheader-2x31-d0.9-polygon-courtyard,3c1cbaf4-2b6c-4b33-be4d-5148e259f52d
+pkg-pinheader-2x31-d0.9-polygon-outline,8fa22484-63bb-456a-89f5-c4a363a14c26
 pkg-pinheader-2x31-d0.9-text-name,81804d3b-f828-4f26-a7f2-3b0c3cbf6418
 pkg-pinheader-2x31-d0.9-text-value,1ed6cd5b-7119-44dc-9de7-86c89768a210
 pkg-pinheader-2x31-d1.0-3d,b7de43da-d8e5-4d2b-a3f4-84d9faa7fd4f
@@ -13120,6 +13500,8 @@ pkg-pinheader-2x31-d1.0-pad-8,88a9e944-eb05-488e-9dd7-1132cb08f0ce
 pkg-pinheader-2x31-d1.0-pad-9,afbabd2a-f6d1-49c4-bcd4-628f866de46f
 pkg-pinheader-2x31-d1.0-pkg,a10123eb-cc73-4016-a40c-5b2dc9dcb296
 pkg-pinheader-2x31-d1.0-polygon-contour,6c14a11b-9b50-4166-b58f-54f4b0cd2141
+pkg-pinheader-2x31-d1.0-polygon-courtyard,baa3c8b4-bf3c-4353-ae31-0b5a58ecf298
+pkg-pinheader-2x31-d1.0-polygon-outline,1bb5f78c-ada9-45bd-adc1-44bb499b2a58
 pkg-pinheader-2x31-d1.0-text-name,4a4d84d6-e591-4def-9cc0-5242a771a7d3
 pkg-pinheader-2x31-d1.0-text-value,da31b0f0-a765-41ce-80b3-9274773a741a
 pkg-pinheader-2x31-d1.1-3d,f1aa1f76-c668-4669-8eef-9048e2fe5e6f
@@ -13188,6 +13570,8 @@ pkg-pinheader-2x31-d1.1-pad-8,85fc0ac9-46fa-4503-a439-2f2340cfab0d
 pkg-pinheader-2x31-d1.1-pad-9,0ed57ddf-e33a-40c9-a581-85e69d9bd944
 pkg-pinheader-2x31-d1.1-pkg,cd7b1b99-a200-4413-812a-76ad72e644a7
 pkg-pinheader-2x31-d1.1-polygon-contour,6e3761cc-50f1-4054-9268-c324c06a87f1
+pkg-pinheader-2x31-d1.1-polygon-courtyard,1ee25445-8289-4d79-9a4a-926d6c308af9
+pkg-pinheader-2x31-d1.1-polygon-outline,b95b2214-1d56-4305-97af-2e98b1c7f422
 pkg-pinheader-2x31-d1.1-text-name,5bae177e-0b36-40fa-9f32-528623189635
 pkg-pinheader-2x31-d1.1-text-value,28e69433-e641-4cce-abc7-33734027d272
 pkg-pinheader-2x32-d0.9-3d,c8ddecea-d817-4ef3-86f4-6650e15c1332
@@ -13258,6 +13642,8 @@ pkg-pinheader-2x32-d0.9-pad-8,419c39ea-d104-4e92-9667-b96f08dff47d
 pkg-pinheader-2x32-d0.9-pad-9,c6640db5-f354-4369-b773-6e16f101b3eb
 pkg-pinheader-2x32-d0.9-pkg,faa27699-ac71-49e6-9e79-31a17ee38085
 pkg-pinheader-2x32-d0.9-polygon-contour,66a51e09-665b-4249-b4e0-a15e62872d6a
+pkg-pinheader-2x32-d0.9-polygon-courtyard,3429c314-3683-4117-b330-14d94fe7203c
+pkg-pinheader-2x32-d0.9-polygon-outline,f8d274fd-fe1d-4bce-9faf-cd738623c39e
 pkg-pinheader-2x32-d0.9-text-name,e53b30eb-65f6-41bf-b0d3-9c0440cdd3b0
 pkg-pinheader-2x32-d0.9-text-value,001cf23d-c750-4058-b468-fe71eb80e8e5
 pkg-pinheader-2x32-d1.0-3d,9c3b441c-fa57-4cc4-be44-4085661e5d3d
@@ -13328,6 +13714,8 @@ pkg-pinheader-2x32-d1.0-pad-8,85340ba8-442d-4c7f-ac3a-6e5019047531
 pkg-pinheader-2x32-d1.0-pad-9,7a982e47-ae5f-476f-a9c5-af07b67a328f
 pkg-pinheader-2x32-d1.0-pkg,e514f146-2572-4492-aed8-008576f5edbc
 pkg-pinheader-2x32-d1.0-polygon-contour,12d837ef-6a84-4586-983f-785df1637942
+pkg-pinheader-2x32-d1.0-polygon-courtyard,3b3cf3c4-8d08-4fae-8335-961b8411f350
+pkg-pinheader-2x32-d1.0-polygon-outline,180e4872-059a-4ee2-9a50-21446bd8352a
 pkg-pinheader-2x32-d1.0-text-name,6489904a-fe58-435b-a618-72c41219e6c6
 pkg-pinheader-2x32-d1.0-text-value,8dec79e8-b44e-431d-975b-556273690301
 pkg-pinheader-2x32-d1.1-3d,84d06f4d-4ca1-49cf-b3b6-21a349fd0a2a
@@ -13398,6 +13786,8 @@ pkg-pinheader-2x32-d1.1-pad-8,6d07a198-3ca6-4057-80aa-e8a00d6a7cfd
 pkg-pinheader-2x32-d1.1-pad-9,dab86d27-70b1-4bcb-9f65-5400b56cd5ee
 pkg-pinheader-2x32-d1.1-pkg,29d14d47-bca8-4baa-bff7-3dab91cd7900
 pkg-pinheader-2x32-d1.1-polygon-contour,cc13a468-bd6e-4618-ac39-f3fab940b297
+pkg-pinheader-2x32-d1.1-polygon-courtyard,c9e8150a-1512-43b5-8154-31080178161d
+pkg-pinheader-2x32-d1.1-polygon-outline,449a7321-6c16-4afb-8bda-e3f74a0f75d4
 pkg-pinheader-2x32-d1.1-text-name,a763d77f-474c-4c6e-8782-f5ec8f35f18e
 pkg-pinheader-2x32-d1.1-text-value,28808ae9-ad65-4e6b-9d18-bca4bf237d80
 pkg-pinheader-2x33-d0.9-3d,c1f30449-d131-4fc4-a523-4d5ae6f1fd1e
@@ -13470,6 +13860,8 @@ pkg-pinheader-2x33-d0.9-pad-8,694840d2-97b9-45ab-8ca2-c2d08e0761df
 pkg-pinheader-2x33-d0.9-pad-9,a1872e3b-78c7-4982-bafc-f48f90d41b4d
 pkg-pinheader-2x33-d0.9-pkg,0dcddc47-ff66-4750-814f-78e499c28d02
 pkg-pinheader-2x33-d0.9-polygon-contour,255f8e8c-455a-470c-8be2-954a963c87d5
+pkg-pinheader-2x33-d0.9-polygon-courtyard,b7e61f64-8bd7-4e3f-b75d-57eeeabd6cb1
+pkg-pinheader-2x33-d0.9-polygon-outline,842c2437-75f5-4fc0-898e-68203ced2bc5
 pkg-pinheader-2x33-d0.9-text-name,7b02c68f-9552-4d23-9160-dd762987e1b1
 pkg-pinheader-2x33-d0.9-text-value,e9b038db-5aa4-47fa-9590-ca6644c897b1
 pkg-pinheader-2x33-d1.0-3d,8743d1b4-7285-4721-ae4b-dd08792ac5ae
@@ -13542,6 +13934,8 @@ pkg-pinheader-2x33-d1.0-pad-8,c4139d1b-0200-427c-8588-6566985625b1
 pkg-pinheader-2x33-d1.0-pad-9,97494952-7d54-425c-989d-5931ae3de2ce
 pkg-pinheader-2x33-d1.0-pkg,0b7ab98d-f2d5-4e20-bea3-201c5587d4f3
 pkg-pinheader-2x33-d1.0-polygon-contour,2eaf9095-b657-4f72-907c-623d1f6ddaa3
+pkg-pinheader-2x33-d1.0-polygon-courtyard,bd9c65fc-12ce-4633-930c-6400b8f7379f
+pkg-pinheader-2x33-d1.0-polygon-outline,7ec7749d-5d4b-45b2-9645-8075826f22da
 pkg-pinheader-2x33-d1.0-text-name,fb777756-9c4a-4a35-86d7-8284c73a1365
 pkg-pinheader-2x33-d1.0-text-value,2f30d4b1-f57a-4159-b921-8e2674f6b4fa
 pkg-pinheader-2x33-d1.1-3d,0ee5a1fa-19a9-45de-8160-71ceab5fc7f2
@@ -13614,6 +14008,8 @@ pkg-pinheader-2x33-d1.1-pad-8,9f2ffc36-353b-45ef-ac07-ff40a0cba339
 pkg-pinheader-2x33-d1.1-pad-9,ec4171bc-51c6-4382-950f-2a0ad29de6f8
 pkg-pinheader-2x33-d1.1-pkg,a9ad4f0a-2e45-4f9c-b41c-bbd286a45e76
 pkg-pinheader-2x33-d1.1-polygon-contour,c7e55bfe-4467-48cd-8b69-0cce29be6f4d
+pkg-pinheader-2x33-d1.1-polygon-courtyard,a1a5065c-f806-432b-aa16-19407be8c13d
+pkg-pinheader-2x33-d1.1-polygon-outline,3f61a02b-1809-4255-8e73-614a613cbd61
 pkg-pinheader-2x33-d1.1-text-name,b6b71cbc-1898-4dc4-9649-d3105d0dd4c2
 pkg-pinheader-2x33-d1.1-text-value,0ee2f6b8-04d9-4b05-9548-a9e4a6ef7cbd
 pkg-pinheader-2x34-d0.9-3d,2794df4b-3df9-4734-8764-a04cc9e96ffd
@@ -13688,6 +14084,8 @@ pkg-pinheader-2x34-d0.9-pad-8,e0e44bb6-cd9b-42c0-a3b3-60ce8f934b1d
 pkg-pinheader-2x34-d0.9-pad-9,4fe53642-72e7-47ac-a68f-628e18771587
 pkg-pinheader-2x34-d0.9-pkg,b8e0dc9d-8304-4adc-accf-56c85c8a94b0
 pkg-pinheader-2x34-d0.9-polygon-contour,c55f1338-1ac5-4f26-a767-dcf7ad0b4eec
+pkg-pinheader-2x34-d0.9-polygon-courtyard,cf038b58-48f8-4f57-b298-428189b780e9
+pkg-pinheader-2x34-d0.9-polygon-outline,03c57ca9-a45d-4582-95ef-2f47a6bf88c1
 pkg-pinheader-2x34-d0.9-text-name,b94bab9b-3ff4-42a8-aef0-eafce7bf52cd
 pkg-pinheader-2x34-d0.9-text-value,335cd7c1-7196-45dd-bce1-903dddd78ea6
 pkg-pinheader-2x34-d1.0-3d,8e4ca4b6-b4b2-4d0b-804b-66f68b9ca961
@@ -13762,6 +14160,8 @@ pkg-pinheader-2x34-d1.0-pad-8,bb775811-8e5a-4320-babe-0c16c078461e
 pkg-pinheader-2x34-d1.0-pad-9,249c9d16-eac1-4a02-b30d-8e09b2e67b1d
 pkg-pinheader-2x34-d1.0-pkg,a0cf2059-392c-437e-a305-340cbd00fcc1
 pkg-pinheader-2x34-d1.0-polygon-contour,9da29e7a-0b53-476e-8290-7c6c231f120c
+pkg-pinheader-2x34-d1.0-polygon-courtyard,faeade3f-6040-447d-b97d-7dde490756f9
+pkg-pinheader-2x34-d1.0-polygon-outline,dca49a81-3f03-4b72-8edc-e38d3d68fb80
 pkg-pinheader-2x34-d1.0-text-name,6847c592-9080-4c14-a203-2fa8800afadd
 pkg-pinheader-2x34-d1.0-text-value,c0b88f4f-e894-48a8-8ea1-420123e6142e
 pkg-pinheader-2x34-d1.1-3d,ad808606-6572-44de-aefa-99d89a9c08d2
@@ -13836,6 +14236,8 @@ pkg-pinheader-2x34-d1.1-pad-8,56a0959a-2af3-451c-a7e8-ea2f0dff0d6d
 pkg-pinheader-2x34-d1.1-pad-9,f640ba88-35ca-4b18-b409-ee3ec0282d44
 pkg-pinheader-2x34-d1.1-pkg,b4875c02-86fa-4851-91ad-960916bb24c3
 pkg-pinheader-2x34-d1.1-polygon-contour,f4a6f614-246b-45b8-8ed0-de431fde37a5
+pkg-pinheader-2x34-d1.1-polygon-courtyard,89873701-5fe7-4999-8a9e-218a02b6e21d
+pkg-pinheader-2x34-d1.1-polygon-outline,bc4ab69d-f77e-4e10-96ad-c66b6d4ea106
 pkg-pinheader-2x34-d1.1-text-name,59538b87-94a2-44a0-b908-980edda17d38
 pkg-pinheader-2x34-d1.1-text-value,0098754c-60f9-486b-ab10-549bd9a8e078
 pkg-pinheader-2x35-d0.9-3d,981f03a2-a39a-4852-9646-bbea3e4b3af9
@@ -13912,6 +14314,8 @@ pkg-pinheader-2x35-d0.9-pad-8,bfda896e-0386-44af-bfc9-17a2b2d3ace9
 pkg-pinheader-2x35-d0.9-pad-9,cc30655c-2331-42ce-9568-61d5f4b6e367
 pkg-pinheader-2x35-d0.9-pkg,70806522-7f92-4186-a57b-d2e2950756d1
 pkg-pinheader-2x35-d0.9-polygon-contour,7205a02a-b9f3-4624-9c1a-0ab8c9322f95
+pkg-pinheader-2x35-d0.9-polygon-courtyard,5252a2b1-7780-4236-b026-3e32b3c3e961
+pkg-pinheader-2x35-d0.9-polygon-outline,738bc4c1-45c5-4438-9b0d-61fdcf9c0441
 pkg-pinheader-2x35-d0.9-text-name,c7946e3e-8034-478c-8251-565abd1c639d
 pkg-pinheader-2x35-d0.9-text-value,2bee0bc7-2b3f-40a0-81f3-0d915f4af701
 pkg-pinheader-2x35-d1.0-3d,393ba705-727c-407a-9199-4efe7b90742b
@@ -13988,6 +14392,8 @@ pkg-pinheader-2x35-d1.0-pad-8,c189c8dd-e7f0-4cbd-86cc-e5165eee5fde
 pkg-pinheader-2x35-d1.0-pad-9,8090b9b1-6bf5-4af2-8cee-1dbcdfad5d33
 pkg-pinheader-2x35-d1.0-pkg,126f90ee-8264-4ed9-9064-421bd29438a9
 pkg-pinheader-2x35-d1.0-polygon-contour,5b43e04a-1065-48f9-bd4d-37d085846f53
+pkg-pinheader-2x35-d1.0-polygon-courtyard,3947eaa7-0d81-44eb-b140-3f75f38f78c2
+pkg-pinheader-2x35-d1.0-polygon-outline,72d35075-fd5c-435b-927f-79924e469083
 pkg-pinheader-2x35-d1.0-text-name,0ec20525-bf66-470a-bbbe-8aa69d7c8789
 pkg-pinheader-2x35-d1.0-text-value,c06f2481-1953-452a-8b9c-3fd627963072
 pkg-pinheader-2x35-d1.1-3d,3a536e5d-5402-4c93-ad3f-37cc2d1dc80c
@@ -14064,6 +14470,8 @@ pkg-pinheader-2x35-d1.1-pad-8,87c2d8e8-c721-4cd0-a35d-d482e35f1739
 pkg-pinheader-2x35-d1.1-pad-9,f0be7349-64cf-4fac-a39c-1ff50da7c342
 pkg-pinheader-2x35-d1.1-pkg,309808a8-cce6-455a-8420-538d99ed7a59
 pkg-pinheader-2x35-d1.1-polygon-contour,f5108718-3375-4bbd-9ac9-980d01a7cfc1
+pkg-pinheader-2x35-d1.1-polygon-courtyard,32da900e-06ac-4d21-94f4-e5ccd05cfc67
+pkg-pinheader-2x35-d1.1-polygon-outline,3f60aecd-f4f3-4836-82c6-a97ff00bc89d
 pkg-pinheader-2x35-d1.1-text-name,b049c78a-b2cd-48b8-abdb-bf702fb88a75
 pkg-pinheader-2x35-d1.1-text-value,12e6f191-3d55-40fc-84f0-3c6a43630f60
 pkg-pinheader-2x36-d0.9-3d,dc8821a5-0210-43d3-9667-cb7dd991e8a2
@@ -14142,6 +14550,8 @@ pkg-pinheader-2x36-d0.9-pad-8,5a27187e-b802-4e0e-ab99-33f6f1aef465
 pkg-pinheader-2x36-d0.9-pad-9,bc94eb40-89df-4baa-8f92-1c71ac67b8db
 pkg-pinheader-2x36-d0.9-pkg,1ad3ae94-04a1-4843-9e3b-420bf12c0dda
 pkg-pinheader-2x36-d0.9-polygon-contour,d920901b-60de-4327-b095-96091635b5f0
+pkg-pinheader-2x36-d0.9-polygon-courtyard,bca13619-0900-45d9-9cc8-ba3e0aaba233
+pkg-pinheader-2x36-d0.9-polygon-outline,03f1bb35-ae1f-4e2d-b8ee-2a623aaacf45
 pkg-pinheader-2x36-d0.9-text-name,9516145d-fe88-4c05-bbd1-49f9270c06f4
 pkg-pinheader-2x36-d0.9-text-value,f2944b28-73a1-42a3-a3a2-69f042a30819
 pkg-pinheader-2x36-d1.0-3d,2677d0bd-b01f-4306-9329-0d57b2272464
@@ -14220,6 +14630,8 @@ pkg-pinheader-2x36-d1.0-pad-8,425ce961-5cf0-42b4-a28c-ae87059fd451
 pkg-pinheader-2x36-d1.0-pad-9,a327bd21-9fb5-45eb-8c23-1b03704a5e41
 pkg-pinheader-2x36-d1.0-pkg,9ee4cfbf-27f9-4a56-a68b-b95c1de0f8a4
 pkg-pinheader-2x36-d1.0-polygon-contour,7454e3ed-9363-4439-a0f8-434950f5ba65
+pkg-pinheader-2x36-d1.0-polygon-courtyard,f6da67f3-0165-4c6f-bff8-1fb2c96bd8bf
+pkg-pinheader-2x36-d1.0-polygon-outline,43c806e0-6718-47cf-adce-10eb167eff2e
 pkg-pinheader-2x36-d1.0-text-name,d830bf5f-0687-4708-b6a2-d49f2842398e
 pkg-pinheader-2x36-d1.0-text-value,1c62a128-f62a-489f-98b9-cd8f0a5b5989
 pkg-pinheader-2x36-d1.1-3d,7a9c1d65-588d-42dc-89d4-adfb0e8cf89f
@@ -14298,6 +14710,8 @@ pkg-pinheader-2x36-d1.1-pad-8,0e2c2f12-966c-45d3-b35e-6240d10d25b6
 pkg-pinheader-2x36-d1.1-pad-9,24e9df1d-0a83-43b5-ab33-f8d06d411553
 pkg-pinheader-2x36-d1.1-pkg,f792dab6-b7ac-4952-91bf-781f199d31a9
 pkg-pinheader-2x36-d1.1-polygon-contour,c962850d-632c-4cd6-a071-8f3ed10d21ea
+pkg-pinheader-2x36-d1.1-polygon-courtyard,a4482ed9-7be3-444d-8a44-580e9b965610
+pkg-pinheader-2x36-d1.1-polygon-outline,1ed7a589-43cf-4796-87de-ed8deb4694f5
 pkg-pinheader-2x36-d1.1-text-name,2977262a-8266-4c25-a2b0-34086ca04782
 pkg-pinheader-2x36-d1.1-text-value,3a156b04-2519-4eba-aac6-8e55274ddb7c
 pkg-pinheader-2x37-d0.9-3d,e4810d39-e168-4f3a-bd1e-8cb24e70301e
@@ -14378,6 +14792,8 @@ pkg-pinheader-2x37-d0.9-pad-8,45bcef0d-78cd-466b-aa51-d53217ce977a
 pkg-pinheader-2x37-d0.9-pad-9,46b0e4f9-cbfc-45d7-8c63-f4108b531a43
 pkg-pinheader-2x37-d0.9-pkg,6933fa42-7c39-47a5-9ee6-eee8f545e78a
 pkg-pinheader-2x37-d0.9-polygon-contour,d7564a52-bd4f-4b15-916b-5ed00f7043d6
+pkg-pinheader-2x37-d0.9-polygon-courtyard,ae519757-5bc7-4b58-81d9-05c24fad5d4f
+pkg-pinheader-2x37-d0.9-polygon-outline,1b39e2c2-ada3-43ca-8275-45d3c495da4a
 pkg-pinheader-2x37-d0.9-text-name,c209f3c2-0784-43fd-88aa-0c3da44ec549
 pkg-pinheader-2x37-d0.9-text-value,fe9d9359-9ca9-494b-bb7f-0148b5711a1a
 pkg-pinheader-2x37-d1.0-3d,8c4d5a2f-2487-4570-89f4-ae1b6bb20f89
@@ -14458,6 +14874,8 @@ pkg-pinheader-2x37-d1.0-pad-8,ca7d8345-e16f-4bf5-b0bd-81f664fa0ba2
 pkg-pinheader-2x37-d1.0-pad-9,69730271-046f-4622-a90b-b71a83ca1443
 pkg-pinheader-2x37-d1.0-pkg,fd710036-c5a2-4967-b778-5fb962637f49
 pkg-pinheader-2x37-d1.0-polygon-contour,920fd531-b846-46d3-93cf-d5d5cffeb2fa
+pkg-pinheader-2x37-d1.0-polygon-courtyard,c73c6485-b222-4854-8f1a-ee1357c18955
+pkg-pinheader-2x37-d1.0-polygon-outline,3bfacb02-dd2a-4ecb-aa57-a24100d10f47
 pkg-pinheader-2x37-d1.0-text-name,f8f51690-8095-48fc-a0eb-577a13a21116
 pkg-pinheader-2x37-d1.0-text-value,c853fd67-27a5-4ffc-8b2b-edee502295af
 pkg-pinheader-2x37-d1.1-3d,d477c099-fb01-4f00-983c-98770e5231ca
@@ -14538,6 +14956,8 @@ pkg-pinheader-2x37-d1.1-pad-8,bea1a593-d46a-4ee8-a8be-9a9fff2ca5bc
 pkg-pinheader-2x37-d1.1-pad-9,aa4d9f4e-9f9f-457e-8a5c-569a29a4cb57
 pkg-pinheader-2x37-d1.1-pkg,f50edc5d-3140-41eb-907e-388b0d4c9b6b
 pkg-pinheader-2x37-d1.1-polygon-contour,b4a0a548-c7e9-47f3-b85f-aae99c507143
+pkg-pinheader-2x37-d1.1-polygon-courtyard,16ece452-016d-44a0-96a7-e637033df75b
+pkg-pinheader-2x37-d1.1-polygon-outline,89a40544-ebf7-40b5-9119-6cad09a621a4
 pkg-pinheader-2x37-d1.1-text-name,8f02b6c1-7a58-4f4f-a5f5-6d9f4e7ece96
 pkg-pinheader-2x37-d1.1-text-value,0118c144-c2aa-4a84-9bc4-15e4f7fccd49
 pkg-pinheader-2x38-d0.9-3d,1ce7c8b2-0603-41bb-9ac9-87cc478ac610
@@ -14620,6 +15040,8 @@ pkg-pinheader-2x38-d0.9-pad-8,eccb7fdd-6783-4ebb-a8a1-ec909d6dde95
 pkg-pinheader-2x38-d0.9-pad-9,e1abfb69-037e-4ce4-a265-495680f6de30
 pkg-pinheader-2x38-d0.9-pkg,519e3649-dadf-4713-ae1a-dd0120318a2b
 pkg-pinheader-2x38-d0.9-polygon-contour,8a799673-df42-46b3-baf3-8643c98c4fd3
+pkg-pinheader-2x38-d0.9-polygon-courtyard,748695a1-62c6-4f1b-a166-da74f44de766
+pkg-pinheader-2x38-d0.9-polygon-outline,ca719788-ce05-4ee7-b3a4-df39a8adb343
 pkg-pinheader-2x38-d0.9-text-name,93ad951a-d6ce-46ae-9d90-4716e7ca582e
 pkg-pinheader-2x38-d0.9-text-value,be057999-4de7-4a48-b914-a70d700979b2
 pkg-pinheader-2x38-d1.0-3d,fb42906b-408e-4b9c-8cee-7b22d990c03c
@@ -14702,6 +15124,8 @@ pkg-pinheader-2x38-d1.0-pad-8,8bde6de7-ace7-484f-a4bd-b20aa2f1db84
 pkg-pinheader-2x38-d1.0-pad-9,b10a73bf-9e25-4d6d-a8af-8db4ac32cea8
 pkg-pinheader-2x38-d1.0-pkg,9fde083c-1a80-43dc-b7f3-6890517502d1
 pkg-pinheader-2x38-d1.0-polygon-contour,a6fe4830-5206-4c98-894f-887f4d1d9dc1
+pkg-pinheader-2x38-d1.0-polygon-courtyard,c1d7bc80-bee3-4a3d-990d-fe743d6a6c8e
+pkg-pinheader-2x38-d1.0-polygon-outline,9c785397-fcb7-45fd-9910-0775451c193c
 pkg-pinheader-2x38-d1.0-text-name,a7df985a-02e7-48f5-afd7-5bb28a398080
 pkg-pinheader-2x38-d1.0-text-value,f71180a8-3c24-4831-ad45-6f3da73057c1
 pkg-pinheader-2x38-d1.1-3d,994748a1-3fca-4b9e-aeb3-d96bf7be5559
@@ -14784,6 +15208,8 @@ pkg-pinheader-2x38-d1.1-pad-8,dd1b61d2-dc0c-4ec0-88c0-8553edd82ee1
 pkg-pinheader-2x38-d1.1-pad-9,b162b7ce-ad87-458e-95b4-b79643dd1147
 pkg-pinheader-2x38-d1.1-pkg,71591344-2a8e-4683-93d6-7df1ee2cf015
 pkg-pinheader-2x38-d1.1-polygon-contour,9ca82fbe-b323-4f27-8382-f259824620bd
+pkg-pinheader-2x38-d1.1-polygon-courtyard,38e34f5d-a8d8-47c4-96d8-5a5706a7cb59
+pkg-pinheader-2x38-d1.1-polygon-outline,c76e7499-e558-4adf-9da7-ddeb3a597b15
 pkg-pinheader-2x38-d1.1-text-name,ce37be7e-c18d-421e-87d6-967e050e6863
 pkg-pinheader-2x38-d1.1-text-value,7d734431-4acf-4f3e-900d-5dcb67d4107d
 pkg-pinheader-2x39-d0.9-3d,d7a76442-5ecb-4035-9e70-c58704a397ec
@@ -14868,6 +15294,8 @@ pkg-pinheader-2x39-d0.9-pad-8,60413d23-58e5-4c63-bcbe-8333dbabd865
 pkg-pinheader-2x39-d0.9-pad-9,132c93ba-b1c5-415f-b485-b70a29aed321
 pkg-pinheader-2x39-d0.9-pkg,d31d1d33-f0bd-4d43-8bbb-3c26c3bc62b1
 pkg-pinheader-2x39-d0.9-polygon-contour,cc006eaa-828c-406b-9acc-ed11ee4e7e8d
+pkg-pinheader-2x39-d0.9-polygon-courtyard,77d5693e-573f-4112-8243-508e97843727
+pkg-pinheader-2x39-d0.9-polygon-outline,a35c930c-dae6-45ff-aa83-a35c700ebaa8
 pkg-pinheader-2x39-d0.9-text-name,ce1b53c9-781d-4079-85c2-80041c56dc3c
 pkg-pinheader-2x39-d0.9-text-value,4d7a75d5-4aac-415c-be13-472933ee8eb7
 pkg-pinheader-2x39-d1.0-3d,bc797871-def2-4072-a943-efb9ee8cc1e6
@@ -14952,6 +15380,8 @@ pkg-pinheader-2x39-d1.0-pad-8,a4216dd6-d82a-4ef4-ae6e-3ba02b876c73
 pkg-pinheader-2x39-d1.0-pad-9,e2331f36-d305-4861-926c-cab05bdbaa49
 pkg-pinheader-2x39-d1.0-pkg,b740311f-1aa1-4bcf-bcab-9205eb1daddc
 pkg-pinheader-2x39-d1.0-polygon-contour,9d2591af-d48e-4af9-80c2-16b1830a027f
+pkg-pinheader-2x39-d1.0-polygon-courtyard,69f4bb50-b766-4207-acbc-d3b3fe15e565
+pkg-pinheader-2x39-d1.0-polygon-outline,cdc2c7d1-2173-499d-bbfb-febf60b6c255
 pkg-pinheader-2x39-d1.0-text-name,564e3b6f-7f71-47a1-8e97-84613a68bd90
 pkg-pinheader-2x39-d1.0-text-value,7b279e0d-9035-4844-9175-96b52d25e471
 pkg-pinheader-2x39-d1.1-3d,ddd013ec-d63f-46df-b323-c3d5b3261bf4
@@ -15036,6 +15466,8 @@ pkg-pinheader-2x39-d1.1-pad-8,e94b8d41-4bee-4048-956f-234ea6917009
 pkg-pinheader-2x39-d1.1-pad-9,63404b25-f139-4239-8501-0a3fd234bc55
 pkg-pinheader-2x39-d1.1-pkg,61686530-abd8-40cd-aee3-b15200487b7a
 pkg-pinheader-2x39-d1.1-polygon-contour,e6a496e4-eaf1-4191-8cae-2cc3f05b6ac5
+pkg-pinheader-2x39-d1.1-polygon-courtyard,de25256b-4567-4399-9290-8094510353b8
+pkg-pinheader-2x39-d1.1-polygon-outline,d288fdd4-eacd-4822-88a6-3634534c6272
 pkg-pinheader-2x39-d1.1-text-name,cf7f7a38-4210-4c7a-89f3-ff1fe678670a
 pkg-pinheader-2x39-d1.1-text-value,700fcf30-a5ad-4526-90cb-8cae7e970398
 pkg-pinheader-2x4-d0.9-3d,3334dc9e-c664-40a9-b8a8-9fd76192cdca
@@ -15050,6 +15482,8 @@ pkg-pinheader-2x4-d0.9-pad-6,d4fccd98-8365-4751-bc66-f66a76738bd6
 pkg-pinheader-2x4-d0.9-pad-7,68824370-ec5e-47bf-8056-ce41b229fa30
 pkg-pinheader-2x4-d0.9-pkg,ff6391fd-403d-4c8b-97f2-452c1d9779bb
 pkg-pinheader-2x4-d0.9-polygon-contour,cc56e2cd-6f6c-4721-b69d-bcdd3f1a2da4
+pkg-pinheader-2x4-d0.9-polygon-courtyard,caa3e6eb-592e-4613-98b6-e767c6088cec
+pkg-pinheader-2x4-d0.9-polygon-outline,dd5a9fa2-6b9b-42c8-b82a-60b2d2ff4bdb
 pkg-pinheader-2x4-d0.9-text-name,656debeb-6be0-40f0-aa04-9c1676f7e7c4
 pkg-pinheader-2x4-d0.9-text-value,7cd352fe-cdb7-4e9d-a3f8-9a85437f6319
 pkg-pinheader-2x4-d1.0-3d,01a7670b-5e4f-4010-805c-717f09261f66
@@ -15064,6 +15498,8 @@ pkg-pinheader-2x4-d1.0-pad-6,682b0958-c4f8-48de-9e76-873dbab82468
 pkg-pinheader-2x4-d1.0-pad-7,bf19eb1b-9108-4de3-b92b-d7bcd985957a
 pkg-pinheader-2x4-d1.0-pkg,d4bb6869-5a14-4db2-bd99-9ff9698ba4ed
 pkg-pinheader-2x4-d1.0-polygon-contour,bc767f97-4b5d-4e7c-8d6c-82dfe021cdcf
+pkg-pinheader-2x4-d1.0-polygon-courtyard,7ac22745-41e6-43b7-9447-2750ddb93519
+pkg-pinheader-2x4-d1.0-polygon-outline,12d6694e-ba58-4237-8c17-213d8f0a092a
 pkg-pinheader-2x4-d1.0-text-name,b8118748-8204-49b5-9fbd-c00d19dc932d
 pkg-pinheader-2x4-d1.0-text-value,6e0bd2d7-55c7-4659-9288-05881948bce2
 pkg-pinheader-2x4-d1.1-3d,35d90b3e-9d97-4ec7-a01b-e66d29f10ed8
@@ -15078,6 +15514,8 @@ pkg-pinheader-2x4-d1.1-pad-6,f39c5d49-a6dd-413e-860d-ed09aa8c847f
 pkg-pinheader-2x4-d1.1-pad-7,df641c1f-26f9-4d02-ae0f-e54d64224e52
 pkg-pinheader-2x4-d1.1-pkg,54fb350c-f00e-4f67-8f7d-918626f7c6d0
 pkg-pinheader-2x4-d1.1-polygon-contour,eb66b93b-a6df-4a6a-9a2e-afd492a3411d
+pkg-pinheader-2x4-d1.1-polygon-courtyard,29f991e1-4457-48f2-97fc-1abe87a1435a
+pkg-pinheader-2x4-d1.1-polygon-outline,47a92eca-b9a7-4972-981d-2cd90ad20083
 pkg-pinheader-2x4-d1.1-text-name,aede7d27-a22a-4443-8101-a8fa2d3b9ee0
 pkg-pinheader-2x4-d1.1-text-value,98f7cd21-6f48-47c0-adfa-54e4f20d2019
 pkg-pinheader-2x40-d0.9-3d,9163c999-ffd2-4f67-b40c-b59de3547bd4
@@ -15164,6 +15602,8 @@ pkg-pinheader-2x40-d0.9-pad-8,35127a7c-b71b-4823-9ea9-3ed5516c93fc
 pkg-pinheader-2x40-d0.9-pad-9,9ba3e44f-2381-4967-bec4-4aed007ada2e
 pkg-pinheader-2x40-d0.9-pkg,ab0d7b78-5614-44af-bd40-95ee0ffb5d8c
 pkg-pinheader-2x40-d0.9-polygon-contour,b113ac38-a4b0-4843-b8c0-66abb9082c65
+pkg-pinheader-2x40-d0.9-polygon-courtyard,9e63e019-9af0-4aad-b47c-9d0c2ed3670a
+pkg-pinheader-2x40-d0.9-polygon-outline,8566c665-d349-44a0-be7e-271694904d02
 pkg-pinheader-2x40-d0.9-text-name,aaf24e18-1754-4775-8cf0-40f2fcd3ea34
 pkg-pinheader-2x40-d0.9-text-value,46ceedec-8c37-4685-8111-68c821388ede
 pkg-pinheader-2x40-d1.0-3d,907513ff-a324-41e5-8969-6211d2daa62a
@@ -15250,6 +15690,8 @@ pkg-pinheader-2x40-d1.0-pad-8,1c3685f7-4d6c-451a-a47e-ca5ce91e0b22
 pkg-pinheader-2x40-d1.0-pad-9,39b29a3d-91b6-4fe5-83e0-0ba2da3ba292
 pkg-pinheader-2x40-d1.0-pkg,75dced91-0650-497a-b5df-d8768d4a4e3e
 pkg-pinheader-2x40-d1.0-polygon-contour,eadfdb80-e7c3-4a55-b901-74622664c394
+pkg-pinheader-2x40-d1.0-polygon-courtyard,07b456f5-e98b-4c73-a03f-0cddd3108926
+pkg-pinheader-2x40-d1.0-polygon-outline,c7af4173-d9bd-447f-914f-0c3b35dce08d
 pkg-pinheader-2x40-d1.0-text-name,d28ede78-4c8e-4e3d-beae-ec999eb3473b
 pkg-pinheader-2x40-d1.0-text-value,b43a65f1-3441-4ba7-ace8-bc3f14a16b57
 pkg-pinheader-2x40-d1.1-3d,b826122c-27e7-41a9-9953-67b8604564fe
@@ -15336,6 +15778,8 @@ pkg-pinheader-2x40-d1.1-pad-8,56f1d34f-7b17-419a-8b45-00f1774cca4f
 pkg-pinheader-2x40-d1.1-pad-9,93351710-86eb-4e19-8179-09447737ae6b
 pkg-pinheader-2x40-d1.1-pkg,50deb76a-3d2c-4a72-925e-346020a83e02
 pkg-pinheader-2x40-d1.1-polygon-contour,4560ede1-0909-4f56-b2fb-c6c3181d0219
+pkg-pinheader-2x40-d1.1-polygon-courtyard,d356dfae-e3f0-45aa-84ab-7a3df69bb8de
+pkg-pinheader-2x40-d1.1-polygon-outline,1144c1fa-99fe-4dd6-98b4-af048f22ffad
 pkg-pinheader-2x40-d1.1-text-name,5935b65f-9b77-4610-85d7-a7d1bb03a27b
 pkg-pinheader-2x40-d1.1-text-value,212ae974-abe2-4e06-a9f5-cbfb5b7acc2c
 pkg-pinheader-2x5-d0.9-3d,037ba082-81c0-481e-a36b-4226e31be739
@@ -15352,6 +15796,8 @@ pkg-pinheader-2x5-d0.9-pad-8,571cba1e-327f-4437-a6c1-94a2d6b50e0f
 pkg-pinheader-2x5-d0.9-pad-9,d4402a53-9424-4a18-9da5-17636bab6a3c
 pkg-pinheader-2x5-d0.9-pkg,de5f39c8-bc20-446c-8b73-6bc65eae8842
 pkg-pinheader-2x5-d0.9-polygon-contour,6220774c-e5ee-4f64-acb2-e9bbfcef7b0e
+pkg-pinheader-2x5-d0.9-polygon-courtyard,5268c92b-ac5c-467d-b5c5-16c435c9bcc6
+pkg-pinheader-2x5-d0.9-polygon-outline,b23f4a3d-9afc-4fbb-abab-7c6d7ad4553e
 pkg-pinheader-2x5-d0.9-text-name,f5997caf-46a8-473f-974b-f457f7cb734d
 pkg-pinheader-2x5-d0.9-text-value,5a8ff803-42d9-4d9f-877c-13e6229af66b
 pkg-pinheader-2x5-d1.0-3d,12af0f97-49a6-44aa-916c-dcb3ac99bc5c
@@ -15368,6 +15814,8 @@ pkg-pinheader-2x5-d1.0-pad-8,ad381d92-64fe-46e3-8c73-1c2e92b9ec79
 pkg-pinheader-2x5-d1.0-pad-9,81d7b96f-02cc-4c8a-a870-b6cab965f6ab
 pkg-pinheader-2x5-d1.0-pkg,25426bd1-5db2-456b-9c1e-73181b7511ae
 pkg-pinheader-2x5-d1.0-polygon-contour,b3e23090-2e7a-488f-8252-ea3de3b32370
+pkg-pinheader-2x5-d1.0-polygon-courtyard,82c82285-c432-4156-b306-8e90b7d996c7
+pkg-pinheader-2x5-d1.0-polygon-outline,35c26ee4-6e37-4b3a-809b-88400e0f2715
 pkg-pinheader-2x5-d1.0-text-name,8c3a8850-38df-4bc4-85b5-8cb67e603cdc
 pkg-pinheader-2x5-d1.0-text-value,628b4742-1fda-4559-b9f0-2f84706fe630
 pkg-pinheader-2x5-d1.1-3d,75e94231-6211-4850-890d-f633a8a78bce
@@ -15384,6 +15832,8 @@ pkg-pinheader-2x5-d1.1-pad-8,790ea493-dad4-4123-b981-343a8858e0c2
 pkg-pinheader-2x5-d1.1-pad-9,ad70b3ed-9718-48e9-88bf-62cc5974f555
 pkg-pinheader-2x5-d1.1-pkg,e4759eba-09b3-4bca-84bf-c3e4b3c05213
 pkg-pinheader-2x5-d1.1-polygon-contour,92b42e85-127e-4948-8a91-f20ece6aeb85
+pkg-pinheader-2x5-d1.1-polygon-courtyard,bbec96c8-62b8-48f8-bd7d-7b05464948fa
+pkg-pinheader-2x5-d1.1-polygon-outline,c141aec3-0de4-46f7-aa48-d51e85fbe838
 pkg-pinheader-2x5-d1.1-text-name,0ebae0c1-bfe1-4ca9-8cd1-702ca76b933b
 pkg-pinheader-2x5-d1.1-text-value,2f5921a0-d34a-446a-9771-f44aec114a7a
 pkg-pinheader-2x6-d0.9-3d,5a20a0bc-96b1-41e1-af3a-7a722c43c115
@@ -15402,6 +15852,8 @@ pkg-pinheader-2x6-d0.9-pad-8,a1354838-274e-458b-9727-138213a84dae
 pkg-pinheader-2x6-d0.9-pad-9,ad006dbf-e56b-4c99-bc3d-ac533c447d29
 pkg-pinheader-2x6-d0.9-pkg,3ad9a444-471f-4145-ac03-d5a2e06d6ec4
 pkg-pinheader-2x6-d0.9-polygon-contour,fdf646af-ce9c-4e74-b5c9-d7977077bb78
+pkg-pinheader-2x6-d0.9-polygon-courtyard,9e619413-c65d-4462-bfa8-b6d91a07cce8
+pkg-pinheader-2x6-d0.9-polygon-outline,e7f59bf2-5cdd-4c6d-9112-de5d28e8eb48
 pkg-pinheader-2x6-d0.9-text-name,062f9613-22de-4d37-912d-ad88603ec50a
 pkg-pinheader-2x6-d0.9-text-value,9d94ed6b-409b-4bf7-ba31-26e5c6950a7f
 pkg-pinheader-2x6-d1.0-3d,32f24a8f-1eb0-4e44-8dc5-aaa1bdba9eb0
@@ -15420,6 +15872,8 @@ pkg-pinheader-2x6-d1.0-pad-8,0e2bce5b-a1cc-46f8-8e71-c0b9aba097a3
 pkg-pinheader-2x6-d1.0-pad-9,83cf5097-5572-49e4-8035-ccc5159d1670
 pkg-pinheader-2x6-d1.0-pkg,26a8a29e-096f-44f3-bc8d-0185ef362103
 pkg-pinheader-2x6-d1.0-polygon-contour,fa312159-1f5a-4df8-a273-518a27a8d384
+pkg-pinheader-2x6-d1.0-polygon-courtyard,73df82e5-243e-4006-a263-207b88808913
+pkg-pinheader-2x6-d1.0-polygon-outline,197c0f43-1f46-4f89-bc33-3824faf0271d
 pkg-pinheader-2x6-d1.0-text-name,a3e09cca-b13d-49e4-a951-c09c68174bfa
 pkg-pinheader-2x6-d1.0-text-value,af8489da-ecfb-473c-ada8-5ce478f96334
 pkg-pinheader-2x6-d1.1-3d,95fab9c3-b8fe-4cdd-92a2-828e52a0d7e0
@@ -15438,6 +15892,8 @@ pkg-pinheader-2x6-d1.1-pad-8,a2fc3d62-5397-4e9a-9caa-ae171548125a
 pkg-pinheader-2x6-d1.1-pad-9,f45c0504-cb09-4842-a464-6e7f3f5720f0
 pkg-pinheader-2x6-d1.1-pkg,7a3ee1d5-e3f6-422a-bb5c-1285f0695518
 pkg-pinheader-2x6-d1.1-polygon-contour,c29c02bc-caea-4fbd-99b3-a8150f0c22bd
+pkg-pinheader-2x6-d1.1-polygon-courtyard,21a81cd6-47ca-46f2-99c2-5b14f2c9e47c
+pkg-pinheader-2x6-d1.1-polygon-outline,bff3f868-600a-47c8-86e2-46383a6cc40a
 pkg-pinheader-2x6-d1.1-text-name,ae5fe670-adc8-4fed-ad63-e1f19b7b0f50
 pkg-pinheader-2x6-d1.1-text-value,3f88cd66-c737-4ed7-b07e-a8145de0501d
 pkg-pinheader-2x7-d0.9-3d,502af276-e65b-4465-a128-1ab4d5af455a
@@ -15458,6 +15914,8 @@ pkg-pinheader-2x7-d0.9-pad-8,0841a9f8-36bf-4354-8207-8a3bb4e5e280
 pkg-pinheader-2x7-d0.9-pad-9,55ebde54-c5b0-4e47-bf40-26b3859eee89
 pkg-pinheader-2x7-d0.9-pkg,87365869-05ee-42f1-ad48-870f63218327
 pkg-pinheader-2x7-d0.9-polygon-contour,3ef9ec94-2a59-41ab-b21d-b653ace690a4
+pkg-pinheader-2x7-d0.9-polygon-courtyard,9600cd38-98d6-4d50-a241-ecf7b49cc4b2
+pkg-pinheader-2x7-d0.9-polygon-outline,cbbe89a8-a063-46dd-b238-500ca231d0d0
 pkg-pinheader-2x7-d0.9-text-name,b7db8bd0-00da-4126-ac67-84808729f318
 pkg-pinheader-2x7-d0.9-text-value,b9fb9b92-3cc8-4ad2-b014-41a08c202744
 pkg-pinheader-2x7-d1.0-3d,6d8c653e-e9a2-4623-89e7-40d3b10163ab
@@ -15478,6 +15936,8 @@ pkg-pinheader-2x7-d1.0-pad-8,2dcb75eb-e10a-4678-aaf1-e13b32d34e98
 pkg-pinheader-2x7-d1.0-pad-9,8b73f9de-e832-40c4-ae13-955045e51e04
 pkg-pinheader-2x7-d1.0-pkg,f7fcdefd-6847-4fe8-9d93-4b661bda5e7c
 pkg-pinheader-2x7-d1.0-polygon-contour,9ce0e235-0937-4538-993b-711388a58437
+pkg-pinheader-2x7-d1.0-polygon-courtyard,c70b50b9-4117-4342-86d2-cfff99d947c4
+pkg-pinheader-2x7-d1.0-polygon-outline,e57e3e3d-9673-4a1f-b1b7-e60d7e648666
 pkg-pinheader-2x7-d1.0-text-name,50831ea2-2e90-408f-98b4-241bb583c783
 pkg-pinheader-2x7-d1.0-text-value,25e759da-8e66-4155-87e2-2326633cb755
 pkg-pinheader-2x7-d1.1-3d,fdbc7793-27a6-4375-a9ed-ec2e048b36ec
@@ -15498,6 +15958,8 @@ pkg-pinheader-2x7-d1.1-pad-8,4e01ceb0-27fc-49e7-a5c8-3b1a63027984
 pkg-pinheader-2x7-d1.1-pad-9,677cdaee-d3b2-4b24-b9c6-8db20383ca7f
 pkg-pinheader-2x7-d1.1-pkg,28304b8e-e459-466b-84fd-edd4f52c6ec0
 pkg-pinheader-2x7-d1.1-polygon-contour,173e0fe3-718b-431e-952d-53dce33bd656
+pkg-pinheader-2x7-d1.1-polygon-courtyard,ef092251-6f87-431b-a8f1-a92066b6f7fb
+pkg-pinheader-2x7-d1.1-polygon-outline,161ed30d-8e8e-48a0-95be-cec1628a0281
 pkg-pinheader-2x7-d1.1-text-name,a1aa80dc-1698-4f12-8142-788f0637925e
 pkg-pinheader-2x7-d1.1-text-value,f71f11d8-6cf7-4865-9f97-ea3b9a21eea0
 pkg-pinheader-2x8-d0.9-3d,834f394c-dd0a-42bb-b875-ba4b440e92dc
@@ -15520,6 +15982,8 @@ pkg-pinheader-2x8-d0.9-pad-8,b4afab01-b36d-41bc-986a-eb22017a983d
 pkg-pinheader-2x8-d0.9-pad-9,4a3d337a-cf50-42d8-86d9-d6766244b556
 pkg-pinheader-2x8-d0.9-pkg,20b7b6c7-e763-4cc3-9eef-1527d385757c
 pkg-pinheader-2x8-d0.9-polygon-contour,92f62929-705b-43d6-ae34-e5a9f8aacfc6
+pkg-pinheader-2x8-d0.9-polygon-courtyard,b30daceb-5570-475e-9997-d72bd05a5e40
+pkg-pinheader-2x8-d0.9-polygon-outline,90973755-2637-4999-a238-8617f2e10e85
 pkg-pinheader-2x8-d0.9-text-name,f78a049e-aae5-441b-834d-3e55eb0cb451
 pkg-pinheader-2x8-d0.9-text-value,1283270a-1879-42c9-bc8f-c4ec0e1b2e98
 pkg-pinheader-2x8-d1.0-3d,91e76371-e23e-42c8-b44f-110dce22e766
@@ -15542,6 +16006,8 @@ pkg-pinheader-2x8-d1.0-pad-8,d58dd14a-c6a9-4cd8-8a21-4387df622e8e
 pkg-pinheader-2x8-d1.0-pad-9,d88896a4-fc3c-4ef6-8668-94e6a7fb52c3
 pkg-pinheader-2x8-d1.0-pkg,b8fa88ac-f3dd-4dd1-9ccd-3901c6852ad0
 pkg-pinheader-2x8-d1.0-polygon-contour,ef6dee49-8f73-4f21-a807-1e66b43663c2
+pkg-pinheader-2x8-d1.0-polygon-courtyard,695ea536-ecba-4ca0-8b0b-19116cf0b463
+pkg-pinheader-2x8-d1.0-polygon-outline,b0e6871d-c65c-4229-941c-44d0df4416f8
 pkg-pinheader-2x8-d1.0-text-name,1e7fc9bb-63c8-41de-9743-cffe46abbfb2
 pkg-pinheader-2x8-d1.0-text-value,1444046a-d95d-4bb4-8773-5de75adbfad2
 pkg-pinheader-2x8-d1.1-3d,018cfe1a-da55-4ff1-b2e9-5adbf40a101e
@@ -15564,6 +16030,8 @@ pkg-pinheader-2x8-d1.1-pad-8,23e9576e-9126-43e4-9d5c-11f00821021f
 pkg-pinheader-2x8-d1.1-pad-9,6632b78f-ed9a-4297-9186-a4b972182cef
 pkg-pinheader-2x8-d1.1-pkg,897500cb-1fd5-4b71-8f20-8bd7df92d1e1
 pkg-pinheader-2x8-d1.1-polygon-contour,da75ba9f-a11b-40d2-bb31-964d5805d5da
+pkg-pinheader-2x8-d1.1-polygon-courtyard,14e2818b-8241-4790-845f-196fe13867fc
+pkg-pinheader-2x8-d1.1-polygon-outline,6c0155db-a4e7-4f2e-9948-7c12b48c0075
 pkg-pinheader-2x8-d1.1-text-name,932f1c71-731d-42de-8ea0-fe3dad8f2b98
 pkg-pinheader-2x8-d1.1-text-value,a79f75e4-944a-4959-8c70-599377368953
 pkg-pinheader-2x9-d0.9-3d,1db1b25e-22f2-4f7b-aa5b-245f37bc7058
@@ -15588,6 +16056,8 @@ pkg-pinheader-2x9-d0.9-pad-8,b901c38d-3453-438a-a4da-f97164059432
 pkg-pinheader-2x9-d0.9-pad-9,8e524b1a-ff49-42c0-9eac-6c80dbfaa4e4
 pkg-pinheader-2x9-d0.9-pkg,f03c17a0-5960-4472-97eb-f9c6f279d8ed
 pkg-pinheader-2x9-d0.9-polygon-contour,7b863033-d2c7-4e91-b647-c8508ca8f169
+pkg-pinheader-2x9-d0.9-polygon-courtyard,bb85f6e8-6f7a-48ef-bb4a-1c8b3e2727d0
+pkg-pinheader-2x9-d0.9-polygon-outline,176c2ec8-909c-4092-9050-4509e595474c
 pkg-pinheader-2x9-d0.9-text-name,4a49a418-98d7-4a78-a790-4ddddb7083aa
 pkg-pinheader-2x9-d0.9-text-value,cee80770-c863-49b8-aa1a-223ffe4c3486
 pkg-pinheader-2x9-d1.0-3d,486e39d9-f80d-4a12-843d-3f9d8e5e4867
@@ -15612,6 +16082,8 @@ pkg-pinheader-2x9-d1.0-pad-8,65fe8baa-6979-4a7c-9960-2f899b187abf
 pkg-pinheader-2x9-d1.0-pad-9,11e41519-9b47-4add-a4a5-fdd6ca035866
 pkg-pinheader-2x9-d1.0-pkg,5c2d1e07-40a6-41e1-bf7b-6dd74bad9c42
 pkg-pinheader-2x9-d1.0-polygon-contour,c941aef6-f116-4ee8-9e5e-10fc3eb953c4
+pkg-pinheader-2x9-d1.0-polygon-courtyard,a964d9d8-14fe-495d-a0d6-b3170e5d88ab
+pkg-pinheader-2x9-d1.0-polygon-outline,73786654-d6ad-4ecb-b7fc-c728040dc37d
 pkg-pinheader-2x9-d1.0-text-name,848b29e3-f673-46f6-9258-51fad7c5a966
 pkg-pinheader-2x9-d1.0-text-value,760ceb81-b9e1-4167-a5a0-8482b251f66d
 pkg-pinheader-2x9-d1.1-3d,33f068c4-e4da-4bb4-8971-17a55030b207
@@ -15636,6 +16108,8 @@ pkg-pinheader-2x9-d1.1-pad-8,6b69e92e-f164-4f15-acd9-cac11c3333ef
 pkg-pinheader-2x9-d1.1-pad-9,19e0eecd-44b4-4081-8c15-9d817697a198
 pkg-pinheader-2x9-d1.1-pkg,52857568-be2d-41b4-815f-b1531c690342
 pkg-pinheader-2x9-d1.1-polygon-contour,55c2e9ae-62c8-46cb-a150-1385dc93cd92
+pkg-pinheader-2x9-d1.1-polygon-courtyard,9f8201fa-5973-4ef2-bd6f-fe26dfd04468
+pkg-pinheader-2x9-d1.1-polygon-outline,e8ad88a2-8379-49f5-a373-60932497e205
 pkg-pinheader-2x9-d1.1-text-name,445817a4-650f-4aa9-ba3e-d3afc9d9559e
 pkg-pinheader-2x9-d1.1-text-value,868ca6ee-c0e3-49db-9664-172545d842fd
 pkg-pinsocket-1x1-d0.9-3d,12892254-5813-4264-8353-4fb0ebba7532
@@ -15643,6 +16117,8 @@ pkg-pinsocket-1x1-d0.9-footprint-default,6497783c-458b-481d-9042-9c6a18aae2fc
 pkg-pinsocket-1x1-d0.9-pad-0,2f89c577-770d-4f78-8174-76de31093e02
 pkg-pinsocket-1x1-d0.9-pkg,f459433d-9ecd-4d7f-b3f9-9852d847f646
 pkg-pinsocket-1x1-d0.9-polygon-contour,0651f175-bf83-4aa1-ad84-e2471e7d5288
+pkg-pinsocket-1x1-d0.9-polygon-courtyard,d3d42302-b3fb-4c49-be11-c128fb1b842a
+pkg-pinsocket-1x1-d0.9-polygon-outline,1ba5c288-d588-48ce-b555-59e8b2184059
 pkg-pinsocket-1x1-d0.9-text-name,b336f217-3458-459f-806c-9d655116930d
 pkg-pinsocket-1x1-d0.9-text-value,34da0d0f-4204-4e6d-8a66-3a530a73472b
 pkg-pinsocket-1x1-d1.0-3d,7bbe6703-f533-4d53-95ab-2e555faa4972
@@ -15650,6 +16126,8 @@ pkg-pinsocket-1x1-d1.0-footprint-default,84c20d6c-2767-4a71-9456-c1bbb88e09c7
 pkg-pinsocket-1x1-d1.0-pad-0,bd68803a-85dd-472c-9db6-3174de5a473e
 pkg-pinsocket-1x1-d1.0-pkg,d87ff56d-134c-4b81-9f55-916abbd27a90
 pkg-pinsocket-1x1-d1.0-polygon-contour,b2d136a5-1d60-4a23-9e58-4d333042f687
+pkg-pinsocket-1x1-d1.0-polygon-courtyard,aaf3be5a-ce23-48e6-ab37-fc1aa7019422
+pkg-pinsocket-1x1-d1.0-polygon-outline,6e2a99d6-5561-41ea-82d6-301fcd93ec85
 pkg-pinsocket-1x1-d1.0-text-name,59e4c81b-d652-4284-9d11-281094028262
 pkg-pinsocket-1x1-d1.0-text-value,1e78b8b4-4217-46b4-9ce3-0f53d7193653
 pkg-pinsocket-1x1-d1.1-3d,b6a08167-e365-41ee-87e2-2a3c2a8cf096
@@ -15657,6 +16135,8 @@ pkg-pinsocket-1x1-d1.1-footprint-default,8f2f1430-2129-4712-9f7d-ec5219d90f7e
 pkg-pinsocket-1x1-d1.1-pad-0,961c4885-e824-420a-8e1a-252b9675a7c1
 pkg-pinsocket-1x1-d1.1-pkg,1b2701ad-2408-4dc1-b9d7-119a9f20a874
 pkg-pinsocket-1x1-d1.1-polygon-contour,13be0f55-54f8-46a0-bcaf-ab740d515b04
+pkg-pinsocket-1x1-d1.1-polygon-courtyard,08c3a29d-6100-466b-b5a0-2aa52c9217d8
+pkg-pinsocket-1x1-d1.1-polygon-outline,964a9f10-16f2-48ef-9cfb-4c8951371f93
 pkg-pinsocket-1x1-d1.1-text-name,05e23895-71b8-42dc-bf68-4366891b11d4
 pkg-pinsocket-1x1-d1.1-text-value,485fdbe4-a0ee-41b1-9061-b9cdcfa6e64f
 pkg-pinsocket-1x10-d0.9-3d,6be846d6-8f4f-43b2-a28f-ffa7fd7432ef
@@ -15673,6 +16153,8 @@ pkg-pinsocket-1x10-d0.9-pad-8,b6424123-64ea-4360-9469-ae77270430ea
 pkg-pinsocket-1x10-d0.9-pad-9,b0b2bde6-47da-438c-aa05-19167f60fd40
 pkg-pinsocket-1x10-d0.9-pkg,4a052fa2-2abb-4d67-abae-006f13c8051d
 pkg-pinsocket-1x10-d0.9-polygon-contour,01b183e4-ddb4-4dcd-988f-1385fe6057ec
+pkg-pinsocket-1x10-d0.9-polygon-courtyard,32f0c373-c335-4abc-a6e6-65548e30f214
+pkg-pinsocket-1x10-d0.9-polygon-outline,4e93f7d0-a29c-47ea-8707-2a6285d8c1f1
 pkg-pinsocket-1x10-d0.9-text-name,ea7312e1-a19d-4faa-8c01-af950ff42da3
 pkg-pinsocket-1x10-d0.9-text-value,d320710a-9468-4beb-b0f8-9cda92ebe24d
 pkg-pinsocket-1x10-d1.0-3d,7e90728f-8d8e-4c82-a5a2-70ae69120e12
@@ -15689,6 +16171,8 @@ pkg-pinsocket-1x10-d1.0-pad-8,2331357f-8d57-444d-bdd2-ffb731a10fa8
 pkg-pinsocket-1x10-d1.0-pad-9,ac6b4e4a-f830-4944-8f0e-1d2c78bb2961
 pkg-pinsocket-1x10-d1.0-pkg,18e1b91d-bd61-4c36-83f3-680d31e44d4f
 pkg-pinsocket-1x10-d1.0-polygon-contour,d0ad4956-1c19-4225-b650-7c1c77582843
+pkg-pinsocket-1x10-d1.0-polygon-courtyard,8436d435-e4bd-4905-be00-9f2bc3da5237
+pkg-pinsocket-1x10-d1.0-polygon-outline,7ba07c33-0c33-4afd-979f-38fed3ebe959
 pkg-pinsocket-1x10-d1.0-text-name,c43d1680-3203-4911-9187-610c44e1dddd
 pkg-pinsocket-1x10-d1.0-text-value,a4638422-6f28-4db0-b3cd-511db3f99845
 pkg-pinsocket-1x10-d1.1-3d,3dc0a420-1d6b-46fa-9622-538b2d3102ae
@@ -15705,6 +16189,8 @@ pkg-pinsocket-1x10-d1.1-pad-8,99a4f08a-dfcf-4792-b719-21943e4a25d2
 pkg-pinsocket-1x10-d1.1-pad-9,238cf2e8-dc85-4aa2-a05b-0ef49674e84b
 pkg-pinsocket-1x10-d1.1-pkg,06b6e33b-ead4-48fe-994f-86ebb9b3e16f
 pkg-pinsocket-1x10-d1.1-polygon-contour,2115a27b-a411-400b-a112-75b15d4668dc
+pkg-pinsocket-1x10-d1.1-polygon-courtyard,47e3b143-2bcd-4cdc-909a-0f0e2714b996
+pkg-pinsocket-1x10-d1.1-polygon-outline,3899dd8a-7b72-4f68-b459-69e93f6dd8d3
 pkg-pinsocket-1x10-d1.1-text-name,d9f9703d-2ecb-42e0-bd12-c65c6c1bdf50
 pkg-pinsocket-1x10-d1.1-text-value,4d18f05b-2f52-471e-af6e-76856eeaab17
 pkg-pinsocket-1x11-d0.9-3d,b49f16bc-8da2-45b7-b90b-2542753a4d07
@@ -15722,6 +16208,8 @@ pkg-pinsocket-1x11-d0.9-pad-8,60960af5-59c8-4d7c-9667-b5fdcd909390
 pkg-pinsocket-1x11-d0.9-pad-9,d28b263f-88bf-48f6-a36e-93a7938982bc
 pkg-pinsocket-1x11-d0.9-pkg,2ecd91b9-af02-4591-8e56-6ee51dade6ea
 pkg-pinsocket-1x11-d0.9-polygon-contour,9b3c28e9-c087-4f80-aab6-b7f02145a513
+pkg-pinsocket-1x11-d0.9-polygon-courtyard,6ae93dfd-70cd-4a10-af92-7a88a06061c2
+pkg-pinsocket-1x11-d0.9-polygon-outline,91462a2e-c9ec-4666-9ef1-23948cc78128
 pkg-pinsocket-1x11-d0.9-text-name,002b6833-db82-40aa-9071-4c00fddb158c
 pkg-pinsocket-1x11-d0.9-text-value,55372dd8-61b5-4972-84af-393644abe85e
 pkg-pinsocket-1x11-d1.0-3d,e0c2e427-855d-4d68-a689-090390d74c70
@@ -15739,6 +16227,8 @@ pkg-pinsocket-1x11-d1.0-pad-8,668231f9-e0b3-4107-a861-b28bc9c8fb74
 pkg-pinsocket-1x11-d1.0-pad-9,772a2acd-4990-4d65-85f4-87d0591d0b1e
 pkg-pinsocket-1x11-d1.0-pkg,704dec79-3c67-4ff5-b3db-e9478b1c94a1
 pkg-pinsocket-1x11-d1.0-polygon-contour,dba968fe-92da-4ca6-b847-cb7aa0c0ff2b
+pkg-pinsocket-1x11-d1.0-polygon-courtyard,0cb8bb5f-a5dd-4f29-a296-b4aa31f1e087
+pkg-pinsocket-1x11-d1.0-polygon-outline,88433d73-a98b-48ca-a323-ecd743c4d4a2
 pkg-pinsocket-1x11-d1.0-text-name,8424f0b4-b2ec-430a-86e2-3cf203a0e3b3
 pkg-pinsocket-1x11-d1.0-text-value,ca124815-17ff-45ca-a59e-53f74df95946
 pkg-pinsocket-1x11-d1.1-3d,2c8061ce-2511-40ee-bdca-9ee479de68db
@@ -15756,6 +16246,8 @@ pkg-pinsocket-1x11-d1.1-pad-8,fabe1564-fb93-4d45-a182-e3fa3083478e
 pkg-pinsocket-1x11-d1.1-pad-9,1579ccec-2b63-46ea-9f43-36c82bcc5202
 pkg-pinsocket-1x11-d1.1-pkg,0b221e37-390d-4c9f-86da-428b680a79f1
 pkg-pinsocket-1x11-d1.1-polygon-contour,00e0bff9-169a-46bc-b692-75049e434de2
+pkg-pinsocket-1x11-d1.1-polygon-courtyard,6c6b99b4-e6fa-4f5a-8674-eec1b39b3d91
+pkg-pinsocket-1x11-d1.1-polygon-outline,e986609a-8d38-46f4-91a0-4c2c7a52a2f3
 pkg-pinsocket-1x11-d1.1-text-name,d232ac76-dfab-4883-a70b-00d61bbf1dfb
 pkg-pinsocket-1x11-d1.1-text-value,ee3698f6-4b49-42e9-b5ae-dfe75f98c459
 pkg-pinsocket-1x12-d0.9-3d,b6710652-31dd-4003-b6bf-2f91323c24f0
@@ -15774,6 +16266,8 @@ pkg-pinsocket-1x12-d0.9-pad-8,1d278370-1acd-4b09-83ef-86166bc9bec8
 pkg-pinsocket-1x12-d0.9-pad-9,3c37e2cc-0a72-41f4-99f1-cb57c7c6545d
 pkg-pinsocket-1x12-d0.9-pkg,c7363655-42cd-47b5-81c2-77621834debf
 pkg-pinsocket-1x12-d0.9-polygon-contour,f83a269a-eb3a-4477-a43c-94d98dd0e579
+pkg-pinsocket-1x12-d0.9-polygon-courtyard,3dcd8ea1-4596-42be-b9cb-2e5603aeec10
+pkg-pinsocket-1x12-d0.9-polygon-outline,95acb446-4c53-40bc-9a52-7a165ea8f07d
 pkg-pinsocket-1x12-d0.9-text-name,b845a3a2-cc50-466d-a492-74bd97ca412c
 pkg-pinsocket-1x12-d0.9-text-value,2089462c-d200-4555-8d4b-d3a378413c82
 pkg-pinsocket-1x12-d1.0-3d,8f27a2d1-e7a3-404a-8c56-51befd13fcc8
@@ -15792,6 +16286,8 @@ pkg-pinsocket-1x12-d1.0-pad-8,c1890df1-3ac8-4f17-a985-59aefb53a141
 pkg-pinsocket-1x12-d1.0-pad-9,739ce033-8a3c-42c2-9852-e33dd29193ea
 pkg-pinsocket-1x12-d1.0-pkg,ef77c553-7e3e-4b86-b56e-c0c07aa55107
 pkg-pinsocket-1x12-d1.0-polygon-contour,5924db0d-6f1b-4a4b-8e1e-a62b9f440a76
+pkg-pinsocket-1x12-d1.0-polygon-courtyard,99a8e284-5249-4e09-ad7a-bbb109f9a876
+pkg-pinsocket-1x12-d1.0-polygon-outline,3817b792-dbd9-4856-b427-38819c13731c
 pkg-pinsocket-1x12-d1.0-text-name,fb8d5e1c-4291-41d7-a538-2d176a09f850
 pkg-pinsocket-1x12-d1.0-text-value,529cc465-469e-4476-bf23-5a64c6299274
 pkg-pinsocket-1x12-d1.1-3d,e4f5585d-63d8-47c8-8d2d-84a1412f3505
@@ -15810,6 +16306,8 @@ pkg-pinsocket-1x12-d1.1-pad-8,f4a20fc4-aa67-4e29-963d-2faba2268da5
 pkg-pinsocket-1x12-d1.1-pad-9,2807dfe7-1caa-4481-ae81-5b762be0f22e
 pkg-pinsocket-1x12-d1.1-pkg,b4e92c64-18c4-44a6-aa39-d1be3e8c29bd
 pkg-pinsocket-1x12-d1.1-polygon-contour,354ce433-ac52-4427-ac69-345cbfbc258a
+pkg-pinsocket-1x12-d1.1-polygon-courtyard,b36240be-fa18-4b41-8309-0d91c0b03b3c
+pkg-pinsocket-1x12-d1.1-polygon-outline,bab0349c-0d55-4fa1-9bce-5aaf7753f0a0
 pkg-pinsocket-1x12-d1.1-text-name,a299062d-c0f9-4664-b644-55a9bd69bbc3
 pkg-pinsocket-1x12-d1.1-text-value,9a8f20ba-d87a-494a-8ede-18b9cc8205b1
 pkg-pinsocket-1x13-d0.9-3d,e1fae7ec-a29d-4e52-ba9a-6ef977734609
@@ -15829,6 +16327,8 @@ pkg-pinsocket-1x13-d0.9-pad-8,9f1ebc4e-af9b-4bf5-baaf-cb4ee119b544
 pkg-pinsocket-1x13-d0.9-pad-9,b762e6af-68c5-4a09-b3a0-bd5a5b92acd5
 pkg-pinsocket-1x13-d0.9-pkg,ddca2f2d-f0b7-4b32-97a5-0923e1b6b752
 pkg-pinsocket-1x13-d0.9-polygon-contour,fb2ca855-a623-4110-a67c-cbc42d0ae2e5
+pkg-pinsocket-1x13-d0.9-polygon-courtyard,903d3dce-077a-4b5d-9ddc-b83814367336
+pkg-pinsocket-1x13-d0.9-polygon-outline,1d187bd8-29b9-4a96-a408-0a3d540ac91b
 pkg-pinsocket-1x13-d0.9-text-name,26d41b9f-5a92-46fe-ac4d-8fa05a5cc93f
 pkg-pinsocket-1x13-d0.9-text-value,4d1174ff-b8e7-4d13-9d42-67ea40d7b32b
 pkg-pinsocket-1x13-d1.0-3d,c893ce60-a384-4942-b372-55104e95723d
@@ -15848,6 +16348,8 @@ pkg-pinsocket-1x13-d1.0-pad-8,bae8a973-271e-4bfd-8296-2beeef68b7f3
 pkg-pinsocket-1x13-d1.0-pad-9,f7738487-112d-4a9c-94a5-c79b66d5b690
 pkg-pinsocket-1x13-d1.0-pkg,3c3c07d2-4dc8-4944-8a27-6fa806c1bf50
 pkg-pinsocket-1x13-d1.0-polygon-contour,166daa4c-78f4-43ca-9200-c4fbbebe65f8
+pkg-pinsocket-1x13-d1.0-polygon-courtyard,68e2f595-9dd1-4e56-a9be-3a741fa85e4d
+pkg-pinsocket-1x13-d1.0-polygon-outline,ffcdb16e-bb95-4b09-abc1-038b3c497c9f
 pkg-pinsocket-1x13-d1.0-text-name,1184a731-c335-459d-be11-63f9e480d8d0
 pkg-pinsocket-1x13-d1.0-text-value,35347188-bee4-40cb-b711-ab7124193251
 pkg-pinsocket-1x13-d1.1-3d,a6de64f5-7670-4563-a24f-1ff907c6a30f
@@ -15867,6 +16369,8 @@ pkg-pinsocket-1x13-d1.1-pad-8,f3ef2e52-045e-43f3-ad84-1540812cf8fd
 pkg-pinsocket-1x13-d1.1-pad-9,122cf8b2-452b-489a-8cea-aa0004d6380a
 pkg-pinsocket-1x13-d1.1-pkg,36019d77-ca95-42fa-836a-46d63a3edd9f
 pkg-pinsocket-1x13-d1.1-polygon-contour,cd8518ee-4483-439b-9e6a-ccebed0350e9
+pkg-pinsocket-1x13-d1.1-polygon-courtyard,80e90ef5-1182-463d-8de9-97530c4968bb
+pkg-pinsocket-1x13-d1.1-polygon-outline,02307afa-b963-4d6f-9583-3b1da8f54d30
 pkg-pinsocket-1x13-d1.1-text-name,0759e156-f35f-4b46-9259-073821efa836
 pkg-pinsocket-1x13-d1.1-text-value,9aeaee0f-2914-428d-98be-d4d16d4dc44b
 pkg-pinsocket-1x14-d0.9-3d,ba3d6e0d-7beb-4543-9e1c-78382bf9dfb5
@@ -15887,6 +16391,8 @@ pkg-pinsocket-1x14-d0.9-pad-8,8956265f-6e93-4000-96fe-6e06d8b1a73f
 pkg-pinsocket-1x14-d0.9-pad-9,ef79b19b-ff51-42c8-bd23-98f04a72cffb
 pkg-pinsocket-1x14-d0.9-pkg,3dd8a1ba-092b-4f5d-9d32-eca08bc33b89
 pkg-pinsocket-1x14-d0.9-polygon-contour,9ea273d8-9fa4-4b65-a120-b1d3a7640465
+pkg-pinsocket-1x14-d0.9-polygon-courtyard,ca22d410-27c2-4488-90e4-52081489279a
+pkg-pinsocket-1x14-d0.9-polygon-outline,b92a6abd-9303-41d2-a435-ffa237aa5ce3
 pkg-pinsocket-1x14-d0.9-text-name,d4004c58-4047-4726-b3ee-1c39accbc1ee
 pkg-pinsocket-1x14-d0.9-text-value,5db3da0f-0ff3-4eca-a38d-4a19c26373ca
 pkg-pinsocket-1x14-d1.0-3d,c1d08c8a-2be6-45ef-8f93-aa241dcfd961
@@ -15907,6 +16413,8 @@ pkg-pinsocket-1x14-d1.0-pad-8,24f617b5-cc10-4502-9e9a-5d7b5a9eed6b
 pkg-pinsocket-1x14-d1.0-pad-9,5f0e0a21-bb2d-4902-8900-70b705607b3e
 pkg-pinsocket-1x14-d1.0-pkg,98e178a1-b98a-4b09-8f8d-e1d5f1b45771
 pkg-pinsocket-1x14-d1.0-polygon-contour,2e0d73c2-ce6c-4cb5-9c4d-321b8f0991e9
+pkg-pinsocket-1x14-d1.0-polygon-courtyard,6ade5df3-8ddb-4a23-8516-b4a55cd4631c
+pkg-pinsocket-1x14-d1.0-polygon-outline,aa32a0c3-5a2c-42e8-b788-34d932f310e4
 pkg-pinsocket-1x14-d1.0-text-name,515b7742-0f9d-44c8-9511-b846a6229b34
 pkg-pinsocket-1x14-d1.0-text-value,c2014dbb-ad94-456c-8372-e3e6b8d71524
 pkg-pinsocket-1x14-d1.1-3d,3ed0b823-3b86-48f1-8be9-5bc4c6bb2dc8
@@ -15927,6 +16435,8 @@ pkg-pinsocket-1x14-d1.1-pad-8,770beed7-fe07-47cf-853e-fca2dac3c54e
 pkg-pinsocket-1x14-d1.1-pad-9,37504899-a989-4d67-aeb7-f9ab0f2abd71
 pkg-pinsocket-1x14-d1.1-pkg,dede094f-08ed-4186-9759-1fcdf18c20e7
 pkg-pinsocket-1x14-d1.1-polygon-contour,f961ebba-9d2b-445f-bac9-3b7c2afd1daf
+pkg-pinsocket-1x14-d1.1-polygon-courtyard,a5b02023-249e-4c2e-890b-6c8256b03aed
+pkg-pinsocket-1x14-d1.1-polygon-outline,efbc27c3-eeb2-4cc0-a1e4-b4d34f38f80f
 pkg-pinsocket-1x14-d1.1-text-name,72d5fdff-aaa2-4013-adbe-391d897be45f
 pkg-pinsocket-1x14-d1.1-text-value,cdaace52-1117-4d81-8ef5-ee2c166d7a6d
 pkg-pinsocket-1x15-d0.9-3d,d5e73ca3-6ace-446c-9c57-ba4959afa14a
@@ -15948,6 +16458,8 @@ pkg-pinsocket-1x15-d0.9-pad-8,40328a42-ae57-4967-9dd2-965537e17b14
 pkg-pinsocket-1x15-d0.9-pad-9,ea3e2995-2377-48b9-b3d6-eb40d2a2d124
 pkg-pinsocket-1x15-d0.9-pkg,b4d9c67f-20e3-4ff6-9550-aef1f1fb1b3d
 pkg-pinsocket-1x15-d0.9-polygon-contour,14118480-f470-4bf6-9109-4b8060b2b11a
+pkg-pinsocket-1x15-d0.9-polygon-courtyard,7a928769-325d-4e3c-8322-bf4e75dae176
+pkg-pinsocket-1x15-d0.9-polygon-outline,9bf5252c-4a64-4823-85e4-1b8de03295aa
 pkg-pinsocket-1x15-d0.9-text-name,324faabb-152d-43e6-9bbe-87a7978f3ac9
 pkg-pinsocket-1x15-d0.9-text-value,50787737-454a-4a92-b795-a0f97b8efbf0
 pkg-pinsocket-1x15-d1.0-3d,fd98c14e-8fcd-4d4f-8e1f-6f5e49c8e152
@@ -15969,6 +16481,8 @@ pkg-pinsocket-1x15-d1.0-pad-8,6a83a6ef-cdd4-41d9-83be-f2869f7eaefa
 pkg-pinsocket-1x15-d1.0-pad-9,834df1aa-c7ff-4be0-b7ac-fa153c87ce37
 pkg-pinsocket-1x15-d1.0-pkg,b03a1a7a-555d-4cd8-b475-9ecd5e45c839
 pkg-pinsocket-1x15-d1.0-polygon-contour,853720f1-a6d3-4c6a-81a6-85857c07034d
+pkg-pinsocket-1x15-d1.0-polygon-courtyard,b3bfa363-b1ea-40da-a890-a7354517ec94
+pkg-pinsocket-1x15-d1.0-polygon-outline,c734e5ed-eead-4bd7-8cc4-c61f47a20abf
 pkg-pinsocket-1x15-d1.0-text-name,e0f4dbcc-ac10-4290-9193-f6d09ae2aace
 pkg-pinsocket-1x15-d1.0-text-value,e53dfb50-ffc1-48dd-97e8-38019b518f8a
 pkg-pinsocket-1x15-d1.1-3d,2c01c777-2297-460e-9897-391d06a6a6b6
@@ -15990,6 +16504,8 @@ pkg-pinsocket-1x15-d1.1-pad-8,51e38d04-71f8-46b7-8ad8-7d2f1c7ce248
 pkg-pinsocket-1x15-d1.1-pad-9,9063e64f-e20c-4164-80ee-0f5935c06646
 pkg-pinsocket-1x15-d1.1-pkg,d5d0bea1-b527-4a1e-80bd-a379e2e07a7b
 pkg-pinsocket-1x15-d1.1-polygon-contour,dbd3cd81-cd76-437f-ab20-4f8657c62da7
+pkg-pinsocket-1x15-d1.1-polygon-courtyard,9a290662-0515-447c-a236-45e986a03189
+pkg-pinsocket-1x15-d1.1-polygon-outline,e1fa8154-bb3d-458e-8a23-b3d7e6c46756
 pkg-pinsocket-1x15-d1.1-text-name,ce82b4aa-09f7-4382-9616-54833d724916
 pkg-pinsocket-1x15-d1.1-text-value,459d2c33-ad0f-4434-afbc-76fb2c26eef3
 pkg-pinsocket-1x16-d0.9-3d,74e62776-6bc1-461b-a7eb-0e505331a2d6
@@ -16012,6 +16528,8 @@ pkg-pinsocket-1x16-d0.9-pad-8,60b9f297-485b-47b9-aca7-cb460c680323
 pkg-pinsocket-1x16-d0.9-pad-9,0e6ae586-741b-44d6-9015-02c2435b2664
 pkg-pinsocket-1x16-d0.9-pkg,7dd008d6-48cb-4b4c-aa0d-e0d03b2b985d
 pkg-pinsocket-1x16-d0.9-polygon-contour,c112809e-7da3-4157-a6b6-d79dafa33d28
+pkg-pinsocket-1x16-d0.9-polygon-courtyard,bb5c2ed8-62c6-4b81-9958-c1d82aaefad9
+pkg-pinsocket-1x16-d0.9-polygon-outline,516fa1aa-4735-4e8b-803d-d832b1487358
 pkg-pinsocket-1x16-d0.9-text-name,8a23f65c-f64a-47e2-b3ee-36187ead92f0
 pkg-pinsocket-1x16-d0.9-text-value,927e3513-a6ba-49b4-ac55-a786ff4489b8
 pkg-pinsocket-1x16-d1.0-3d,967b07e6-5045-41ab-b4a6-8737f92b8cf2
@@ -16034,6 +16552,8 @@ pkg-pinsocket-1x16-d1.0-pad-8,49313a27-ea5b-49f6-86fb-ec23bbe6159b
 pkg-pinsocket-1x16-d1.0-pad-9,b15550f6-d5a6-46e1-bc4d-5853de585dd4
 pkg-pinsocket-1x16-d1.0-pkg,f1c1e736-4378-4f36-966d-38af9023528f
 pkg-pinsocket-1x16-d1.0-polygon-contour,3a174f46-2a62-40e8-aaca-d47b23ded41e
+pkg-pinsocket-1x16-d1.0-polygon-courtyard,c8ec149c-1b6f-4d1d-8ab5-8bf6c54e3590
+pkg-pinsocket-1x16-d1.0-polygon-outline,1ac48426-b288-4b61-b9c9-046bc625af13
 pkg-pinsocket-1x16-d1.0-text-name,d59637cf-9f0f-4566-baac-395816b9d1ae
 pkg-pinsocket-1x16-d1.0-text-value,a61724fc-ad6d-4a0f-80bc-62d963199fcd
 pkg-pinsocket-1x16-d1.1-3d,a4275999-3a58-41aa-b15c-3ac5fdb977d6
@@ -16056,6 +16576,8 @@ pkg-pinsocket-1x16-d1.1-pad-8,fbee2264-fa7c-481d-883f-108554bdcbbc
 pkg-pinsocket-1x16-d1.1-pad-9,d33ad175-3eb4-49d2-9878-ed81c4541bcd
 pkg-pinsocket-1x16-d1.1-pkg,10877ef0-012c-48a4-ab8e-f4f1a3c649ad
 pkg-pinsocket-1x16-d1.1-polygon-contour,7a60a520-2263-4135-bc3b-c0f1b8a3d1ce
+pkg-pinsocket-1x16-d1.1-polygon-courtyard,fc721727-c2f4-4fa3-a3a0-68ba1381f0ce
+pkg-pinsocket-1x16-d1.1-polygon-outline,2bb2e834-99ca-437c-9f5c-1d8b09b60f40
 pkg-pinsocket-1x16-d1.1-text-name,784c2998-0bde-4c81-b046-fdc6fa1a678f
 pkg-pinsocket-1x16-d1.1-text-value,dc6b2b23-126c-4d5a-ace8-d764e4c69f78
 pkg-pinsocket-1x17-d0.9-3d,bb729210-d6dc-409f-9645-2ee0a28763cb
@@ -16079,6 +16601,8 @@ pkg-pinsocket-1x17-d0.9-pad-8,7a876fa9-a86d-4321-b89c-2da6dcb071ed
 pkg-pinsocket-1x17-d0.9-pad-9,103387f5-7f23-4759-81ca-f63d95ebcbc6
 pkg-pinsocket-1x17-d0.9-pkg,19e107b5-17e9-4eb3-9869-cb2dbba8260c
 pkg-pinsocket-1x17-d0.9-polygon-contour,6b3a58aa-f8fc-4369-bdec-093d307528cb
+pkg-pinsocket-1x17-d0.9-polygon-courtyard,dea031c6-8b70-4f0e-9ace-7f91c48df8e3
+pkg-pinsocket-1x17-d0.9-polygon-outline,e0a40cab-eecf-44fc-bdff-2517a05b9fea
 pkg-pinsocket-1x17-d0.9-text-name,d5474038-a8bc-45f5-8137-35e5e7fe3b7d
 pkg-pinsocket-1x17-d0.9-text-value,3f74ce6f-7d53-4558-ad3a-b3defbef2f4f
 pkg-pinsocket-1x17-d1.0-3d,46566535-309e-48d8-9af4-ecf12c98ccbd
@@ -16102,6 +16626,8 @@ pkg-pinsocket-1x17-d1.0-pad-8,0ae99b7f-55cd-40c4-8507-436c133a389f
 pkg-pinsocket-1x17-d1.0-pad-9,a7624e63-d27c-4bc3-b025-e130850038b4
 pkg-pinsocket-1x17-d1.0-pkg,e1a0e20a-38ff-48ee-9018-df45a3d25a1b
 pkg-pinsocket-1x17-d1.0-polygon-contour,de39e853-05a8-45c6-a9a2-e18c23ad5734
+pkg-pinsocket-1x17-d1.0-polygon-courtyard,8d09607c-f81d-4e44-8234-a17ad5f151d3
+pkg-pinsocket-1x17-d1.0-polygon-outline,6bcbef9e-ea9f-4293-9714-fe1db4ac22c8
 pkg-pinsocket-1x17-d1.0-text-name,01d06bd2-e14b-422e-bdee-a277a949c8d5
 pkg-pinsocket-1x17-d1.0-text-value,90ae732a-048b-43c6-95d2-8626f4100a95
 pkg-pinsocket-1x17-d1.1-3d,de68097a-a64d-4089-a4d4-584312ee9b84
@@ -16125,6 +16651,8 @@ pkg-pinsocket-1x17-d1.1-pad-8,a42e91c3-a739-4e60-bec9-9e2a881543a7
 pkg-pinsocket-1x17-d1.1-pad-9,25fd1729-3f3e-4e20-bf3c-2e07f42a7654
 pkg-pinsocket-1x17-d1.1-pkg,0a238ea6-f79f-4f4f-86d9-5d926667e02a
 pkg-pinsocket-1x17-d1.1-polygon-contour,f2eb5af1-7ece-4718-b940-82ca39809435
+pkg-pinsocket-1x17-d1.1-polygon-courtyard,4400c89e-917f-4ca1-a543-30b4c5b8290b
+pkg-pinsocket-1x17-d1.1-polygon-outline,ab4ff0c8-8807-4eba-82b0-98eb3d1df630
 pkg-pinsocket-1x17-d1.1-text-name,91c50a68-5c36-4328-9218-27408e2fd43f
 pkg-pinsocket-1x17-d1.1-text-value,3527ab97-d060-49f0-a6c5-912319025895
 pkg-pinsocket-1x18-d0.9-3d,1c708184-41a9-4e95-8444-56440f4aeb34
@@ -16149,6 +16677,8 @@ pkg-pinsocket-1x18-d0.9-pad-8,0a9f0ad1-a88b-43cd-b5ca-a94b666e81a1
 pkg-pinsocket-1x18-d0.9-pad-9,100075d8-042b-44af-bf14-f189b5b96077
 pkg-pinsocket-1x18-d0.9-pkg,057347db-010e-4aa9-9765-e57fb06feed3
 pkg-pinsocket-1x18-d0.9-polygon-contour,dde91690-636c-4738-af0f-639085dba931
+pkg-pinsocket-1x18-d0.9-polygon-courtyard,6e5e2335-8de1-4014-94b8-110265917f7a
+pkg-pinsocket-1x18-d0.9-polygon-outline,26ac0349-f709-4273-8323-306bf31814e2
 pkg-pinsocket-1x18-d0.9-text-name,8b68a571-9a04-4fce-ac9c-6e48aaea4048
 pkg-pinsocket-1x18-d0.9-text-value,15b4e074-2987-4db9-b817-24d64a5fbb67
 pkg-pinsocket-1x18-d1.0-3d,15474f91-da7e-4f6c-b741-d5793ba4af44
@@ -16173,6 +16703,8 @@ pkg-pinsocket-1x18-d1.0-pad-8,3369d98c-eb05-4879-829d-42333de5bfa7
 pkg-pinsocket-1x18-d1.0-pad-9,9648cdea-d92b-47ca-8558-4e22b03647f2
 pkg-pinsocket-1x18-d1.0-pkg,4c72a072-0bcd-474e-98d3-1d977e33ee27
 pkg-pinsocket-1x18-d1.0-polygon-contour,e6d66d3e-84d9-403e-bfe4-f6f65196ce1a
+pkg-pinsocket-1x18-d1.0-polygon-courtyard,a2cd79f9-357a-4434-8003-091e15580f89
+pkg-pinsocket-1x18-d1.0-polygon-outline,0716cbe1-6ba3-446e-841b-39fa2ab01e93
 pkg-pinsocket-1x18-d1.0-text-name,9da14355-5589-40d8-b4f8-0b4a6d94ef0d
 pkg-pinsocket-1x18-d1.0-text-value,143e43d3-0f0b-4445-8e81-4bffd56f0bcd
 pkg-pinsocket-1x18-d1.1-3d,20bce68a-1b4e-4f31-b9ce-89796293453b
@@ -16197,6 +16729,8 @@ pkg-pinsocket-1x18-d1.1-pad-8,3e8f50bb-adbd-48da-8cb8-724da1eb20e7
 pkg-pinsocket-1x18-d1.1-pad-9,ff1a47b4-7be6-4b87-b7ee-d900098ac581
 pkg-pinsocket-1x18-d1.1-pkg,214a3b95-27ca-499b-83c8-e2862396c21a
 pkg-pinsocket-1x18-d1.1-polygon-contour,2c5f1f2d-3fcf-4429-ab6e-bddea78568cf
+pkg-pinsocket-1x18-d1.1-polygon-courtyard,30f2b9df-f85c-431a-ba80-fa30b0a8c4a3
+pkg-pinsocket-1x18-d1.1-polygon-outline,d71a0f16-fb7d-487e-b9eb-160d05020ac8
 pkg-pinsocket-1x18-d1.1-text-name,537a1e8d-aebc-4d13-9e5d-bfdcc318a06a
 pkg-pinsocket-1x18-d1.1-text-value,c6c7672e-2909-472c-8ad2-b9fbbdb31011
 pkg-pinsocket-1x19-d0.9-3d,302b8fad-8f62-40a9-9243-ae1683334d5c
@@ -16222,6 +16756,8 @@ pkg-pinsocket-1x19-d0.9-pad-8,077cd8e5-80ff-4794-be62-8f4747d1876c
 pkg-pinsocket-1x19-d0.9-pad-9,37854d6f-1494-46dd-97b8-66137ff17076
 pkg-pinsocket-1x19-d0.9-pkg,49603665-d797-4ac0-9914-7bd7de39efe8
 pkg-pinsocket-1x19-d0.9-polygon-contour,063016cc-2298-408c-aafc-3e82bbbe0ada
+pkg-pinsocket-1x19-d0.9-polygon-courtyard,6ebc3c31-5777-4124-9e96-9f7ecfd5c8b6
+pkg-pinsocket-1x19-d0.9-polygon-outline,5299b7c4-c3b9-4ece-be79-bae66375d18e
 pkg-pinsocket-1x19-d0.9-text-name,a16dc2db-d710-4831-99d6-6563092148e1
 pkg-pinsocket-1x19-d0.9-text-value,aee6ed48-38d2-4a56-8fee-384802bafa07
 pkg-pinsocket-1x19-d1.0-3d,204cb88e-49a3-4726-a6fb-f155bd3ec4e6
@@ -16247,6 +16783,8 @@ pkg-pinsocket-1x19-d1.0-pad-8,72a25da1-7c6a-4350-abcc-961fc60b026f
 pkg-pinsocket-1x19-d1.0-pad-9,a0ef1ff4-f49f-400c-910b-8861637bd584
 pkg-pinsocket-1x19-d1.0-pkg,be3397f5-65be-4158-820e-cc0cd937a912
 pkg-pinsocket-1x19-d1.0-polygon-contour,e2039ea8-d322-4158-a8b2-46ed20cc7516
+pkg-pinsocket-1x19-d1.0-polygon-courtyard,f16b9354-01e7-4805-87d6-4205f20de953
+pkg-pinsocket-1x19-d1.0-polygon-outline,d48d1ab3-b567-4266-9d8c-78b419a304a3
 pkg-pinsocket-1x19-d1.0-text-name,a2fcb4f7-775d-41ff-a4e7-4b4663677040
 pkg-pinsocket-1x19-d1.0-text-value,4cc54408-9241-4856-8e9a-dcf16cc51225
 pkg-pinsocket-1x19-d1.1-3d,7ef3e258-4a28-454b-801c-b5598fc91d0d
@@ -16272,6 +16810,8 @@ pkg-pinsocket-1x19-d1.1-pad-8,8dbdd4b7-9509-4ce8-a4da-0c4aa562e914
 pkg-pinsocket-1x19-d1.1-pad-9,287e1cd0-798e-4a96-a237-b17fd1c8d165
 pkg-pinsocket-1x19-d1.1-pkg,e280c528-8beb-4ba1-8529-b60f2fbfec64
 pkg-pinsocket-1x19-d1.1-polygon-contour,e69e3218-bda3-4f4f-b7f1-8de2e9c291a4
+pkg-pinsocket-1x19-d1.1-polygon-courtyard,010aa348-4b4f-406c-9e4f-26965e16fc34
+pkg-pinsocket-1x19-d1.1-polygon-outline,e568f664-c10b-446c-89c2-40b050265f1d
 pkg-pinsocket-1x19-d1.1-text-name,7adad2f3-2280-4ce9-a9aa-f28442cc386a
 pkg-pinsocket-1x19-d1.1-text-value,b3f06664-bb97-4860-8759-f905891a48df
 pkg-pinsocket-1x2-d0.9-3d,475cbf6d-337f-43eb-98f2-94ce9fa1cdc3
@@ -16280,6 +16820,8 @@ pkg-pinsocket-1x2-d0.9-pad-0,52aed999-bf69-4f01-801b-c45ffdadfc9c
 pkg-pinsocket-1x2-d0.9-pad-1,77f1468f-7609-464d-b47b-ecf4a832ea10
 pkg-pinsocket-1x2-d0.9-pkg,58d2403a-c1e3-42fd-9b9f-dde6dad56d9c
 pkg-pinsocket-1x2-d0.9-polygon-contour,de91a2d9-6e0b-442b-a7dc-bfb1cf310135
+pkg-pinsocket-1x2-d0.9-polygon-courtyard,e3f5b000-48e9-4b84-8df3-9b6d0b016b7d
+pkg-pinsocket-1x2-d0.9-polygon-outline,ffcb8c70-28f6-44ce-a499-1b9f66a08677
 pkg-pinsocket-1x2-d0.9-text-name,68e690bc-769c-4462-b60e-311f3de84ee6
 pkg-pinsocket-1x2-d0.9-text-value,b4cc5951-bd2a-409b-9289-b914ea3ee143
 pkg-pinsocket-1x2-d1.0-3d,92503d6c-33e5-4000-8c0f-0a42760438d9
@@ -16288,6 +16830,8 @@ pkg-pinsocket-1x2-d1.0-pad-0,65c11009-42c7-4025-9f1f-494a5ab17c9a
 pkg-pinsocket-1x2-d1.0-pad-1,0f47fe09-122c-41c6-8141-b7af50b20281
 pkg-pinsocket-1x2-d1.0-pkg,5263e03f-244e-4470-8806-62e5fb7f2f62
 pkg-pinsocket-1x2-d1.0-polygon-contour,de141c4b-d7a5-40ce-99e8-a82ae9eb84f9
+pkg-pinsocket-1x2-d1.0-polygon-courtyard,335660da-6710-4b6a-bf5f-a9c28fc79270
+pkg-pinsocket-1x2-d1.0-polygon-outline,36240695-31b2-4c53-8482-63af27dfb23b
 pkg-pinsocket-1x2-d1.0-text-name,18dbd81f-c34c-478f-bfae-2637acd84786
 pkg-pinsocket-1x2-d1.0-text-value,5aab199a-b779-4995-ba31-900fe3a330d4
 pkg-pinsocket-1x2-d1.1-3d,3abb4c23-dd1d-443e-858f-1d5ab79ff40b
@@ -16296,6 +16840,8 @@ pkg-pinsocket-1x2-d1.1-pad-0,c47028f1-ea26-4981-afbc-838eb1281ea3
 pkg-pinsocket-1x2-d1.1-pad-1,6bb9aefc-f193-47fa-bf43-0dcb3999a6b8
 pkg-pinsocket-1x2-d1.1-pkg,2ba2ea31-fd08-4fc1-87d8-2cd5c61f905f
 pkg-pinsocket-1x2-d1.1-polygon-contour,28ee053f-9317-4e58-964b-a116501a1d1c
+pkg-pinsocket-1x2-d1.1-polygon-courtyard,d68ab864-9c8f-4261-95aa-e00ac6bc9bf1
+pkg-pinsocket-1x2-d1.1-polygon-outline,d6b1e2ec-04f7-44be-a2ea-6019ca223237
 pkg-pinsocket-1x2-d1.1-text-name,43ab2ba2-c7c6-4b86-a36e-09f8a8c639cb
 pkg-pinsocket-1x2-d1.1-text-value,9a376513-a335-4c37-a7b0-45c6bf1bd89e
 pkg-pinsocket-1x20-d0.9-3d,346f7bc5-4ec1-40ec-bbe7-7a1c53c7f10f
@@ -16322,6 +16868,8 @@ pkg-pinsocket-1x20-d0.9-pad-8,051c69c3-f360-4449-b238-e4ce69814cd4
 pkg-pinsocket-1x20-d0.9-pad-9,a43f6955-c5bd-4c10-8433-415cfe6e1e1c
 pkg-pinsocket-1x20-d0.9-pkg,e286d1e1-9c1b-4b43-bd28-3ee9e695c759
 pkg-pinsocket-1x20-d0.9-polygon-contour,9a9c7d57-a18a-4477-b0d9-038dcdd1cf6e
+pkg-pinsocket-1x20-d0.9-polygon-courtyard,d3c37c7d-2fde-432d-89e6-28f022e75941
+pkg-pinsocket-1x20-d0.9-polygon-outline,c9120058-0736-4908-8e41-8812d7f42794
 pkg-pinsocket-1x20-d0.9-text-name,ce1dad52-0c6e-4b3b-9b8d-679a0e2fbff2
 pkg-pinsocket-1x20-d0.9-text-value,4747f98d-49f3-4e5a-834b-f3cd3fb2a407
 pkg-pinsocket-1x20-d1.0-3d,38b30beb-ae91-4574-ad22-9347ccc563b0
@@ -16348,6 +16896,8 @@ pkg-pinsocket-1x20-d1.0-pad-8,e62f55b3-73cc-42de-bfb9-8edd80f77cbf
 pkg-pinsocket-1x20-d1.0-pad-9,58794d61-6fcd-4535-ae42-8dcf52716fc1
 pkg-pinsocket-1x20-d1.0-pkg,bf92c5d9-ea19-41b6-aa58-bb9c426569a0
 pkg-pinsocket-1x20-d1.0-polygon-contour,1ee8a27e-0fa3-4c93-a363-b68e4c139c06
+pkg-pinsocket-1x20-d1.0-polygon-courtyard,4007862d-e73a-4bc3-91d9-6f80e232d37e
+pkg-pinsocket-1x20-d1.0-polygon-outline,493e864c-cac5-4867-a44d-4dab9f88bd88
 pkg-pinsocket-1x20-d1.0-text-name,24d8e19a-2594-4932-b10c-479647d8a300
 pkg-pinsocket-1x20-d1.0-text-value,533bdd0a-c05c-4f31-91cf-b531dd889f4b
 pkg-pinsocket-1x20-d1.1-3d,815c300a-3c0a-4618-a4a2-0e5d52faf621
@@ -16374,6 +16924,8 @@ pkg-pinsocket-1x20-d1.1-pad-8,6d62b056-35fd-413a-81a4-8de937c28d3a
 pkg-pinsocket-1x20-d1.1-pad-9,10568bf8-5e4f-469a-8d49-f86349f23742
 pkg-pinsocket-1x20-d1.1-pkg,d96116bb-76e8-4c24-b7cf-632f84a9c3fa
 pkg-pinsocket-1x20-d1.1-polygon-contour,61666d82-80e8-4351-8a63-71f568d389fb
+pkg-pinsocket-1x20-d1.1-polygon-courtyard,6c55d357-d323-4303-9d71-ae7cce1b7603
+pkg-pinsocket-1x20-d1.1-polygon-outline,5ccd4c12-8025-42b5-a60c-ff42ce8cc276
 pkg-pinsocket-1x20-d1.1-text-name,feb8233b-48a8-4fd0-8e8d-c1e666b55a72
 pkg-pinsocket-1x20-d1.1-text-value,1b0432e1-7d96-45b6-8ada-7900309e1493
 pkg-pinsocket-1x21-d0.9-3d,109489f1-a407-4d10-9e75-0891ba8125ef
@@ -16401,6 +16953,8 @@ pkg-pinsocket-1x21-d0.9-pad-8,aa6a1b6d-e2dd-463a-8078-13d4bbae20a1
 pkg-pinsocket-1x21-d0.9-pad-9,995cdd0b-5fe9-4bd8-b179-c955300a2925
 pkg-pinsocket-1x21-d0.9-pkg,4675811d-ed36-447e-a66c-72b13a81cc24
 pkg-pinsocket-1x21-d0.9-polygon-contour,674c6b21-c794-4b5c-953e-6d88c3eb1628
+pkg-pinsocket-1x21-d0.9-polygon-courtyard,833ba7b7-366c-47e4-b857-fd6831bc604e
+pkg-pinsocket-1x21-d0.9-polygon-outline,c5fbca52-4d9b-41b1-a2ed-bc4af437ed5f
 pkg-pinsocket-1x21-d0.9-text-name,bc31afdd-fd66-4b39-b83c-25a190c89fe3
 pkg-pinsocket-1x21-d0.9-text-value,2b439bb6-e1aa-492a-b4ed-daa2c86a1525
 pkg-pinsocket-1x21-d1.0-3d,453cc1ab-15fc-4c53-8e55-a9cd60d26425
@@ -16428,6 +16982,8 @@ pkg-pinsocket-1x21-d1.0-pad-8,93894765-c050-4fef-9cd5-f13eadac8a44
 pkg-pinsocket-1x21-d1.0-pad-9,776982c3-5584-44be-b22f-e405e011cbc8
 pkg-pinsocket-1x21-d1.0-pkg,575111d9-c5f2-42a2-920b-2a1f53847e7e
 pkg-pinsocket-1x21-d1.0-polygon-contour,0f13b62d-c387-4b55-873b-76f7ef33790d
+pkg-pinsocket-1x21-d1.0-polygon-courtyard,009a4c93-07cd-4092-be31-253432c88fea
+pkg-pinsocket-1x21-d1.0-polygon-outline,d8f0aa0a-55be-4c98-b2d8-e88c17e11817
 pkg-pinsocket-1x21-d1.0-text-name,3f0ea4c3-992c-46bf-8e49-9d843c616725
 pkg-pinsocket-1x21-d1.0-text-value,7ba657ac-fe33-41aa-bef6-a99134159ff7
 pkg-pinsocket-1x21-d1.1-3d,0c0a7bf2-6d8a-4865-9381-c35ed4111a22
@@ -16455,6 +17011,8 @@ pkg-pinsocket-1x21-d1.1-pad-8,9b8743b4-7649-487e-8d79-f50227bdb616
 pkg-pinsocket-1x21-d1.1-pad-9,be5a7e2a-8044-4f7c-a3df-d2129c912f75
 pkg-pinsocket-1x21-d1.1-pkg,134b1121-0044-49d6-b8ef-43dfbef0c589
 pkg-pinsocket-1x21-d1.1-polygon-contour,75471f70-ad02-4f4c-9ad3-8c214375c3d1
+pkg-pinsocket-1x21-d1.1-polygon-courtyard,b2a307b2-a3fb-45b2-bc69-8e48a7b65473
+pkg-pinsocket-1x21-d1.1-polygon-outline,9c424a71-aea7-4ba6-bf8e-1bed59ce2345
 pkg-pinsocket-1x21-d1.1-text-name,f8c8820f-f504-4c09-a345-29d16a9a93ce
 pkg-pinsocket-1x21-d1.1-text-value,ddc66ad6-b98e-4ee5-b840-25303ba1f81d
 pkg-pinsocket-1x22-d0.9-3d,4dd1194b-766c-46ed-8be8-2e25f7fcafb8
@@ -16483,6 +17041,8 @@ pkg-pinsocket-1x22-d0.9-pad-8,3dbf84fa-a151-432d-9564-ba366a557824
 pkg-pinsocket-1x22-d0.9-pad-9,af20dc14-3a82-47ed-a14d-3532a0c067a9
 pkg-pinsocket-1x22-d0.9-pkg,05d3d24e-cf37-4ba1-ab09-a1edc44f9cfa
 pkg-pinsocket-1x22-d0.9-polygon-contour,9d085652-70e6-43a1-99af-513b07c75826
+pkg-pinsocket-1x22-d0.9-polygon-courtyard,4229ae20-1404-4a9c-9841-a348a66d298c
+pkg-pinsocket-1x22-d0.9-polygon-outline,58dc422c-36ce-4ba6-b9a8-6b57a550ada9
 pkg-pinsocket-1x22-d0.9-text-name,0fb3fa63-b015-49ee-bbd1-d3a0598238c5
 pkg-pinsocket-1x22-d0.9-text-value,09117838-147d-4ce9-af75-2ab0f9cb5f5d
 pkg-pinsocket-1x22-d1.0-3d,44c5f1d4-ab4d-4e00-8277-b76f25289613
@@ -16511,6 +17071,8 @@ pkg-pinsocket-1x22-d1.0-pad-8,92436111-a59e-48d2-a98e-b1531a5ae0ff
 pkg-pinsocket-1x22-d1.0-pad-9,8206f490-dd4c-40d4-9acb-c14cbca3847b
 pkg-pinsocket-1x22-d1.0-pkg,683dde86-0c5d-4abc-833a-a780bbcfe544
 pkg-pinsocket-1x22-d1.0-polygon-contour,e583c15e-f41a-4513-9ceb-e8eec5d36a7e
+pkg-pinsocket-1x22-d1.0-polygon-courtyard,c7b0d05c-6fbe-4fde-9c37-83f2a0188375
+pkg-pinsocket-1x22-d1.0-polygon-outline,8c2e968b-97eb-4def-8c72-e71ccce39dc0
 pkg-pinsocket-1x22-d1.0-text-name,6b163de4-4c17-44e6-ba42-0124189e3720
 pkg-pinsocket-1x22-d1.0-text-value,c9b58fbb-7d55-4270-b85c-ac070266bd1c
 pkg-pinsocket-1x22-d1.1-3d,c5a73f72-5458-482b-9ede-f3273d7db320
@@ -16539,6 +17101,8 @@ pkg-pinsocket-1x22-d1.1-pad-8,7f7d16b4-4a5c-469d-ad5d-055cdbc19b63
 pkg-pinsocket-1x22-d1.1-pad-9,fa1ab255-28cb-4ea0-b4f3-b0474d91c88e
 pkg-pinsocket-1x22-d1.1-pkg,72ed35a0-aaab-48ff-ad39-4cadb015248f
 pkg-pinsocket-1x22-d1.1-polygon-contour,6a2a88ac-bac3-42ba-a6ec-c2224d5ced87
+pkg-pinsocket-1x22-d1.1-polygon-courtyard,f987e888-6885-4ac1-9d53-6c7a49b2139f
+pkg-pinsocket-1x22-d1.1-polygon-outline,5304976e-c567-4f91-88ad-fd1e7888cd5c
 pkg-pinsocket-1x22-d1.1-text-name,d77c1f44-e226-47d6-a885-fc24e78cc25c
 pkg-pinsocket-1x22-d1.1-text-value,0c3f7074-4908-4385-92a0-c14491c40333
 pkg-pinsocket-1x23-d0.9-3d,8ba5c335-fec2-404d-be59-8c65caecb2ce
@@ -16568,6 +17132,8 @@ pkg-pinsocket-1x23-d0.9-pad-8,d6325f18-7214-4eec-98a4-c1846296bdb0
 pkg-pinsocket-1x23-d0.9-pad-9,7bb6dc8a-c727-4dbb-b17e-5b62f9f971f0
 pkg-pinsocket-1x23-d0.9-pkg,558ac505-32f7-44f2-a2eb-a39d6e1f2c07
 pkg-pinsocket-1x23-d0.9-polygon-contour,d928ff6f-972f-4e5a-a6e2-89c4ea52b0f9
+pkg-pinsocket-1x23-d0.9-polygon-courtyard,165cab50-0700-45a8-bf65-b0306cc542ab
+pkg-pinsocket-1x23-d0.9-polygon-outline,521fcd0d-d95d-4231-a180-8ec71215dbc8
 pkg-pinsocket-1x23-d0.9-text-name,b69253f4-5da6-4890-a788-9df7c3815a71
 pkg-pinsocket-1x23-d0.9-text-value,c9a71d5d-d3a6-43b4-ae51-689f2cc01fdb
 pkg-pinsocket-1x23-d1.0-3d,d3606a8c-07bb-4034-8ac5-a35f7f17465a
@@ -16597,6 +17163,8 @@ pkg-pinsocket-1x23-d1.0-pad-8,2ac192e5-b5e5-4299-adda-171891eb2673
 pkg-pinsocket-1x23-d1.0-pad-9,0b29c0f9-be8b-48d2-a37e-0e2d4bbca436
 pkg-pinsocket-1x23-d1.0-pkg,3b656fcc-2d8d-4099-a918-ca04b38dafb8
 pkg-pinsocket-1x23-d1.0-polygon-contour,bd7e8ec7-0e5e-4b5c-b9b0-72f662dd878b
+pkg-pinsocket-1x23-d1.0-polygon-courtyard,765e61d3-d535-43a6-81bb-6e7d68392faf
+pkg-pinsocket-1x23-d1.0-polygon-outline,78d2fa3b-ceb8-48eb-a732-27fc7aad0381
 pkg-pinsocket-1x23-d1.0-text-name,a0b7144c-d5cb-47de-a231-e31cc8852252
 pkg-pinsocket-1x23-d1.0-text-value,40a8eb5f-8131-4dd2-a960-0be06f5cc27a
 pkg-pinsocket-1x23-d1.1-3d,1ca95b27-6b69-46db-9a25-890aacf59e7c
@@ -16626,6 +17194,8 @@ pkg-pinsocket-1x23-d1.1-pad-8,4f28c355-072f-4acc-a4ed-1022a26b88ac
 pkg-pinsocket-1x23-d1.1-pad-9,844b5754-1d9b-4bac-9373-94e9b1e122e8
 pkg-pinsocket-1x23-d1.1-pkg,5644a763-e31b-4fff-bc13-3485f4e2d9b1
 pkg-pinsocket-1x23-d1.1-polygon-contour,9856e6f5-cad7-47c0-b14d-2bd8547ffbcf
+pkg-pinsocket-1x23-d1.1-polygon-courtyard,e1f03b8c-4dce-4e39-b277-f58377d84fef
+pkg-pinsocket-1x23-d1.1-polygon-outline,ae99a2f8-b79a-422b-8ec2-1cef38abff96
 pkg-pinsocket-1x23-d1.1-text-name,750da151-16bc-44d7-a159-550923ab7314
 pkg-pinsocket-1x23-d1.1-text-value,bcb1cd2d-b2d7-4eae-b8eb-383adeaec862
 pkg-pinsocket-1x24-d0.9-3d,680431ed-fb88-4dc5-a674-76360e00011e
@@ -16656,6 +17226,8 @@ pkg-pinsocket-1x24-d0.9-pad-8,f527262f-a0e0-472f-8297-44de60a6de79
 pkg-pinsocket-1x24-d0.9-pad-9,0879f07b-431f-4be0-8f1e-52051070bcbb
 pkg-pinsocket-1x24-d0.9-pkg,b2a2ba5f-64ad-4527-9d58-c55763fd6e37
 pkg-pinsocket-1x24-d0.9-polygon-contour,235bf0cc-0d07-4360-8184-79d66fab87b4
+pkg-pinsocket-1x24-d0.9-polygon-courtyard,6728b549-ccfb-4d52-ba9f-2789a11fc2be
+pkg-pinsocket-1x24-d0.9-polygon-outline,b3924fac-4c33-486f-bdbc-661d13862205
 pkg-pinsocket-1x24-d0.9-text-name,42e80615-c496-4901-b876-6ad58cdf53b6
 pkg-pinsocket-1x24-d0.9-text-value,67edea71-adcc-4edd-b727-83cc713f4728
 pkg-pinsocket-1x24-d1.0-3d,246abf56-f216-430e-9bc2-2ae86afbaa42
@@ -16686,6 +17258,8 @@ pkg-pinsocket-1x24-d1.0-pad-8,61554428-3ad1-461e-af24-3c9fd072c385
 pkg-pinsocket-1x24-d1.0-pad-9,57e0ec7b-637f-49db-836d-c9e0423a6684
 pkg-pinsocket-1x24-d1.0-pkg,81bc20f9-5cb8-4998-af1f-89e3da5f33b3
 pkg-pinsocket-1x24-d1.0-polygon-contour,bfff9801-d3d8-4e4a-aa48-bd951a78bd5d
+pkg-pinsocket-1x24-d1.0-polygon-courtyard,7e1dd35f-8394-45fd-8e32-695b0ef1dd82
+pkg-pinsocket-1x24-d1.0-polygon-outline,296b191f-a095-49ea-b855-3e411dd5451a
 pkg-pinsocket-1x24-d1.0-text-name,2b58661b-a7c9-4557-92be-782b64b185e3
 pkg-pinsocket-1x24-d1.0-text-value,53d32904-f07a-4a16-ab22-aeae4571f651
 pkg-pinsocket-1x24-d1.1-3d,4250238b-3aca-44ac-a11f-d3b9de7d4f13
@@ -16716,6 +17290,8 @@ pkg-pinsocket-1x24-d1.1-pad-8,4961a844-0467-4a26-ae63-0a7b9621baca
 pkg-pinsocket-1x24-d1.1-pad-9,864dedaf-348e-47cf-8c0a-3d6359204817
 pkg-pinsocket-1x24-d1.1-pkg,c87aacc0-5d5d-47b3-b862-09f46aef845a
 pkg-pinsocket-1x24-d1.1-polygon-contour,835f8ac2-4e6d-4861-ad60-8ce34021974b
+pkg-pinsocket-1x24-d1.1-polygon-courtyard,cdb9eec2-4357-4151-8ccb-745ad93495a3
+pkg-pinsocket-1x24-d1.1-polygon-outline,c1e423df-69b3-4f41-891c-45d5ddc1d281
 pkg-pinsocket-1x24-d1.1-text-name,1f375eef-a573-4441-896d-c61caf30b184
 pkg-pinsocket-1x24-d1.1-text-value,0d2108a0-cf6a-4b30-9d5b-ecdfc2b815da
 pkg-pinsocket-1x25-d0.9-3d,7f24451b-b2b9-4f93-acd7-d09566606e78
@@ -16747,6 +17323,8 @@ pkg-pinsocket-1x25-d0.9-pad-8,1e50b14d-5728-4c1e-ab11-da29c7059877
 pkg-pinsocket-1x25-d0.9-pad-9,37c5ce2b-2c90-4922-aeb0-d57b0a5cfae7
 pkg-pinsocket-1x25-d0.9-pkg,b87458e4-c835-4922-a933-133eb93eaccc
 pkg-pinsocket-1x25-d0.9-polygon-contour,298d0093-aa95-4b62-a5a8-98f9f50cdd68
+pkg-pinsocket-1x25-d0.9-polygon-courtyard,d8f209e3-26ba-4410-a57c-f3626b20e30a
+pkg-pinsocket-1x25-d0.9-polygon-outline,fa836e6f-ab87-49d7-be44-fc89a4a86719
 pkg-pinsocket-1x25-d0.9-text-name,a02e18e6-af63-4fa6-abd1-ffc7c16e979b
 pkg-pinsocket-1x25-d0.9-text-value,f3fb4a48-cb91-484f-844a-ee29376b63f4
 pkg-pinsocket-1x25-d1.0-3d,a8fb183c-5696-4d78-8546-b2b93d52ddc1
@@ -16778,6 +17356,8 @@ pkg-pinsocket-1x25-d1.0-pad-8,7854608a-7dac-4d4e-8f6d-f09a42ec7c48
 pkg-pinsocket-1x25-d1.0-pad-9,d26d0480-33e0-40dd-a343-033373930385
 pkg-pinsocket-1x25-d1.0-pkg,9d85147f-863d-4def-b844-ca6ca0af8737
 pkg-pinsocket-1x25-d1.0-polygon-contour,81787fc3-97c2-4197-827a-118023c4912d
+pkg-pinsocket-1x25-d1.0-polygon-courtyard,162e277b-21f0-47b5-a1e2-7a7e3b41f453
+pkg-pinsocket-1x25-d1.0-polygon-outline,7cf583c5-a266-4ae7-a7c3-9540d1f77b0b
 pkg-pinsocket-1x25-d1.0-text-name,43319989-a6b0-453e-a903-b047cafeec03
 pkg-pinsocket-1x25-d1.0-text-value,6b220d96-64ac-4f1a-a166-99144ac7bd3c
 pkg-pinsocket-1x25-d1.1-3d,ee1f2712-67a7-4652-90a0-35cc6b685831
@@ -16809,6 +17389,8 @@ pkg-pinsocket-1x25-d1.1-pad-8,e9f7f9a9-f3b9-4e4e-9024-4ef0d93f2d19
 pkg-pinsocket-1x25-d1.1-pad-9,ee9f73c4-720a-4040-abdc-25aaa73df80c
 pkg-pinsocket-1x25-d1.1-pkg,c986c138-859f-4205-a43a-c8bfb1d27a10
 pkg-pinsocket-1x25-d1.1-polygon-contour,53bfdd6f-2de1-4db1-84a2-f6d6d546a49b
+pkg-pinsocket-1x25-d1.1-polygon-courtyard,0b838532-830b-453f-8249-ab954e2412b7
+pkg-pinsocket-1x25-d1.1-polygon-outline,6a8ac0f2-54b6-48dc-9a0a-23c83b67ecb2
 pkg-pinsocket-1x25-d1.1-text-name,9ce4f128-d2db-4796-ad7a-88803f3e4222
 pkg-pinsocket-1x25-d1.1-text-value,f348fb4c-489b-4fb4-83de-9fc4af6ee55d
 pkg-pinsocket-1x26-d0.9-3d,bee6092f-7ff9-42d2-b72f-ce33671d7809
@@ -16841,6 +17423,8 @@ pkg-pinsocket-1x26-d0.9-pad-8,3b78ab56-7749-4593-a519-79ac1cc6301e
 pkg-pinsocket-1x26-d0.9-pad-9,d70b6ff6-3bed-497b-ac1e-a0c4af97b8ae
 pkg-pinsocket-1x26-d0.9-pkg,4b4a57b9-d9c5-4b54-9495-4e29fd066e9d
 pkg-pinsocket-1x26-d0.9-polygon-contour,2df80f24-2fa3-405e-a968-ab3a0488a57a
+pkg-pinsocket-1x26-d0.9-polygon-courtyard,96f344b6-31a8-4238-98c0-737adca9d7db
+pkg-pinsocket-1x26-d0.9-polygon-outline,d7801a91-97fb-4c33-906a-50e1405895e6
 pkg-pinsocket-1x26-d0.9-text-name,42f333ed-db05-4f9e-9b99-39258adf8f49
 pkg-pinsocket-1x26-d0.9-text-value,3ab51375-8b28-47c3-a36d-ee0e57e8c134
 pkg-pinsocket-1x26-d1.0-3d,a9334442-fe53-42d3-b64e-8b70b12e923a
@@ -16873,6 +17457,8 @@ pkg-pinsocket-1x26-d1.0-pad-8,f16a1942-c91d-44c6-954f-fe9be2dfa852
 pkg-pinsocket-1x26-d1.0-pad-9,439ce2ad-6136-4ace-b3c3-ae67634fbc5e
 pkg-pinsocket-1x26-d1.0-pkg,71eba6aa-fa06-4c3f-9ba9-6cd451e1a588
 pkg-pinsocket-1x26-d1.0-polygon-contour,cfbdaed6-baf0-49fe-86c1-b8a755662761
+pkg-pinsocket-1x26-d1.0-polygon-courtyard,f8030793-9a3f-49dc-803e-4f0f879efecc
+pkg-pinsocket-1x26-d1.0-polygon-outline,143d92ee-7fe6-4bde-881e-88dff1dcf3d0
 pkg-pinsocket-1x26-d1.0-text-name,b770dd82-f566-4b5b-9eba-d7be0120648b
 pkg-pinsocket-1x26-d1.0-text-value,eb570a82-0b89-473f-840e-584ce75c3253
 pkg-pinsocket-1x26-d1.1-3d,783f1809-0bf9-420e-b06a-3ec949462f55
@@ -16905,6 +17491,8 @@ pkg-pinsocket-1x26-d1.1-pad-8,116c68d4-6b61-487c-b5dc-264f22f98cf3
 pkg-pinsocket-1x26-d1.1-pad-9,fddffa67-6bd5-415a-ae1d-914767c17eea
 pkg-pinsocket-1x26-d1.1-pkg,aeb33cd4-dac3-45c5-a1a8-19581a1895bc
 pkg-pinsocket-1x26-d1.1-polygon-contour,5dc80eec-ade8-43fa-8ca0-b95f1e26b3df
+pkg-pinsocket-1x26-d1.1-polygon-courtyard,6efc0e1c-d52b-4846-be48-6a866bd93a37
+pkg-pinsocket-1x26-d1.1-polygon-outline,312a41f9-063f-41aa-b386-1bb5f7459aa2
 pkg-pinsocket-1x26-d1.1-text-name,b3c1b3fb-1f80-4091-8fc7-c953bff80197
 pkg-pinsocket-1x26-d1.1-text-value,17ad97fa-8efd-42ec-88ab-87604ee3718c
 pkg-pinsocket-1x27-d0.9-3d,689291ff-7d83-4971-8000-72363b64ad61
@@ -16938,6 +17526,8 @@ pkg-pinsocket-1x27-d0.9-pad-8,3b13364d-1b97-42e5-a923-6c70c488329f
 pkg-pinsocket-1x27-d0.9-pad-9,c5169520-2710-4e29-bcd6-cc0d7991ba44
 pkg-pinsocket-1x27-d0.9-pkg,a6fe632f-6bfa-46f6-ba3c-3998d13b0c24
 pkg-pinsocket-1x27-d0.9-polygon-contour,2e133e95-bbd3-4f5a-bc5a-ecd91acdb014
+pkg-pinsocket-1x27-d0.9-polygon-courtyard,3bd4eed0-d278-46e9-8022-85eca3977aed
+pkg-pinsocket-1x27-d0.9-polygon-outline,d9354e80-0480-4cf3-9d22-ed3e9d71eb41
 pkg-pinsocket-1x27-d0.9-text-name,579d2bf2-e012-49d4-9ea2-32417174ce2d
 pkg-pinsocket-1x27-d0.9-text-value,a35b8663-0132-46f2-ad3c-17f619e0bd9f
 pkg-pinsocket-1x27-d1.0-3d,fffe0b67-4537-466f-96a1-1dcb8775ede9
@@ -16971,6 +17561,8 @@ pkg-pinsocket-1x27-d1.0-pad-8,5bfc3948-064e-47ad-94d6-07740d23bc59
 pkg-pinsocket-1x27-d1.0-pad-9,7ad14c5c-8975-42c5-98ec-85589eb1dfaf
 pkg-pinsocket-1x27-d1.0-pkg,cac6915d-8d7f-41e8-a4f5-af90a8dc7b09
 pkg-pinsocket-1x27-d1.0-polygon-contour,3d3745a1-c76e-4a63-8ba7-5e0b135eff44
+pkg-pinsocket-1x27-d1.0-polygon-courtyard,0e4a0624-83de-4a43-aa2c-fd450ee05e30
+pkg-pinsocket-1x27-d1.0-polygon-outline,361131d8-17d5-45e2-963f-a0ca90bcd126
 pkg-pinsocket-1x27-d1.0-text-name,c2c93f52-009b-42ee-b17d-093520d955eb
 pkg-pinsocket-1x27-d1.0-text-value,799569ef-3ee5-41eb-a4e1-73ac8844b063
 pkg-pinsocket-1x27-d1.1-3d,a95d504c-ae1b-4e6d-b65e-378344ab08e5
@@ -17004,6 +17596,8 @@ pkg-pinsocket-1x27-d1.1-pad-8,7aa49ad1-724b-4ce7-bfa0-1abfd8740055
 pkg-pinsocket-1x27-d1.1-pad-9,efeb67b4-7f93-4db5-bd95-92fef0ab9a22
 pkg-pinsocket-1x27-d1.1-pkg,17aa5459-0fb5-48c9-9039-2d152140973e
 pkg-pinsocket-1x27-d1.1-polygon-contour,f80162d9-de84-4d39-9ad2-acd8470db2ae
+pkg-pinsocket-1x27-d1.1-polygon-courtyard,216f261a-db48-463e-8478-d848d4b63f64
+pkg-pinsocket-1x27-d1.1-polygon-outline,5c6fafc7-2f7f-46d5-9751-5741a94a7084
 pkg-pinsocket-1x27-d1.1-text-name,a18c8769-dd47-474d-adfd-a2d0d9170c45
 pkg-pinsocket-1x27-d1.1-text-value,51d621c1-e4ba-4903-9fde-57e8f3213f60
 pkg-pinsocket-1x28-d0.9-3d,7c283e45-3fba-4137-8475-008f6820e9aa
@@ -17038,6 +17632,8 @@ pkg-pinsocket-1x28-d0.9-pad-8,3439d67f-5104-4234-8915-ab48d3bf9b2e
 pkg-pinsocket-1x28-d0.9-pad-9,8e5ed573-9dff-4205-a8ce-d3a12c1491af
 pkg-pinsocket-1x28-d0.9-pkg,ae1cbcf0-a3f3-4471-826a-208f0f5762f3
 pkg-pinsocket-1x28-d0.9-polygon-contour,cd0584c9-e3e8-4ef7-8afa-c3bd417bd213
+pkg-pinsocket-1x28-d0.9-polygon-courtyard,2124e324-7e9b-4563-8065-b9b764c72410
+pkg-pinsocket-1x28-d0.9-polygon-outline,11b0510f-29a2-40b6-8da1-a8ae2c05db29
 pkg-pinsocket-1x28-d0.9-text-name,4071c589-a9bc-46c9-bcd5-ba20f7b844a9
 pkg-pinsocket-1x28-d0.9-text-value,b9b6f1cd-3f68-459e-8b59-5228923aa003
 pkg-pinsocket-1x28-d1.0-3d,6d77f8c0-958f-4e3f-8e18-529bd2f0b5a2
@@ -17072,6 +17668,8 @@ pkg-pinsocket-1x28-d1.0-pad-8,ad561012-52ee-405d-b089-911c496f2832
 pkg-pinsocket-1x28-d1.0-pad-9,39358664-21ef-4e6b-8433-cb9b2f00170d
 pkg-pinsocket-1x28-d1.0-pkg,bd78dee9-3ea9-4793-80a0-ddb2caaccf0c
 pkg-pinsocket-1x28-d1.0-polygon-contour,87a13c43-55e2-44f0-9c0b-67f0f2833b03
+pkg-pinsocket-1x28-d1.0-polygon-courtyard,cba736de-0774-47aa-b5b5-84085a0ee4e3
+pkg-pinsocket-1x28-d1.0-polygon-outline,7abd9608-6424-408f-886e-3bcadc5771f4
 pkg-pinsocket-1x28-d1.0-text-name,4e1f4074-28a4-4499-845e-3857d10bbba3
 pkg-pinsocket-1x28-d1.0-text-value,3c5dbdd3-6b88-4f9d-ab9e-d2fe4e35a6e1
 pkg-pinsocket-1x28-d1.1-3d,59259140-a564-4f79-b956-0288e9ae89e3
@@ -17106,6 +17704,8 @@ pkg-pinsocket-1x28-d1.1-pad-8,4cbbccb0-fd06-4164-8d96-7e6de3a5414d
 pkg-pinsocket-1x28-d1.1-pad-9,9ce8bcf5-ba12-4bc4-b05c-32f3f1180675
 pkg-pinsocket-1x28-d1.1-pkg,fea2c948-7837-4deb-8e6c-b8e16df326e0
 pkg-pinsocket-1x28-d1.1-polygon-contour,ef88a3f8-f976-451e-a435-c11fa8ffee94
+pkg-pinsocket-1x28-d1.1-polygon-courtyard,8410fbc7-3449-4f23-8d04-70b8fce1484d
+pkg-pinsocket-1x28-d1.1-polygon-outline,de18a925-01cf-4f97-96e7-e36a50f7f43e
 pkg-pinsocket-1x28-d1.1-text-name,2d9e7248-8af1-4094-b21f-126303669789
 pkg-pinsocket-1x28-d1.1-text-value,14cac5ac-d85c-48a9-8045-8ee5e73f4323
 pkg-pinsocket-1x29-d0.9-3d,3048295f-656b-4572-889c-9d97800da58a
@@ -17141,6 +17741,8 @@ pkg-pinsocket-1x29-d0.9-pad-8,acf940fa-be27-4099-a4d5-9628e48ace86
 pkg-pinsocket-1x29-d0.9-pad-9,8ca7ed24-dbb4-4f77-8f5f-21d9fcda88b6
 pkg-pinsocket-1x29-d0.9-pkg,b703670e-c919-4f76-b01c-ada8ddef63c8
 pkg-pinsocket-1x29-d0.9-polygon-contour,55611a78-aa17-4174-8de0-a638dc64c629
+pkg-pinsocket-1x29-d0.9-polygon-courtyard,09e527f8-bf80-4965-b967-5decab59748b
+pkg-pinsocket-1x29-d0.9-polygon-outline,ebcce854-a9ad-481a-9864-c9d689b4e0e7
 pkg-pinsocket-1x29-d0.9-text-name,d321e0e3-0550-423d-b8b8-d9999810136d
 pkg-pinsocket-1x29-d0.9-text-value,6f22de26-40e3-49bb-a6ea-351543c4dc34
 pkg-pinsocket-1x29-d1.0-3d,e5a57400-822a-4926-94ee-032c9a339a6c
@@ -17176,6 +17778,8 @@ pkg-pinsocket-1x29-d1.0-pad-8,e857604a-5c47-42b2-90a0-7f9871f05cd7
 pkg-pinsocket-1x29-d1.0-pad-9,11006d61-e33d-413f-a088-8c501161f8c4
 pkg-pinsocket-1x29-d1.0-pkg,b670fa05-b4e1-4d08-be2f-fbdd106115a8
 pkg-pinsocket-1x29-d1.0-polygon-contour,e9a953d8-f06f-4ef8-9862-547d73186a27
+pkg-pinsocket-1x29-d1.0-polygon-courtyard,76b84d8e-029a-4299-ab54-9823f644c72a
+pkg-pinsocket-1x29-d1.0-polygon-outline,09a5d5b2-3952-4522-8339-18d3cfee6378
 pkg-pinsocket-1x29-d1.0-text-name,1b965b36-7545-4298-adcc-353d9863c700
 pkg-pinsocket-1x29-d1.0-text-value,ddff4e78-772c-473b-8722-afc0e218c642
 pkg-pinsocket-1x29-d1.1-3d,7222628d-041d-4948-a3b3-b40e362f9074
@@ -17211,6 +17815,8 @@ pkg-pinsocket-1x29-d1.1-pad-8,b2c409d7-09e3-466f-86f4-01089c22c39a
 pkg-pinsocket-1x29-d1.1-pad-9,a0538a81-38cf-4437-b120-32a504fb4eed
 pkg-pinsocket-1x29-d1.1-pkg,636129c4-00bd-4075-8ff3-3089f35ce3e7
 pkg-pinsocket-1x29-d1.1-polygon-contour,8366e6bf-e560-4a2c-a9f7-59e41850c1f2
+pkg-pinsocket-1x29-d1.1-polygon-courtyard,3390727d-f49a-491d-8cbb-2b6d738486b8
+pkg-pinsocket-1x29-d1.1-polygon-outline,1fefccb6-0526-43a2-9dcd-441c0b39d84e
 pkg-pinsocket-1x29-d1.1-text-name,e397793d-1f1e-450c-917f-579d3add36df
 pkg-pinsocket-1x29-d1.1-text-value,783fafde-105c-4040-8ed6-5d132aebab23
 pkg-pinsocket-1x3-d0.9-3d,174fa475-bd92-4945-aa0e-29548b3fcb96
@@ -17220,6 +17826,8 @@ pkg-pinsocket-1x3-d0.9-pad-1,b791d283-899e-42b1-b5ee-6bdf057506b8
 pkg-pinsocket-1x3-d0.9-pad-2,ba27192d-3111-4bf0-9652-67671bb8520b
 pkg-pinsocket-1x3-d0.9-pkg,2f0f6d72-2a71-49da-b4ec-5ee5678c97e2
 pkg-pinsocket-1x3-d0.9-polygon-contour,ecc999a9-37c4-47fa-a687-db5cdbac78d9
+pkg-pinsocket-1x3-d0.9-polygon-courtyard,f70e2744-fd09-40f2-9636-ce3bcd88761f
+pkg-pinsocket-1x3-d0.9-polygon-outline,19a88b66-916d-4531-be6a-fa4e40bf137c
 pkg-pinsocket-1x3-d0.9-text-name,34a95be0-b3f5-4ace-b827-cfed17099f02
 pkg-pinsocket-1x3-d0.9-text-value,08d1d200-3278-41d3-a76e-a077d81c96b2
 pkg-pinsocket-1x3-d1.0-3d,37536330-208d-41b1-a87f-14a3326c3ca4
@@ -17229,6 +17837,8 @@ pkg-pinsocket-1x3-d1.0-pad-1,f8f6b6cb-d3da-412c-8737-5933a12b99cb
 pkg-pinsocket-1x3-d1.0-pad-2,41f20ad9-4dfb-482a-8451-76de913abb80
 pkg-pinsocket-1x3-d1.0-pkg,4f119178-d8be-42da-a2a6-1979db7aa680
 pkg-pinsocket-1x3-d1.0-polygon-contour,d1555bea-d3e8-45b3-8119-979f9557fdc2
+pkg-pinsocket-1x3-d1.0-polygon-courtyard,22ffad55-1398-44a4-8904-caf3cdd961f3
+pkg-pinsocket-1x3-d1.0-polygon-outline,961a2381-ad78-478f-8c81-6ef06f01c98b
 pkg-pinsocket-1x3-d1.0-text-name,5e511a37-7249-4fc3-acf1-5cda2aa90d3f
 pkg-pinsocket-1x3-d1.0-text-value,bf73f2c8-717d-4cb1-88ce-6ab71ee81359
 pkg-pinsocket-1x3-d1.1-3d,ae204d40-8527-4284-adfa-a8860e6bf2b7
@@ -17238,6 +17848,8 @@ pkg-pinsocket-1x3-d1.1-pad-1,7be0cfbd-6cc0-4cc5-ad60-de1dfb101686
 pkg-pinsocket-1x3-d1.1-pad-2,3edd60ae-7483-4e1f-9a7f-98cfffa6e016
 pkg-pinsocket-1x3-d1.1-pkg,3fb61b45-c93a-451c-9e6b-18e542e45ec4
 pkg-pinsocket-1x3-d1.1-polygon-contour,06c6d641-9704-4a6e-98ac-2f731afa74b5
+pkg-pinsocket-1x3-d1.1-polygon-courtyard,63306b32-e80b-479e-beed-5a6863e15615
+pkg-pinsocket-1x3-d1.1-polygon-outline,f3ebd43a-87f1-477b-b1db-6bb627aa207d
 pkg-pinsocket-1x3-d1.1-text-name,d1306c09-20c3-4ce6-9c6c-0fd4b20d77ef
 pkg-pinsocket-1x3-d1.1-text-value,1c62a463-7ea1-4d69-bb45-fe31768b768d
 pkg-pinsocket-1x30-d0.9-3d,eb43506c-79f4-4965-9b05-86b154f50ce5
@@ -17274,6 +17886,8 @@ pkg-pinsocket-1x30-d0.9-pad-8,7551ea62-1b8d-444f-938e-30b23f799ea9
 pkg-pinsocket-1x30-d0.9-pad-9,c62cbd3c-d74d-47e7-a826-495fe15959ce
 pkg-pinsocket-1x30-d0.9-pkg,2dd3e039-54a6-4859-8dfd-de088ae2246e
 pkg-pinsocket-1x30-d0.9-polygon-contour,8b9a519d-bd5e-4a0e-ad79-3277cb2c38c0
+pkg-pinsocket-1x30-d0.9-polygon-courtyard,ef05651e-012f-4e66-b9b2-4057446dfd4a
+pkg-pinsocket-1x30-d0.9-polygon-outline,956f0187-9430-441f-a67e-7c0572db2ae5
 pkg-pinsocket-1x30-d0.9-text-name,9b9b9080-0128-4ead-876c-5465816a2f69
 pkg-pinsocket-1x30-d0.9-text-value,a4ca30a2-8c61-4d4c-bf55-60ef6b9fcceb
 pkg-pinsocket-1x30-d1.0-3d,813832c2-e556-462b-bb76-7851f9ae5e5b
@@ -17310,6 +17924,8 @@ pkg-pinsocket-1x30-d1.0-pad-8,2cff98af-942b-436d-a1eb-40a4dce250de
 pkg-pinsocket-1x30-d1.0-pad-9,db3157fa-03a1-4cb1-9749-2ae3bc222f23
 pkg-pinsocket-1x30-d1.0-pkg,676cc37a-0b16-4d04-84db-63cbe40f0c1d
 pkg-pinsocket-1x30-d1.0-polygon-contour,a9ef2a6e-a140-4130-8eb0-f91dc6dc97cc
+pkg-pinsocket-1x30-d1.0-polygon-courtyard,cc70bcfb-9c8a-4669-9fcb-2dec354dcea2
+pkg-pinsocket-1x30-d1.0-polygon-outline,2a6d82d9-dded-4837-8c69-db42f6b6c8e3
 pkg-pinsocket-1x30-d1.0-text-name,71a01b87-7b8a-4c41-89ba-f40fb0d89253
 pkg-pinsocket-1x30-d1.0-text-value,d2930994-1440-483e-a55f-ef527cec77f9
 pkg-pinsocket-1x30-d1.1-3d,8f9b5bfd-fc91-4af5-a20b-7409fe3df6d5
@@ -17346,6 +17962,8 @@ pkg-pinsocket-1x30-d1.1-pad-8,c04759eb-45c3-4c12-92ce-dcdee75a1a5f
 pkg-pinsocket-1x30-d1.1-pad-9,a87851b3-408b-4958-98b9-7f077a8a740d
 pkg-pinsocket-1x30-d1.1-pkg,a8e365c8-55a2-4511-a37d-31520d5fec30
 pkg-pinsocket-1x30-d1.1-polygon-contour,c5a9c4d7-6809-4cca-acd6-7e63b08e4934
+pkg-pinsocket-1x30-d1.1-polygon-courtyard,a111894a-1b3b-4ca1-b96c-6e9f34677b60
+pkg-pinsocket-1x30-d1.1-polygon-outline,76251c73-b08f-45e7-b084-40f161853bde
 pkg-pinsocket-1x30-d1.1-text-name,e1285bfe-aad2-4464-bd56-4f04bca98d2c
 pkg-pinsocket-1x30-d1.1-text-value,c0fb93aa-2806-4cb0-945d-48e10bc23a2a
 pkg-pinsocket-1x31-d0.9-3d,24e92eb8-679f-4fa6-a73d-651141b3d365
@@ -17383,6 +18001,8 @@ pkg-pinsocket-1x31-d0.9-pad-8,511e649e-d49c-4283-ad62-cb43b85a7991
 pkg-pinsocket-1x31-d0.9-pad-9,45c4094b-6afc-49aa-8687-73ce78dd39e6
 pkg-pinsocket-1x31-d0.9-pkg,7e3d8fbf-e3a3-4c97-92a9-e746ccce131d
 pkg-pinsocket-1x31-d0.9-polygon-contour,0767a652-8488-4af9-a253-5632b1798cb4
+pkg-pinsocket-1x31-d0.9-polygon-courtyard,2e94a15b-f534-4ac7-9b25-b4c61acd1a8e
+pkg-pinsocket-1x31-d0.9-polygon-outline,d31a67f0-f5bf-4f4a-8bc3-001866e27e4c
 pkg-pinsocket-1x31-d0.9-text-name,7e3ccad3-619b-4123-9e61-f641e84ccb64
 pkg-pinsocket-1x31-d0.9-text-value,5540258b-16fe-4a0d-9cf8-91a83b6b2390
 pkg-pinsocket-1x31-d1.0-3d,60c7a140-7a57-4341-85d8-bcf2322e3b0c
@@ -17420,6 +18040,8 @@ pkg-pinsocket-1x31-d1.0-pad-8,41444cf5-73a4-4254-910a-e805670c18f0
 pkg-pinsocket-1x31-d1.0-pad-9,721cfd52-add7-4be5-8690-54c389111ac5
 pkg-pinsocket-1x31-d1.0-pkg,61a26805-ce99-44e5-b5a0-45b57656fb39
 pkg-pinsocket-1x31-d1.0-polygon-contour,86316d54-d783-4c91-9297-32a6b0124818
+pkg-pinsocket-1x31-d1.0-polygon-courtyard,3ca226af-37a5-49fa-b65b-8cc525ea6620
+pkg-pinsocket-1x31-d1.0-polygon-outline,6e301eb0-0cce-4ebd-bc41-113949660e99
 pkg-pinsocket-1x31-d1.0-text-name,679806cb-4d4e-4697-b2e4-9ccb73bdd6d7
 pkg-pinsocket-1x31-d1.0-text-value,b62e87f9-47ba-4bf8-8cdc-bdb22b354845
 pkg-pinsocket-1x31-d1.1-3d,5b8724f6-fcdb-46f6-9062-dfdea2ce8a1f
@@ -17457,6 +18079,8 @@ pkg-pinsocket-1x31-d1.1-pad-8,8318ac22-6f49-4245-bad9-0424a174519d
 pkg-pinsocket-1x31-d1.1-pad-9,a202da26-34e7-4c9d-861c-0581d275a8c1
 pkg-pinsocket-1x31-d1.1-pkg,01ccf413-844d-4b9e-a47c-f201f81c7d4f
 pkg-pinsocket-1x31-d1.1-polygon-contour,ac01a5b2-770a-4cb3-9e27-e63b434b667d
+pkg-pinsocket-1x31-d1.1-polygon-courtyard,0bbd96d6-7514-4d9e-be1d-4a452cce2f2c
+pkg-pinsocket-1x31-d1.1-polygon-outline,cd8d8592-d1f7-4d64-8544-711ec3606abe
 pkg-pinsocket-1x31-d1.1-text-name,cf62ea67-7fa8-4cbb-9c50-74329ec93357
 pkg-pinsocket-1x31-d1.1-text-value,778c3c7a-eb9b-4f64-b0cd-0e8d5acee691
 pkg-pinsocket-1x32-d0.9-3d,9cad650e-9c2c-44cf-aeda-9b525299ab67
@@ -17495,6 +18119,8 @@ pkg-pinsocket-1x32-d0.9-pad-8,217aac32-f8e5-40d8-b3a5-0c732cff267c
 pkg-pinsocket-1x32-d0.9-pad-9,56d4fe86-bd3a-46b5-ae35-a5eae49059e0
 pkg-pinsocket-1x32-d0.9-pkg,e1c2f4f2-1aca-4c1d-8d02-e8d9983db674
 pkg-pinsocket-1x32-d0.9-polygon-contour,beabb13e-8941-440e-86dc-b1d370851d56
+pkg-pinsocket-1x32-d0.9-polygon-courtyard,633ed48d-bf1f-4120-bb7a-2f47703bacab
+pkg-pinsocket-1x32-d0.9-polygon-outline,c0d345b9-fead-4be5-9662-851121223811
 pkg-pinsocket-1x32-d0.9-text-name,e3e9050c-52e9-4059-b530-5d2be5429f3c
 pkg-pinsocket-1x32-d0.9-text-value,66f0c41f-3fd3-4859-8456-79984dabe770
 pkg-pinsocket-1x32-d1.0-3d,1b48744e-85d0-4cc2-96b4-f4af3650ad71
@@ -17533,6 +18159,8 @@ pkg-pinsocket-1x32-d1.0-pad-8,8ade38fc-eacc-424a-b399-019d33b801a5
 pkg-pinsocket-1x32-d1.0-pad-9,bd5bfc9e-2160-4cf8-a4d3-743f0c4a9592
 pkg-pinsocket-1x32-d1.0-pkg,3d843e8c-2000-4fab-83ff-9f0902aa8c77
 pkg-pinsocket-1x32-d1.0-polygon-contour,6aa1f411-6bb7-4295-af82-19a9ffdbb526
+pkg-pinsocket-1x32-d1.0-polygon-courtyard,47292f11-c7ce-4c5c-bac8-f3256c4edf2a
+pkg-pinsocket-1x32-d1.0-polygon-outline,7514d4c3-f961-42ab-8e1d-e29d6fa6b91c
 pkg-pinsocket-1x32-d1.0-text-name,ea964848-eea8-415f-94f3-87920f9676c6
 pkg-pinsocket-1x32-d1.0-text-value,4ce43298-5992-4591-9eeb-9d4c8e73c6ae
 pkg-pinsocket-1x32-d1.1-3d,c1736bea-b964-4d47-9648-7ade310eea46
@@ -17571,6 +18199,8 @@ pkg-pinsocket-1x32-d1.1-pad-8,2899e004-1a4f-44f9-8aaf-d2828d2a6581
 pkg-pinsocket-1x32-d1.1-pad-9,56a4f3c9-f26c-4037-9826-fcd8e6faf6da
 pkg-pinsocket-1x32-d1.1-pkg,3d06cb63-187f-46ac-937e-cc72034fd739
 pkg-pinsocket-1x32-d1.1-polygon-contour,dafd895c-40bf-4c54-a809-452e7f2bb3b0
+pkg-pinsocket-1x32-d1.1-polygon-courtyard,71bafed5-ee9b-4b99-829f-ff61d7c4e4ea
+pkg-pinsocket-1x32-d1.1-polygon-outline,d2661113-7b0e-4199-8a0b-bd1401d66d97
 pkg-pinsocket-1x32-d1.1-text-name,f3668ee6-ac0e-41b1-87ad-8721cea7e654
 pkg-pinsocket-1x32-d1.1-text-value,91ca7226-0837-4e20-bf38-1f63efb4925e
 pkg-pinsocket-1x33-d0.9-3d,5461bc17-4b36-47c5-acd5-59fc4bbe8048
@@ -17610,6 +18240,8 @@ pkg-pinsocket-1x33-d0.9-pad-8,772e7705-4631-4065-9d31-37cd4f72135b
 pkg-pinsocket-1x33-d0.9-pad-9,6fd0a746-0743-4698-9b10-f6320cea052f
 pkg-pinsocket-1x33-d0.9-pkg,8600f667-734c-47d4-a762-0554dd23f992
 pkg-pinsocket-1x33-d0.9-polygon-contour,2aa7dffb-75a8-4780-be4a-fc0eb1ba339c
+pkg-pinsocket-1x33-d0.9-polygon-courtyard,ec878593-9e66-4e4b-92f6-c0587018aa2e
+pkg-pinsocket-1x33-d0.9-polygon-outline,f6fee77f-63a3-40d4-bae8-5af1d047de3e
 pkg-pinsocket-1x33-d0.9-text-name,cea3d89a-f7ef-4603-bb7d-9bbd1da49c58
 pkg-pinsocket-1x33-d0.9-text-value,c080f82d-e59d-4014-8681-d90becf6dee2
 pkg-pinsocket-1x33-d1.0-3d,6d216ce1-441a-478b-b592-ff4fc2ff8c02
@@ -17649,6 +18281,8 @@ pkg-pinsocket-1x33-d1.0-pad-8,e89d62f3-a791-48b7-b604-bdc8e9ffe3bc
 pkg-pinsocket-1x33-d1.0-pad-9,6418fe79-46da-4685-9f1c-c4d9b04b93ad
 pkg-pinsocket-1x33-d1.0-pkg,77439c58-7f5a-4fe3-ae61-bc97b7abc82f
 pkg-pinsocket-1x33-d1.0-polygon-contour,28aee3ad-d3a8-4c52-8174-cd6a84a4bd68
+pkg-pinsocket-1x33-d1.0-polygon-courtyard,f807a73b-fe9c-491e-81d8-d85cdf15fd95
+pkg-pinsocket-1x33-d1.0-polygon-outline,9d3c5d1e-e7d0-41b1-b369-a7b2188d3970
 pkg-pinsocket-1x33-d1.0-text-name,1ebfda33-1a3e-4182-ad42-0017d1be1c8f
 pkg-pinsocket-1x33-d1.0-text-value,23109f9d-b0b7-46cb-afe0-252840b0d5e3
 pkg-pinsocket-1x33-d1.1-3d,37685075-8e00-4571-9b1a-b0ebe7b2f7d1
@@ -17688,6 +18322,8 @@ pkg-pinsocket-1x33-d1.1-pad-8,bcfe3c95-1f28-480e-a04f-0d5da4bc51bd
 pkg-pinsocket-1x33-d1.1-pad-9,02b00dd0-ff92-4f63-b3f4-b2293d701844
 pkg-pinsocket-1x33-d1.1-pkg,b7d969e8-827b-411e-be94-1f04f000ff5e
 pkg-pinsocket-1x33-d1.1-polygon-contour,88a3abe8-bf08-4d92-8126-79a3e79b86ee
+pkg-pinsocket-1x33-d1.1-polygon-courtyard,430ccee4-dd83-472f-b10a-3bf1f816fc28
+pkg-pinsocket-1x33-d1.1-polygon-outline,a01ceddc-1e6f-4df1-a093-0bc3a796c88c
 pkg-pinsocket-1x33-d1.1-text-name,a4f62c0f-af78-47c4-a59c-7b7e2d4a9d1f
 pkg-pinsocket-1x33-d1.1-text-value,ec03b875-d279-4ba9-b2f9-a4b33b1b3ba1
 pkg-pinsocket-1x34-d0.9-3d,4c824717-c2bc-4d87-9f81-d16166e2e797
@@ -17728,6 +18364,8 @@ pkg-pinsocket-1x34-d0.9-pad-8,eaa02e61-3e54-49bd-99a9-417f26301c03
 pkg-pinsocket-1x34-d0.9-pad-9,3d1c4768-b3d2-4923-bd32-296e8ff55153
 pkg-pinsocket-1x34-d0.9-pkg,e1d7f1de-c4c6-42f5-95ae-c67b1b974138
 pkg-pinsocket-1x34-d0.9-polygon-contour,7bd93326-fb6c-48b3-943b-53dba15329aa
+pkg-pinsocket-1x34-d0.9-polygon-courtyard,f4b7f0f4-fcee-4741-a4e1-3353241db654
+pkg-pinsocket-1x34-d0.9-polygon-outline,020d2e86-4bb6-4db1-b0a8-baee7ddce126
 pkg-pinsocket-1x34-d0.9-text-name,50a8e8fc-ac3c-4341-b2b7-c6383c11a0d9
 pkg-pinsocket-1x34-d0.9-text-value,58aa07c1-39dd-4ee6-afae-9d462c22c2ed
 pkg-pinsocket-1x34-d1.0-3d,c56e073b-fb24-411f-b68a-63587a7dfb17
@@ -17768,6 +18406,8 @@ pkg-pinsocket-1x34-d1.0-pad-8,6e237ccd-a3a3-4fac-9fbe-8b0a9665661f
 pkg-pinsocket-1x34-d1.0-pad-9,fb0263a3-7e1d-4f7b-b38b-ac941cd4aca2
 pkg-pinsocket-1x34-d1.0-pkg,303c341b-35e8-4502-981a-938915d6f221
 pkg-pinsocket-1x34-d1.0-polygon-contour,5c1553ed-fd80-41b4-80b3-23f5c1e95536
+pkg-pinsocket-1x34-d1.0-polygon-courtyard,4a60d0b1-225c-4c2a-8ac7-1d843b480094
+pkg-pinsocket-1x34-d1.0-polygon-outline,b1da0e4e-3bdd-40df-adab-387cb6bbaf30
 pkg-pinsocket-1x34-d1.0-text-name,8d29d747-6257-48a7-b725-aa74d49b2672
 pkg-pinsocket-1x34-d1.0-text-value,c1f5564d-22fa-42a4-85cc-5163fa048f28
 pkg-pinsocket-1x34-d1.1-3d,106b7364-0a55-443b-956e-5e784315edee
@@ -17808,6 +18448,8 @@ pkg-pinsocket-1x34-d1.1-pad-8,cdd8c6f1-b2ba-4c67-900c-2de4899b491e
 pkg-pinsocket-1x34-d1.1-pad-9,821dcc69-0b39-4145-a579-425f8e7c2c2e
 pkg-pinsocket-1x34-d1.1-pkg,c19fb959-bbec-436c-a9ab-23aa404b4a84
 pkg-pinsocket-1x34-d1.1-polygon-contour,fb9b4098-5666-403e-b21b-b729479e4823
+pkg-pinsocket-1x34-d1.1-polygon-courtyard,2eb55361-76f0-4955-b9ae-711785b644ed
+pkg-pinsocket-1x34-d1.1-polygon-outline,a01ebfa2-a2e5-4761-a172-eef4f3290049
 pkg-pinsocket-1x34-d1.1-text-name,0c017f42-4994-4165-bcfc-7e4c5c2ba46a
 pkg-pinsocket-1x34-d1.1-text-value,6c1008f1-8394-4922-8563-48a5f6ad375c
 pkg-pinsocket-1x35-d0.9-3d,ab1afe5f-154d-4390-9692-130cce5c6ade
@@ -17849,6 +18491,8 @@ pkg-pinsocket-1x35-d0.9-pad-8,dee5faac-b849-460a-8402-18d81ba160da
 pkg-pinsocket-1x35-d0.9-pad-9,1f3fa51e-1137-4ffe-baa7-6e257524e05a
 pkg-pinsocket-1x35-d0.9-pkg,00b063b9-54fc-43cd-a455-7e7d3c5039d7
 pkg-pinsocket-1x35-d0.9-polygon-contour,06b2f7a3-ddfb-4306-ac07-b2a463d07fff
+pkg-pinsocket-1x35-d0.9-polygon-courtyard,d206f9a2-ee3c-4a94-a106-8feba241655d
+pkg-pinsocket-1x35-d0.9-polygon-outline,246a74de-2858-4d79-8602-15af5d212cf0
 pkg-pinsocket-1x35-d0.9-text-name,eec394e2-620d-42e2-8984-a8c375d89d51
 pkg-pinsocket-1x35-d0.9-text-value,85014d8a-9a7b-4b2e-bef7-bd7675ac7b45
 pkg-pinsocket-1x35-d1.0-3d,f6a6cc30-5b6d-4ffc-8d63-25ea930e93ca
@@ -17890,6 +18534,8 @@ pkg-pinsocket-1x35-d1.0-pad-8,ce619f14-c6e1-454a-aef0-db30bc57ba24
 pkg-pinsocket-1x35-d1.0-pad-9,c29ece98-94d9-4f71-9015-f703390235eb
 pkg-pinsocket-1x35-d1.0-pkg,84d818a7-d4b3-4cb4-84d8-9efd4da2dea0
 pkg-pinsocket-1x35-d1.0-polygon-contour,99e60ae0-693c-4ece-9760-992c2ded1230
+pkg-pinsocket-1x35-d1.0-polygon-courtyard,4fa1e589-f231-4a5a-b83c-70bc707d0f11
+pkg-pinsocket-1x35-d1.0-polygon-outline,2d3a2701-d2af-4cd3-87be-5365d5410fba
 pkg-pinsocket-1x35-d1.0-text-name,3ade08b6-be85-4659-967a-ca7a86871aaa
 pkg-pinsocket-1x35-d1.0-text-value,255974e9-46ca-4d39-a618-30be7c5b3cdc
 pkg-pinsocket-1x35-d1.1-3d,229de6ac-1863-4195-9d8e-e1e6b5a22aa4
@@ -17931,6 +18577,8 @@ pkg-pinsocket-1x35-d1.1-pad-8,57a9204e-c90c-4ba6-9afd-a662f23719fc
 pkg-pinsocket-1x35-d1.1-pad-9,a741230e-a31c-4631-b655-3a68b9443c2e
 pkg-pinsocket-1x35-d1.1-pkg,3aa4cf22-9736-45da-82fb-847667012023
 pkg-pinsocket-1x35-d1.1-polygon-contour,65b13f8e-969a-4e13-80fb-f0c610a1084a
+pkg-pinsocket-1x35-d1.1-polygon-courtyard,d05bb854-8fec-4c7f-a7a4-595b3f48fa42
+pkg-pinsocket-1x35-d1.1-polygon-outline,848ddd25-f9bb-41b1-a64b-23c0c7af320c
 pkg-pinsocket-1x35-d1.1-text-name,8ceaacfa-a7c7-42ea-b420-e0bf68cfa36f
 pkg-pinsocket-1x35-d1.1-text-value,9fa6609b-388a-49bf-aadd-725a5eedf470
 pkg-pinsocket-1x36-d0.9-3d,36ac926a-e7fd-4d42-8f3a-8ced88095bfe
@@ -17973,6 +18621,8 @@ pkg-pinsocket-1x36-d0.9-pad-8,2ce3116e-4850-40dd-8801-b27dd7c2b9cc
 pkg-pinsocket-1x36-d0.9-pad-9,3548be33-557c-4d22-a8d0-853ee691c118
 pkg-pinsocket-1x36-d0.9-pkg,0b9a5d2e-75c6-462e-a22a-805843291251
 pkg-pinsocket-1x36-d0.9-polygon-contour,ef5ecb57-ba4a-4c62-9396-044314e92d5d
+pkg-pinsocket-1x36-d0.9-polygon-courtyard,363ac94b-8074-4990-b62b-a59b6045df4e
+pkg-pinsocket-1x36-d0.9-polygon-outline,842f0a0e-3951-41f1-bdaf-0d76bc9e24d2
 pkg-pinsocket-1x36-d0.9-text-name,14a8c740-1dc9-4a12-a5f9-2b422e5ebc2c
 pkg-pinsocket-1x36-d0.9-text-value,d456ed43-9fcc-427a-98cf-93367bb28ce9
 pkg-pinsocket-1x36-d1.0-3d,ab2abd35-f7fa-4d18-a423-9a4307cf879d
@@ -18015,6 +18665,8 @@ pkg-pinsocket-1x36-d1.0-pad-8,bb68e085-d7d1-43bc-9c22-9f8a082611a8
 pkg-pinsocket-1x36-d1.0-pad-9,7f175846-d599-4183-8eba-5e125a37235f
 pkg-pinsocket-1x36-d1.0-pkg,5dd8c3d5-944d-4d4f-8c46-1a16689e5c86
 pkg-pinsocket-1x36-d1.0-polygon-contour,fdfc0c9e-33a5-44b6-857d-0d613c7b208a
+pkg-pinsocket-1x36-d1.0-polygon-courtyard,ea075856-8a51-4bec-939c-5f1803d14248
+pkg-pinsocket-1x36-d1.0-polygon-outline,b7af2e36-26a6-4437-aacd-1780d1907081
 pkg-pinsocket-1x36-d1.0-text-name,71cc2e7d-e193-4cfc-bcad-e3149357f263
 pkg-pinsocket-1x36-d1.0-text-value,64dc60e3-1c69-442f-a0b1-3ff7678c7f8b
 pkg-pinsocket-1x36-d1.1-3d,1b13e399-4a0b-4079-a868-eef55882a53d
@@ -18057,6 +18709,8 @@ pkg-pinsocket-1x36-d1.1-pad-8,a695dde1-c23c-4373-8d6a-06b19e511ed3
 pkg-pinsocket-1x36-d1.1-pad-9,1065a39d-9d90-43b3-abac-fd761f8c4bc6
 pkg-pinsocket-1x36-d1.1-pkg,b0b2e7cf-32f3-4546-8540-fb78d95db333
 pkg-pinsocket-1x36-d1.1-polygon-contour,156367f7-0c09-4b22-9d9f-7dc8acea3f81
+pkg-pinsocket-1x36-d1.1-polygon-courtyard,d25ea7b2-8669-45a9-bc77-50d54a85179e
+pkg-pinsocket-1x36-d1.1-polygon-outline,9de20618-056d-4137-9925-f9304a77aef2
 pkg-pinsocket-1x36-d1.1-text-name,262c07d7-8053-4c77-a1c6-bbc88d0a381c
 pkg-pinsocket-1x36-d1.1-text-value,c317710a-a97f-4611-83af-9c226fe8170a
 pkg-pinsocket-1x37-d0.9-3d,962b839f-0fec-487a-ab0f-30555d383342
@@ -18100,6 +18754,8 @@ pkg-pinsocket-1x37-d0.9-pad-8,e14503d5-5be0-4001-99b7-1d56cee9577c
 pkg-pinsocket-1x37-d0.9-pad-9,b735bd0a-6885-4fa1-8556-e2963547db7a
 pkg-pinsocket-1x37-d0.9-pkg,c9325d66-c83f-44f9-b958-31529bdf7f60
 pkg-pinsocket-1x37-d0.9-polygon-contour,4de47d2e-fab7-4d1d-b0a0-a09234166e33
+pkg-pinsocket-1x37-d0.9-polygon-courtyard,1c0a6f82-c423-4364-963b-18414b186328
+pkg-pinsocket-1x37-d0.9-polygon-outline,2d84013a-1ec2-40e3-bd68-051a5b14ed51
 pkg-pinsocket-1x37-d0.9-text-name,3dd44b18-d5e8-4aea-9f08-db2f00ed5652
 pkg-pinsocket-1x37-d0.9-text-value,9e9675dd-fc04-4322-9e6f-8eb2eeca38e0
 pkg-pinsocket-1x37-d1.0-3d,fdc6bdfb-3b13-4be3-8f25-3e6eb061a4c2
@@ -18143,6 +18799,8 @@ pkg-pinsocket-1x37-d1.0-pad-8,d44bdc3d-ab40-459e-97d6-be4d3e7b3a49
 pkg-pinsocket-1x37-d1.0-pad-9,d2ea3ba6-f822-4cf6-94dc-6ba2f1737d2d
 pkg-pinsocket-1x37-d1.0-pkg,cd685557-5f88-4f89-b629-52348292fd84
 pkg-pinsocket-1x37-d1.0-polygon-contour,ae89cb27-cbfa-4ede-91fc-88821e037509
+pkg-pinsocket-1x37-d1.0-polygon-courtyard,f0fb108e-5908-454e-9f8a-1838406ba2f2
+pkg-pinsocket-1x37-d1.0-polygon-outline,85049fc0-6f97-4827-9f8a-dc5fabe0c0f8
 pkg-pinsocket-1x37-d1.0-text-name,e65eb63c-2feb-47dd-8569-84408fb2010e
 pkg-pinsocket-1x37-d1.0-text-value,041e12e5-5ac0-4bdb-9c5f-50c3679cf405
 pkg-pinsocket-1x37-d1.1-3d,d2b77919-ada7-4888-9821-b3b6a6dcb62f
@@ -18186,6 +18844,8 @@ pkg-pinsocket-1x37-d1.1-pad-8,f47745ba-423a-4f52-be40-906654dec26d
 pkg-pinsocket-1x37-d1.1-pad-9,8520addc-bbc5-4af3-b827-ec71bf2456dd
 pkg-pinsocket-1x37-d1.1-pkg,8effffba-0c00-4d81-b536-f0ab7857c2a3
 pkg-pinsocket-1x37-d1.1-polygon-contour,2e26b304-2cb7-4bba-bbd7-25977269671e
+pkg-pinsocket-1x37-d1.1-polygon-courtyard,f8691f2a-054c-4c3c-8a73-119695ca50b7
+pkg-pinsocket-1x37-d1.1-polygon-outline,25864a07-215c-4d72-8a77-15ab80aa3d29
 pkg-pinsocket-1x37-d1.1-text-name,01e9febd-3cdb-4887-813d-07f3442d61da
 pkg-pinsocket-1x37-d1.1-text-value,c1807567-687b-4503-b28f-0974e496e908
 pkg-pinsocket-1x38-d0.9-3d,b7ec8d84-0938-405b-a5ef-ac827bcb21fb
@@ -18230,6 +18890,8 @@ pkg-pinsocket-1x38-d0.9-pad-8,900d80fd-85a2-488b-9a09-f8c31a3a7619
 pkg-pinsocket-1x38-d0.9-pad-9,ddcb47e8-55b8-48c5-bf3b-09887d5b0ded
 pkg-pinsocket-1x38-d0.9-pkg,6937547d-a0eb-40fa-b1b0-b58dac29af7e
 pkg-pinsocket-1x38-d0.9-polygon-contour,bd78c0ea-c155-4cad-88eb-f6f68a8e7ac2
+pkg-pinsocket-1x38-d0.9-polygon-courtyard,f9cd2eb1-2a16-4a0f-b81c-141a1f1a330e
+pkg-pinsocket-1x38-d0.9-polygon-outline,87926666-bb13-4457-bcbd-4e62f3d897a2
 pkg-pinsocket-1x38-d0.9-text-name,8033092d-c32b-456b-a6cc-87716e25ff1d
 pkg-pinsocket-1x38-d0.9-text-value,963efec1-fac3-4b00-afe9-970ff1d1cb6e
 pkg-pinsocket-1x38-d1.0-3d,bd067071-6298-4a40-a008-5d9904628eb8
@@ -18274,6 +18936,8 @@ pkg-pinsocket-1x38-d1.0-pad-8,4f8d75ea-f447-4a48-8d3e-8f1749a0f1bb
 pkg-pinsocket-1x38-d1.0-pad-9,47ef395f-cf55-4b61-a848-cae27eb8e718
 pkg-pinsocket-1x38-d1.0-pkg,5716da7a-148e-4ee6-9572-d1fe8e80b97e
 pkg-pinsocket-1x38-d1.0-polygon-contour,e5244453-7f1f-4093-8759-e1d5c3eafc2d
+pkg-pinsocket-1x38-d1.0-polygon-courtyard,052c90d4-d753-4ceb-b5f2-7f381d99c049
+pkg-pinsocket-1x38-d1.0-polygon-outline,616bc954-8bef-4337-91a3-e8275c074dd1
 pkg-pinsocket-1x38-d1.0-text-name,54d34440-c73f-4c11-8aeb-c5a3023b85ab
 pkg-pinsocket-1x38-d1.0-text-value,3629640c-1a8a-44c2-9dbc-be5a5ea7ef78
 pkg-pinsocket-1x38-d1.1-3d,f3394009-6ebb-4c07-a345-1c7d8d349b23
@@ -18318,6 +18982,8 @@ pkg-pinsocket-1x38-d1.1-pad-8,c626939b-e926-4e99-94fd-acf3ab8359d6
 pkg-pinsocket-1x38-d1.1-pad-9,5ef0acde-a189-49b6-be28-5e5732918a28
 pkg-pinsocket-1x38-d1.1-pkg,4d1330a1-52f7-4175-8c9f-2fd5c8052826
 pkg-pinsocket-1x38-d1.1-polygon-contour,3d78aaed-22cb-4129-b4af-b0b9b57db247
+pkg-pinsocket-1x38-d1.1-polygon-courtyard,6af28b76-c708-4e45-8899-3c1e5e2c9929
+pkg-pinsocket-1x38-d1.1-polygon-outline,86ee3b97-7244-41c4-ada7-8527f5bc03a7
 pkg-pinsocket-1x38-d1.1-text-name,d2f1580e-d340-43b5-9789-b26af24abeec
 pkg-pinsocket-1x38-d1.1-text-value,2ace6bcd-4ef9-47ed-9d4a-103652471c54
 pkg-pinsocket-1x39-d0.9-3d,b0b00c85-0a2b-420f-af90-77f45e80dc22
@@ -18363,6 +19029,8 @@ pkg-pinsocket-1x39-d0.9-pad-8,1d9a5577-3668-49e0-ba89-ce9633ceb3c1
 pkg-pinsocket-1x39-d0.9-pad-9,583d265d-dfa8-4f45-8c47-98ad538d05c4
 pkg-pinsocket-1x39-d0.9-pkg,2c61b9fd-c983-4f39-a018-1fbd0f625836
 pkg-pinsocket-1x39-d0.9-polygon-contour,00e4b313-689e-412f-a28a-777454898877
+pkg-pinsocket-1x39-d0.9-polygon-courtyard,08a6808f-1064-4518-a34c-87c4c1c071cf
+pkg-pinsocket-1x39-d0.9-polygon-outline,0f6e1cc1-383b-4bcd-a5b3-80a3f88ffaa5
 pkg-pinsocket-1x39-d0.9-text-name,63171a9b-0edf-4772-82be-97851bb5e23b
 pkg-pinsocket-1x39-d0.9-text-value,f8a16fb2-41b0-4526-9b95-3f1deb5e8dcb
 pkg-pinsocket-1x39-d1.0-3d,57699acf-c6a7-4618-a269-1b67ad59a6d3
@@ -18408,6 +19076,8 @@ pkg-pinsocket-1x39-d1.0-pad-8,f77bcd1b-f9f3-43d2-91a6-24307c8aab2d
 pkg-pinsocket-1x39-d1.0-pad-9,09320dae-6e0f-4d64-9442-242c9796d915
 pkg-pinsocket-1x39-d1.0-pkg,7eee4532-a412-4520-8555-b5f6e78cea59
 pkg-pinsocket-1x39-d1.0-polygon-contour,7eac2cc7-ef95-4dd6-8d42-16ac80dc451a
+pkg-pinsocket-1x39-d1.0-polygon-courtyard,16ea32b6-f683-4b1f-ac8a-a3a4f4ae4688
+pkg-pinsocket-1x39-d1.0-polygon-outline,d65d3d80-6d20-4cd2-95ca-a9adf1be73a9
 pkg-pinsocket-1x39-d1.0-text-name,c138476d-7cc2-4a31-b60c-c13000d68619
 pkg-pinsocket-1x39-d1.0-text-value,83a4d2f7-1ab0-43c9-8840-ee23080971ea
 pkg-pinsocket-1x39-d1.1-3d,1a6f7eb1-554c-408d-ab44-ab77793b6f90
@@ -18453,6 +19123,8 @@ pkg-pinsocket-1x39-d1.1-pad-8,68e31b18-e6f4-4faa-90f5-0ca21b641571
 pkg-pinsocket-1x39-d1.1-pad-9,1ae26cf3-cdc4-4b8a-9bdb-75a08e290103
 pkg-pinsocket-1x39-d1.1-pkg,6e8b7c27-40f4-4a61-b8b7-997b581887b5
 pkg-pinsocket-1x39-d1.1-polygon-contour,64675815-e6ca-4d50-9ba7-12d426023f22
+pkg-pinsocket-1x39-d1.1-polygon-courtyard,5b27eb4e-119e-44c1-b168-7bc11b7153bd
+pkg-pinsocket-1x39-d1.1-polygon-outline,4c7bb492-05fc-451f-aa8c-cc007a2dc82b
 pkg-pinsocket-1x39-d1.1-text-name,e3ad30b6-3eda-4f4f-89fe-ad15a446beda
 pkg-pinsocket-1x39-d1.1-text-value,168bcdb2-6857-4ee6-aaea-034f934c17bd
 pkg-pinsocket-1x4-d0.9-3d,654f668a-25e0-44ce-adfa-dfd98a62b461
@@ -18463,6 +19135,8 @@ pkg-pinsocket-1x4-d0.9-pad-2,a36ad53c-204e-4ed4-af9c-f32eb7198921
 pkg-pinsocket-1x4-d0.9-pad-3,ef113fce-d092-46ef-89f7-4571dd5f48d7
 pkg-pinsocket-1x4-d0.9-pkg,342934ad-75a5-46c2-8c8e-40d19414a3b8
 pkg-pinsocket-1x4-d0.9-polygon-contour,dd1f884b-2c57-446e-a837-477cb252acd0
+pkg-pinsocket-1x4-d0.9-polygon-courtyard,5d1b94ec-4168-47f8-812a-e8f32089b665
+pkg-pinsocket-1x4-d0.9-polygon-outline,e93b4c44-b3fd-4f5f-9cc5-d40f98fd7858
 pkg-pinsocket-1x4-d0.9-text-name,635d4181-9c07-48ce-91e9-89dec7d72ba4
 pkg-pinsocket-1x4-d0.9-text-value,74b2f2ed-ca3a-49b2-9648-5890b4070062
 pkg-pinsocket-1x4-d1.0-3d,57baa24b-ef7b-48e5-ad01-947bc3f7a10a
@@ -18473,6 +19147,8 @@ pkg-pinsocket-1x4-d1.0-pad-2,3f18c21d-83c5-4d9a-83be-772c62435e38
 pkg-pinsocket-1x4-d1.0-pad-3,b3b8f527-55db-4f28-9543-b729a2d80b0b
 pkg-pinsocket-1x4-d1.0-pkg,d3fb9f86-8753-4fa8-b9ac-63556dda82d2
 pkg-pinsocket-1x4-d1.0-polygon-contour,de157254-9aab-4641-b77a-1a951ab83795
+pkg-pinsocket-1x4-d1.0-polygon-courtyard,ec50af80-300c-4360-888c-cf8dbce6a81d
+pkg-pinsocket-1x4-d1.0-polygon-outline,fc344ba8-92db-44a9-9d81-dc574d684ca6
 pkg-pinsocket-1x4-d1.0-text-name,0737f500-e798-44c7-ba17-c54b7c38919a
 pkg-pinsocket-1x4-d1.0-text-value,402818eb-f695-4580-811d-f51a362961e6
 pkg-pinsocket-1x4-d1.1-3d,bcbe820a-fafb-493d-b389-741b4f682a05
@@ -18483,6 +19159,8 @@ pkg-pinsocket-1x4-d1.1-pad-2,72d86624-930b-4f49-9f03-d9f3e76a4533
 pkg-pinsocket-1x4-d1.1-pad-3,96d2e9f0-e7a5-4d99-958d-f647f3508d22
 pkg-pinsocket-1x4-d1.1-pkg,e0abbf72-6a40-441d-8d84-61fabe980f9a
 pkg-pinsocket-1x4-d1.1-polygon-contour,0ca20aa7-16ba-4893-929f-776899b032eb
+pkg-pinsocket-1x4-d1.1-polygon-courtyard,75129d19-1979-4d15-bff5-64a319aa3323
+pkg-pinsocket-1x4-d1.1-polygon-outline,84bc8b47-7e57-4093-b438-ccb161237618
 pkg-pinsocket-1x4-d1.1-text-name,e943a2f0-aea4-4fbc-bde8-4ba4018b7095
 pkg-pinsocket-1x4-d1.1-text-value,ee02d390-07f3-4cff-9c4b-1cf4eae4c9cd
 pkg-pinsocket-1x40-d0.9-3d,61f79266-5c72-4120-b519-eed0d7adc668
@@ -18529,6 +19207,8 @@ pkg-pinsocket-1x40-d0.9-pad-8,feb5fd4b-63ee-4e4f-94b1-ab0d7ba9c40b
 pkg-pinsocket-1x40-d0.9-pad-9,3dbdacaa-7e96-40cf-9dca-5fb4f4cc499c
 pkg-pinsocket-1x40-d0.9-pkg,554c024f-a3ea-446e-879e-1e45976db61a
 pkg-pinsocket-1x40-d0.9-polygon-contour,ee18f912-c975-451b-9901-a7852de1dd53
+pkg-pinsocket-1x40-d0.9-polygon-courtyard,5af3b6d1-ef34-49ba-bb48-cc92192b78a2
+pkg-pinsocket-1x40-d0.9-polygon-outline,495d43cd-6f22-4346-961c-e2464c2c8cf0
 pkg-pinsocket-1x40-d0.9-text-name,3a71f51d-f2fd-4946-9de7-bcf97bb2da6f
 pkg-pinsocket-1x40-d0.9-text-value,a13f7a13-5a95-41d5-bd1a-933684d468d7
 pkg-pinsocket-1x40-d1.0-3d,650e0a07-8d75-4dd2-8547-eb689eb0c764
@@ -18575,6 +19255,8 @@ pkg-pinsocket-1x40-d1.0-pad-8,55a3b9fc-9238-4c20-9409-799840058564
 pkg-pinsocket-1x40-d1.0-pad-9,b8928c26-9ae7-4b98-aa56-41a9511c562b
 pkg-pinsocket-1x40-d1.0-pkg,d9fd91ff-5230-4810-b853-8cd49ce23c00
 pkg-pinsocket-1x40-d1.0-polygon-contour,59f87b78-be4b-4030-b530-b3ebcb5bdb0b
+pkg-pinsocket-1x40-d1.0-polygon-courtyard,1e89ed15-51a7-4cc4-ab76-4e0bcc442b0f
+pkg-pinsocket-1x40-d1.0-polygon-outline,2abd979c-78ce-4347-94d1-16be839b6a98
 pkg-pinsocket-1x40-d1.0-text-name,fdea9c13-e550-445c-936f-babb5251919c
 pkg-pinsocket-1x40-d1.0-text-value,e5c49b72-acbb-4475-9ddc-aa8d33a2d79c
 pkg-pinsocket-1x40-d1.1-3d,6789cf57-3649-49c4-b96f-6ff1d4eabb43
@@ -18621,6 +19303,8 @@ pkg-pinsocket-1x40-d1.1-pad-8,b2094324-42d1-41cb-8cf0-fd05cc403917
 pkg-pinsocket-1x40-d1.1-pad-9,ed671ba4-9ca5-422e-bedb-c115faaf63c5
 pkg-pinsocket-1x40-d1.1-pkg,55142d4f-7352-49ca-afdf-7b17bc622da6
 pkg-pinsocket-1x40-d1.1-polygon-contour,8df48d3a-d34e-4288-a381-df12fedaca5b
+pkg-pinsocket-1x40-d1.1-polygon-courtyard,b78f6138-482d-4504-9797-1888fc71a754
+pkg-pinsocket-1x40-d1.1-polygon-outline,eba74d0b-9202-4eed-95d4-959df15f9747
 pkg-pinsocket-1x40-d1.1-text-name,5eeeae35-798f-4874-9505-05dbd4eb0cc2
 pkg-pinsocket-1x40-d1.1-text-value,5b8d42e7-9768-4fe1-9836-936b3e61fbec
 pkg-pinsocket-1x5-d0.9-3d,14a5c7c6-2613-4577-a4f9-2359420f426a
@@ -18632,6 +19316,8 @@ pkg-pinsocket-1x5-d0.9-pad-3,8916ed72-3a87-4419-b617-93b2d756f264
 pkg-pinsocket-1x5-d0.9-pad-4,d3e7c39a-d094-4dff-a3ad-74980052ec49
 pkg-pinsocket-1x5-d0.9-pkg,ffa520bc-b92a-43e1-a4f1-cf7ffa0adb07
 pkg-pinsocket-1x5-d0.9-polygon-contour,93b13bd7-cfb3-4401-8dcd-544b47a88343
+pkg-pinsocket-1x5-d0.9-polygon-courtyard,7ca6d63a-0d26-49a1-b8cf-f84c78fc3ade
+pkg-pinsocket-1x5-d0.9-polygon-outline,406d1ec1-c96d-40c4-aee8-7f977206a51e
 pkg-pinsocket-1x5-d0.9-text-name,1737fa2a-1306-4964-a8c0-4103d290b826
 pkg-pinsocket-1x5-d0.9-text-value,2f9fe729-65fd-4623-87de-9db965be5522
 pkg-pinsocket-1x5-d1.0-3d,616b1821-cd01-4aa2-b3b5-65073f490419
@@ -18643,6 +19329,8 @@ pkg-pinsocket-1x5-d1.0-pad-3,68ae060c-48ac-4fc2-9efe-cea091639c8e
 pkg-pinsocket-1x5-d1.0-pad-4,5d1d88d2-687f-4a72-b01f-b6fb93165a3e
 pkg-pinsocket-1x5-d1.0-pkg,f61ed8b0-d7f3-4985-a24e-bfd99728d9a5
 pkg-pinsocket-1x5-d1.0-polygon-contour,471d1914-819c-4675-91fd-f6d9edb2bf1f
+pkg-pinsocket-1x5-d1.0-polygon-courtyard,cccb4da5-abcb-4878-a038-acf89872e60c
+pkg-pinsocket-1x5-d1.0-polygon-outline,eb1eac08-949e-4ced-bbd6-78e20fd2d95c
 pkg-pinsocket-1x5-d1.0-text-name,88d11b0a-1236-4796-8c93-7907c7fa727e
 pkg-pinsocket-1x5-d1.0-text-value,5543a25f-0dce-40b9-928f-a8dce14270b5
 pkg-pinsocket-1x5-d1.1-3d,e5a63763-c40a-4068-bfe9-36f2c1172f5d
@@ -18654,6 +19342,8 @@ pkg-pinsocket-1x5-d1.1-pad-3,698c9e08-5457-4d8b-91f1-7a238f415296
 pkg-pinsocket-1x5-d1.1-pad-4,7ec94cc5-802e-4480-b116-06a423407282
 pkg-pinsocket-1x5-d1.1-pkg,6a3738f0-d5aa-4ec1-8def-b2395db72346
 pkg-pinsocket-1x5-d1.1-polygon-contour,dac91c5a-7865-425c-a8ca-8356ba6fdf4c
+pkg-pinsocket-1x5-d1.1-polygon-courtyard,73d5c9b2-3611-4494-8b9d-c71f94bbc40c
+pkg-pinsocket-1x5-d1.1-polygon-outline,87367508-7f21-45d2-b04c-f0ecbc3a2c5a
 pkg-pinsocket-1x5-d1.1-text-name,59cea4e2-3249-4eea-b771-3dcd44b1ff72
 pkg-pinsocket-1x5-d1.1-text-value,78958079-9165-4009-9a01-2bda79ae7297
 pkg-pinsocket-1x6-d0.9-3d,b0536185-4732-4270-8510-514ae50a8022
@@ -18666,6 +19356,8 @@ pkg-pinsocket-1x6-d0.9-pad-4,3ff3f109-5a4b-4b1a-944c-469f4b7f946f
 pkg-pinsocket-1x6-d0.9-pad-5,58f66bdf-1226-4982-995f-9cc9d5fb4d9a
 pkg-pinsocket-1x6-d0.9-pkg,d23e7b89-c7c8-48c4-ac07-0b358b95b7e4
 pkg-pinsocket-1x6-d0.9-polygon-contour,39f7df0a-8813-49ca-aee7-96693b1c32ff
+pkg-pinsocket-1x6-d0.9-polygon-courtyard,ec2cb662-c9b1-4045-8cec-10cd78dd88a8
+pkg-pinsocket-1x6-d0.9-polygon-outline,6489d8e3-ec2a-40de-8cb7-6e5df85f9984
 pkg-pinsocket-1x6-d0.9-text-name,d42a0346-01df-4d32-8351-c6849baf2b1e
 pkg-pinsocket-1x6-d0.9-text-value,7f1d7d2c-f158-455a-a3a8-bf62c7f9cbd1
 pkg-pinsocket-1x6-d1.0-3d,0633340a-7306-429b-9838-7c88d0ffe865
@@ -18678,6 +19370,8 @@ pkg-pinsocket-1x6-d1.0-pad-4,957ed8d7-d8bf-4698-9c74-6332c39a95f5
 pkg-pinsocket-1x6-d1.0-pad-5,fb6acaee-37f8-48ce-8ce0-d9425e20013b
 pkg-pinsocket-1x6-d1.0-pkg,e5db94bf-38f2-4fbd-aa19-6efba6e30b01
 pkg-pinsocket-1x6-d1.0-polygon-contour,37b3cdd3-9bc6-42d9-8337-2af06dbf21d5
+pkg-pinsocket-1x6-d1.0-polygon-courtyard,caa58c79-5a1d-4425-a739-f79ba9560056
+pkg-pinsocket-1x6-d1.0-polygon-outline,10365bed-8276-4991-b130-94dbd72e3b4b
 pkg-pinsocket-1x6-d1.0-text-name,fba3929b-bbe9-4faa-846b-23a8ca068213
 pkg-pinsocket-1x6-d1.0-text-value,6edd35b3-060c-46a8-bcfa-e7746f870052
 pkg-pinsocket-1x6-d1.1-3d,d8277742-795c-4d37-90ba-cbec04f5f9ab
@@ -18690,6 +19384,8 @@ pkg-pinsocket-1x6-d1.1-pad-4,5326b5f6-abca-4bf0-be94-7d2794cbfd20
 pkg-pinsocket-1x6-d1.1-pad-5,9fa781f6-c71e-4257-ac6b-90bd98c49629
 pkg-pinsocket-1x6-d1.1-pkg,c4664c59-356c-42b7-8403-033c85fc3124
 pkg-pinsocket-1x6-d1.1-polygon-contour,1ea05476-1da3-4148-8a96-c1d99873cd74
+pkg-pinsocket-1x6-d1.1-polygon-courtyard,e446d311-3a48-418f-ade5-da958d22bc3f
+pkg-pinsocket-1x6-d1.1-polygon-outline,c561e216-48a0-433e-8446-421f2f28a532
 pkg-pinsocket-1x6-d1.1-text-name,ef3da702-75de-4fb7-9816-a5c7fb0e492a
 pkg-pinsocket-1x6-d1.1-text-value,9ade9d2d-dce6-4d18-8912-d3946ae3ab16
 pkg-pinsocket-1x7-d0.9-3d,de9f062a-876d-4c36-8207-b6df0181fcdc
@@ -18703,6 +19399,8 @@ pkg-pinsocket-1x7-d0.9-pad-5,e71822bb-6c02-4b61-8318-aee1560e07d2
 pkg-pinsocket-1x7-d0.9-pad-6,d204a3e7-680c-436c-92b5-b474444d8c2b
 pkg-pinsocket-1x7-d0.9-pkg,c0890996-6c89-47e3-a7bc-5f59722fb97f
 pkg-pinsocket-1x7-d0.9-polygon-contour,33af2ead-554b-4153-b95d-424f914b2ade
+pkg-pinsocket-1x7-d0.9-polygon-courtyard,e43ee3f7-c7ae-4106-b3a7-097416312c75
+pkg-pinsocket-1x7-d0.9-polygon-outline,0c11b633-11d1-436a-b59c-6c7b27837e2c
 pkg-pinsocket-1x7-d0.9-text-name,b47cf7d2-3f8c-477e-924e-e19fb867c5ef
 pkg-pinsocket-1x7-d0.9-text-value,7a149fec-967c-4356-b58a-ca75b5052839
 pkg-pinsocket-1x7-d1.0-3d,c3b7307c-31cd-4060-a995-c3b60f91f1a0
@@ -18716,6 +19414,8 @@ pkg-pinsocket-1x7-d1.0-pad-5,9f0cbbfe-1e25-4d64-a09b-143af8a7276e
 pkg-pinsocket-1x7-d1.0-pad-6,a9c1ccfd-1668-457e-8b96-f14a07553cd8
 pkg-pinsocket-1x7-d1.0-pkg,738153e1-524f-4001-8955-3a45b14e3e7a
 pkg-pinsocket-1x7-d1.0-polygon-contour,53eda009-a6fe-489e-8ee7-974f9284e1cf
+pkg-pinsocket-1x7-d1.0-polygon-courtyard,816e39d4-4e97-4f56-b1a3-439c8f74f146
+pkg-pinsocket-1x7-d1.0-polygon-outline,6a6a290c-7496-4aeb-bb02-b5a335e1e3f0
 pkg-pinsocket-1x7-d1.0-text-name,3868c7bb-d73b-40da-b0c4-2df71c7925ea
 pkg-pinsocket-1x7-d1.0-text-value,a66a214c-dc65-47ef-9323-10232338fe81
 pkg-pinsocket-1x7-d1.1-3d,edc00988-3ac6-4d85-b36c-26d2fe6c7cbc
@@ -18729,6 +19429,8 @@ pkg-pinsocket-1x7-d1.1-pad-5,2c983325-4700-4231-84e8-40fa924cdb88
 pkg-pinsocket-1x7-d1.1-pad-6,96197d55-8f75-4d8d-893f-b9b8c8a46050
 pkg-pinsocket-1x7-d1.1-pkg,0742bad8-e8d8-4f82-aa53-3e1001911559
 pkg-pinsocket-1x7-d1.1-polygon-contour,366e3d96-51a2-4471-b666-e4118613c9d8
+pkg-pinsocket-1x7-d1.1-polygon-courtyard,0ae82926-c5f1-47d8-94a4-064c7e5cef93
+pkg-pinsocket-1x7-d1.1-polygon-outline,87a90230-3faa-43c3-96cc-69147c4bcb3d
 pkg-pinsocket-1x7-d1.1-text-name,aaa5e9f4-5e2b-42d1-b351-ec20096499ab
 pkg-pinsocket-1x7-d1.1-text-value,57642cd7-3308-469f-a562-0ae2318224d8
 pkg-pinsocket-1x8-d0.9-3d,c6099acf-b4fc-4fdc-8f85-581d6b384f0d
@@ -18743,6 +19445,8 @@ pkg-pinsocket-1x8-d0.9-pad-6,e2fb639f-b51d-4e7d-927d-fa331253d7b3
 pkg-pinsocket-1x8-d0.9-pad-7,8109f866-f5b6-46a4-97e9-85aa75ae43d8
 pkg-pinsocket-1x8-d0.9-pkg,47403047-ffc5-4fb7-b8de-4569d30ab385
 pkg-pinsocket-1x8-d0.9-polygon-contour,854ab402-d571-4a9f-b1e2-6e225da67319
+pkg-pinsocket-1x8-d0.9-polygon-courtyard,2cf1c7c3-40d2-4cd4-8793-62eff76e6d22
+pkg-pinsocket-1x8-d0.9-polygon-outline,7e302f64-5fab-4b36-81c9-25edf0165ac8
 pkg-pinsocket-1x8-d0.9-text-name,c21134d4-c95b-479e-9439-d31b2f0167e5
 pkg-pinsocket-1x8-d0.9-text-value,6ce2bab6-35c7-40d5-adb6-5bc1f181fe29
 pkg-pinsocket-1x8-d1.0-3d,dab418e9-5dc8-431b-8a5f-2252d69dd294
@@ -18757,6 +19461,8 @@ pkg-pinsocket-1x8-d1.0-pad-6,c55accdf-507a-4e47-bd0e-db13d10fad83
 pkg-pinsocket-1x8-d1.0-pad-7,ac885296-9c56-48ca-9d6c-e35a9e453259
 pkg-pinsocket-1x8-d1.0-pkg,a22906bf-c6bc-4ce3-9b46-8bd2fedd68b7
 pkg-pinsocket-1x8-d1.0-polygon-contour,1b96e0f6-2014-4791-b206-d8e989b0ee5e
+pkg-pinsocket-1x8-d1.0-polygon-courtyard,27475287-2117-4645-b395-e7241865e3a5
+pkg-pinsocket-1x8-d1.0-polygon-outline,9e5d0381-026c-4dcb-be63-559ad528cb0e
 pkg-pinsocket-1x8-d1.0-text-name,27de1c7d-e4a7-45fa-bf5c-7f8639794ede
 pkg-pinsocket-1x8-d1.0-text-value,3afdb2bd-664b-46cb-8125-1d7c666ed046
 pkg-pinsocket-1x8-d1.1-3d,22b461bb-b563-4968-96e6-a55f5b38b50f
@@ -18771,6 +19477,8 @@ pkg-pinsocket-1x8-d1.1-pad-6,584804ca-b12a-420c-8272-2526bb16af35
 pkg-pinsocket-1x8-d1.1-pad-7,e185a240-9796-4715-b272-a15b300b8f7d
 pkg-pinsocket-1x8-d1.1-pkg,24cda4d7-3cb4-4f63-9c07-af3dca682534
 pkg-pinsocket-1x8-d1.1-polygon-contour,facd9c5c-787f-495e-8026-9a26187c94bd
+pkg-pinsocket-1x8-d1.1-polygon-courtyard,fb95136e-0e95-4a04-8298-8050aeb2219c
+pkg-pinsocket-1x8-d1.1-polygon-outline,6d9cb3d9-6b81-40fb-90bd-2accffabacc5
 pkg-pinsocket-1x8-d1.1-text-name,32f66fa1-1f94-4314-bee9-5d92a93de820
 pkg-pinsocket-1x8-d1.1-text-value,6c00b67b-3145-4f53-947e-2bc432ac54f1
 pkg-pinsocket-1x9-d0.9-3d,ad71eb7e-ab4b-483f-9d3b-c079e016290c
@@ -18786,6 +19494,8 @@ pkg-pinsocket-1x9-d0.9-pad-7,832adf92-88e9-4133-b70e-afafa54c1ee0
 pkg-pinsocket-1x9-d0.9-pad-8,d9322d3d-2b5e-4a97-b655-bff5c4a1f43f
 pkg-pinsocket-1x9-d0.9-pkg,16b844f4-99c1-43b0-bd75-f2734f66c5dd
 pkg-pinsocket-1x9-d0.9-polygon-contour,6216410f-9c36-4a17-91a2-163eaeeaa4d2
+pkg-pinsocket-1x9-d0.9-polygon-courtyard,14f2fed5-dd22-469a-a483-a301fef0fe75
+pkg-pinsocket-1x9-d0.9-polygon-outline,1234b16d-f5ca-4ef2-a133-7b29fc31a628
 pkg-pinsocket-1x9-d0.9-text-name,393bc6fd-d7f4-4f8a-a1f9-4458f54922ea
 pkg-pinsocket-1x9-d0.9-text-value,00063006-229b-4d0d-8161-184fb0e59264
 pkg-pinsocket-1x9-d1.0-3d,f646a9c3-0ac0-4d64-b287-bad8437fcfa6
@@ -18801,6 +19511,8 @@ pkg-pinsocket-1x9-d1.0-pad-7,3c80e1d3-a1fc-4529-a8fd-e03d9be37fea
 pkg-pinsocket-1x9-d1.0-pad-8,76fd1989-faec-473b-b8a5-d7db4209d376
 pkg-pinsocket-1x9-d1.0-pkg,1ae33123-2ad1-490d-af26-04d82415270d
 pkg-pinsocket-1x9-d1.0-polygon-contour,857385e9-e72a-4e4d-9b6c-248ab5080732
+pkg-pinsocket-1x9-d1.0-polygon-courtyard,e15ea571-883e-4338-b36b-e7209827a4c6
+pkg-pinsocket-1x9-d1.0-polygon-outline,7706266a-fa13-4ac3-925a-424fdb191bcb
 pkg-pinsocket-1x9-d1.0-text-name,823c1837-2101-4f0c-9201-f422a1cf9adf
 pkg-pinsocket-1x9-d1.0-text-value,fed0f2dd-7f7f-4fb9-afab-cc5ac7a550ce
 pkg-pinsocket-1x9-d1.1-3d,6764a582-f215-452a-9269-008357564b4e
@@ -18816,6 +19528,8 @@ pkg-pinsocket-1x9-d1.1-pad-7,c780b904-3b0a-4ddb-b609-9df753a667f0
 pkg-pinsocket-1x9-d1.1-pad-8,62a306cb-86ab-4819-bae9-97655922ce8a
 pkg-pinsocket-1x9-d1.1-pkg,7f093fca-56b8-422e-a284-c9347a4d7480
 pkg-pinsocket-1x9-d1.1-polygon-contour,a2223cb1-2e30-48b7-a0d6-004dae6c2d35
+pkg-pinsocket-1x9-d1.1-polygon-courtyard,d46b6367-2b50-405b-b21e-c35f54961088
+pkg-pinsocket-1x9-d1.1-polygon-outline,47129973-66f4-40cf-b312-6bbae11fc417
 pkg-pinsocket-1x9-d1.1-text-name,40d09f3b-5b40-48ee-a5bf-2ad717ca9f6c
 pkg-pinsocket-1x9-d1.1-text-value,5968e44d-28fc-4c2d-a097-5a7d28734fee
 pkg-pinsocket-2x10-d0.9-3d,115dab97-05e2-444b-942f-c4d499dc6ed6
@@ -18842,6 +19556,8 @@ pkg-pinsocket-2x10-d0.9-pad-8,8114b576-14e2-4d65-b237-d6538c7789c7
 pkg-pinsocket-2x10-d0.9-pad-9,22d3f183-6467-423b-bffa-005ee2232826
 pkg-pinsocket-2x10-d0.9-pkg,deecab33-2077-47a5-9837-062a801bd7be
 pkg-pinsocket-2x10-d0.9-polygon-contour,de54e6e9-5597-413e-afcf-bba25c982c44
+pkg-pinsocket-2x10-d0.9-polygon-courtyard,6abd5d67-7c87-4336-836a-dad713733e47
+pkg-pinsocket-2x10-d0.9-polygon-outline,6fe25f56-d1ca-4f86-91b8-4188946d8262
 pkg-pinsocket-2x10-d0.9-text-name,72eaefd8-36bd-4a72-b756-6067bd42b361
 pkg-pinsocket-2x10-d0.9-text-value,78c6b24c-a496-424b-9663-fcced0efff8c
 pkg-pinsocket-2x10-d1.0-3d,85b5e6b6-2599-43a4-a13d-7cd24004c7e0
@@ -18868,6 +19584,8 @@ pkg-pinsocket-2x10-d1.0-pad-8,52eec9fe-93e4-42a9-8277-5cb5a1c0a284
 pkg-pinsocket-2x10-d1.0-pad-9,bdad35cb-e887-4914-8299-fcc2147d4560
 pkg-pinsocket-2x10-d1.0-pkg,cef1b642-8600-48e0-a889-06c366bebd60
 pkg-pinsocket-2x10-d1.0-polygon-contour,ad51f44f-c1d9-4f78-9b22-2ed8f8aad2a7
+pkg-pinsocket-2x10-d1.0-polygon-courtyard,81e96d67-8c04-4d7a-82aa-c23bddc08174
+pkg-pinsocket-2x10-d1.0-polygon-outline,1b3490af-6907-4eb3-83fb-213d9122fd3f
 pkg-pinsocket-2x10-d1.0-text-name,7d42a82d-1305-406e-9ec1-4e519d7311e9
 pkg-pinsocket-2x10-d1.0-text-value,615f18fb-dbf3-4e65-8e80-cb7eb089db8d
 pkg-pinsocket-2x10-d1.1-3d,49774338-63c2-46e7-a033-2fb621f400cd
@@ -18894,6 +19612,8 @@ pkg-pinsocket-2x10-d1.1-pad-8,26bb6d30-0105-4a2c-b613-083b12b8249c
 pkg-pinsocket-2x10-d1.1-pad-9,4595cea6-1ebd-47e4-8e51-418783d4dc41
 pkg-pinsocket-2x10-d1.1-pkg,b0de8719-02ae-43f2-97ea-4f571f0c3c8a
 pkg-pinsocket-2x10-d1.1-polygon-contour,92f78e40-e58e-4b57-ad90-d22240dfe83b
+pkg-pinsocket-2x10-d1.1-polygon-courtyard,47b74860-69c5-4bde-aeab-c838c2d71584
+pkg-pinsocket-2x10-d1.1-polygon-outline,a161359d-8593-4941-9f86-ad95ffbd0646
 pkg-pinsocket-2x10-d1.1-text-name,93ce0836-7fe8-48af-ab60-286e6430d748
 pkg-pinsocket-2x10-d1.1-text-value,139a2474-6d3c-4819-8c15-3ea794d99e9b
 pkg-pinsocket-2x11-d0.9-3d,f251aa23-7856-4c50-ac7f-e74cc023c983
@@ -18922,6 +19642,8 @@ pkg-pinsocket-2x11-d0.9-pad-8,8eaf1811-dc22-45e5-9702-1568e4d3fb44
 pkg-pinsocket-2x11-d0.9-pad-9,97c29238-c89a-4f2f-95e1-d5516dcadc05
 pkg-pinsocket-2x11-d0.9-pkg,c379cecd-d4f5-47d5-9373-dd026ae0b1c0
 pkg-pinsocket-2x11-d0.9-polygon-contour,e849391d-2be0-4f58-b0fa-6d8b58062e40
+pkg-pinsocket-2x11-d0.9-polygon-courtyard,09acc6a2-798a-4f06-8bff-189631409793
+pkg-pinsocket-2x11-d0.9-polygon-outline,37cdbb59-3bbd-44a7-99d3-ba0000a7c612
 pkg-pinsocket-2x11-d0.9-text-name,89af8090-c8c1-4449-8cdb-925e7493c6da
 pkg-pinsocket-2x11-d0.9-text-value,db94b872-2928-4ada-aed9-912eae52d3c6
 pkg-pinsocket-2x11-d1.0-3d,e847db23-2f5a-482b-aeda-1f6c8b05bd3c
@@ -18950,6 +19672,8 @@ pkg-pinsocket-2x11-d1.0-pad-8,ea75af4c-3ca9-4e5c-8245-c24a9dd8829b
 pkg-pinsocket-2x11-d1.0-pad-9,a52fa4cc-99cb-4cf4-b3b8-8af60c66da7d
 pkg-pinsocket-2x11-d1.0-pkg,86933985-9454-43a0-bbf8-fa393cf59444
 pkg-pinsocket-2x11-d1.0-polygon-contour,6ea848f2-826e-4333-8251-240b4c95807a
+pkg-pinsocket-2x11-d1.0-polygon-courtyard,2969bb85-1689-4abe-b9a0-2c0c2b146d60
+pkg-pinsocket-2x11-d1.0-polygon-outline,ac409e7e-d460-406a-b990-8e195d7b93f8
 pkg-pinsocket-2x11-d1.0-text-name,2eeeab5c-edb5-4649-adb2-089294764a6a
 pkg-pinsocket-2x11-d1.0-text-value,5b315b38-1a3b-410e-9259-9b8b839df8fc
 pkg-pinsocket-2x11-d1.1-3d,41c765c6-d3c0-4cba-922a-c398a99336c1
@@ -18978,6 +19702,8 @@ pkg-pinsocket-2x11-d1.1-pad-8,0f63270c-fdf4-4694-8396-b5ac120835af
 pkg-pinsocket-2x11-d1.1-pad-9,c7153297-b2e7-4f70-9ccd-ac7af474a48a
 pkg-pinsocket-2x11-d1.1-pkg,0428ef3a-e45a-4b13-aeb0-346351aa648d
 pkg-pinsocket-2x11-d1.1-polygon-contour,e3bc9ca6-ce58-4a7a-94ad-484b1aacbe83
+pkg-pinsocket-2x11-d1.1-polygon-courtyard,eb419cfb-e50c-4edf-978a-7d127eb85647
+pkg-pinsocket-2x11-d1.1-polygon-outline,5984c172-5dae-4e45-805f-32d4fa593951
 pkg-pinsocket-2x11-d1.1-text-name,941fd764-497b-441b-892f-baa3fa339152
 pkg-pinsocket-2x11-d1.1-text-value,4115dfa5-aae4-4348-a45f-0f23a84f5893
 pkg-pinsocket-2x12-d0.9-3d,f1ff9e60-6f0c-4ff7-84e9-c27339794023
@@ -19008,6 +19734,8 @@ pkg-pinsocket-2x12-d0.9-pad-8,74be8f2b-86de-45fb-9ebe-4246d42754c5
 pkg-pinsocket-2x12-d0.9-pad-9,59b64e04-d383-44dd-8601-6c286579e097
 pkg-pinsocket-2x12-d0.9-pkg,53ffe496-fc86-4194-bfca-3b3cf263baa0
 pkg-pinsocket-2x12-d0.9-polygon-contour,13d978e2-0e4e-4172-a353-e1ed9849bf3d
+pkg-pinsocket-2x12-d0.9-polygon-courtyard,8a593758-0e0b-47a8-a570-99359cfbb77a
+pkg-pinsocket-2x12-d0.9-polygon-outline,c055715c-dce6-4f6a-8a61-a0ef28208518
 pkg-pinsocket-2x12-d0.9-text-name,1a53af64-e003-4bb5-ba6a-0aa93b244b02
 pkg-pinsocket-2x12-d0.9-text-value,a8931e73-0736-4399-83b6-d1ec4480d3e3
 pkg-pinsocket-2x12-d1.0-3d,c36f6b5a-dae6-45f0-924a-d6c9951f3348
@@ -19038,6 +19766,8 @@ pkg-pinsocket-2x12-d1.0-pad-8,5fdf3d19-e575-4a30-bfb4-6b5b6bae84d4
 pkg-pinsocket-2x12-d1.0-pad-9,432c9f6c-c12d-4eec-bde0-3fcca3faa894
 pkg-pinsocket-2x12-d1.0-pkg,745ef031-9802-46c1-a904-3830ac3bebff
 pkg-pinsocket-2x12-d1.0-polygon-contour,c7e4cb6e-7a7c-4ca9-8734-48fd512718f5
+pkg-pinsocket-2x12-d1.0-polygon-courtyard,60f4b9e6-4846-4106-a4cb-44c4ed346db7
+pkg-pinsocket-2x12-d1.0-polygon-outline,41fadf35-1538-40f0-9e01-6043d7b3a9d5
 pkg-pinsocket-2x12-d1.0-text-name,a46e8195-5f32-4949-9b39-54a0ecdb1403
 pkg-pinsocket-2x12-d1.0-text-value,f91572a2-4fcd-4069-ae7a-6173739e9b12
 pkg-pinsocket-2x12-d1.1-3d,eca5ab05-192d-49d0-ae07-dc9ecd47530d
@@ -19068,6 +19798,8 @@ pkg-pinsocket-2x12-d1.1-pad-8,373a0830-d341-4bdd-945d-75232eca97d9
 pkg-pinsocket-2x12-d1.1-pad-9,472ab2cb-e963-4fba-8028-abbe79b8c785
 pkg-pinsocket-2x12-d1.1-pkg,8be5dbdf-673b-461f-9aea-d8902badcd77
 pkg-pinsocket-2x12-d1.1-polygon-contour,9e274232-1751-4bea-ae17-f158f5bba526
+pkg-pinsocket-2x12-d1.1-polygon-courtyard,f6570250-d1f1-4f38-8935-462166b9329f
+pkg-pinsocket-2x12-d1.1-polygon-outline,7399e191-a7b0-4dde-90f8-ec03401b1227
 pkg-pinsocket-2x12-d1.1-text-name,9a93c42d-7402-4b28-9a42-2167e0bcb570
 pkg-pinsocket-2x12-d1.1-text-value,e44dee93-3a97-4e85-b652-bf06214f8646
 pkg-pinsocket-2x13-d0.9-3d,b16209d4-4b28-4507-a835-aa9c5b5418aa
@@ -19100,6 +19832,8 @@ pkg-pinsocket-2x13-d0.9-pad-8,5a3af0e0-ee78-4cef-b2ec-b9cf7b3db46f
 pkg-pinsocket-2x13-d0.9-pad-9,80eb986f-a903-4c97-8fd2-554aa0e6d36a
 pkg-pinsocket-2x13-d0.9-pkg,be95466b-c4f2-4f7a-bf38-6fab485921f3
 pkg-pinsocket-2x13-d0.9-polygon-contour,d69f29d5-7501-49b6-a67e-0977ccd49b76
+pkg-pinsocket-2x13-d0.9-polygon-courtyard,434f5545-6da5-4170-95a2-13360291090a
+pkg-pinsocket-2x13-d0.9-polygon-outline,b8b78c66-a4c3-48b6-b135-a7aab348c825
 pkg-pinsocket-2x13-d0.9-text-name,ce7e010d-afe7-4440-832d-8e6ae85d0622
 pkg-pinsocket-2x13-d0.9-text-value,4fabeb41-7068-4609-89ae-4162ad096bcd
 pkg-pinsocket-2x13-d1.0-3d,10c21b13-3791-402d-af41-198911c3c138
@@ -19132,6 +19866,8 @@ pkg-pinsocket-2x13-d1.0-pad-8,04183785-8f0e-4719-a05c-e33fb00730bf
 pkg-pinsocket-2x13-d1.0-pad-9,1e956b03-4446-4832-be66-ca65281a6e45
 pkg-pinsocket-2x13-d1.0-pkg,2ceee0dc-ca91-4f71-a429-7bffb7f8a986
 pkg-pinsocket-2x13-d1.0-polygon-contour,554db664-31d6-4fbb-8570-56105c42e5e6
+pkg-pinsocket-2x13-d1.0-polygon-courtyard,a5fb500b-a9a9-4bd0-97c5-4cd71a50991a
+pkg-pinsocket-2x13-d1.0-polygon-outline,add895b9-668b-4163-bc46-4f619c28c22a
 pkg-pinsocket-2x13-d1.0-text-name,4f6a5fcb-35d0-4d49-ac53-326d63f73389
 pkg-pinsocket-2x13-d1.0-text-value,2102fbb8-f73f-49f8-b58d-59ebf69b5601
 pkg-pinsocket-2x13-d1.1-3d,4040481c-d641-4f90-8831-fdc21bd5d882
@@ -19164,6 +19900,8 @@ pkg-pinsocket-2x13-d1.1-pad-8,df154b99-24d4-43b7-8f54-b5b31a4061ec
 pkg-pinsocket-2x13-d1.1-pad-9,6d9cd490-5c60-413b-9ec7-7f86ceb6d1f1
 pkg-pinsocket-2x13-d1.1-pkg,9e4f5b5a-9175-4a90-a0b8-d21a29f77abc
 pkg-pinsocket-2x13-d1.1-polygon-contour,dd7c4de9-0038-45e9-bc9c-493a280de7f6
+pkg-pinsocket-2x13-d1.1-polygon-courtyard,c3af5a65-9ae6-43c8-9a0b-7b589f55bbf2
+pkg-pinsocket-2x13-d1.1-polygon-outline,ef684c59-f01e-4e5f-97eb-99ada22c6e5e
 pkg-pinsocket-2x13-d1.1-text-name,789ebe6c-db03-4969-932f-05932a58a879
 pkg-pinsocket-2x13-d1.1-text-value,9b8759b5-3aa8-407f-bd2b-444d9abb5a50
 pkg-pinsocket-2x14-d0.9-3d,5e244d8d-39a8-4470-9535-fbe2bb702e03
@@ -19198,6 +19936,8 @@ pkg-pinsocket-2x14-d0.9-pad-8,265b1ae1-2c48-4c22-a732-529190075351
 pkg-pinsocket-2x14-d0.9-pad-9,be666f88-d445-47e9-a94e-3a5bba9fef95
 pkg-pinsocket-2x14-d0.9-pkg,6a41ddd1-582a-4975-ab01-a00a740884b9
 pkg-pinsocket-2x14-d0.9-polygon-contour,e8515dd1-cb3f-4aae-9a4a-f3a9c3b1ee7b
+pkg-pinsocket-2x14-d0.9-polygon-courtyard,2023eda0-d486-4838-a17b-10f240ab305d
+pkg-pinsocket-2x14-d0.9-polygon-outline,bbc16f7e-c14c-476b-9612-6730323bb7c4
 pkg-pinsocket-2x14-d0.9-text-name,8f1569f0-5d0d-49f5-9eaa-a5ab017126d0
 pkg-pinsocket-2x14-d0.9-text-value,c3fcf305-0592-44ae-b904-409a101c38c8
 pkg-pinsocket-2x14-d1.0-3d,0ba57970-13e1-4033-ac24-1e14f20c0be2
@@ -19232,6 +19972,8 @@ pkg-pinsocket-2x14-d1.0-pad-8,1d8304cf-ce13-4332-b12e-e885043a7547
 pkg-pinsocket-2x14-d1.0-pad-9,6f934653-8675-4ba5-b112-440fb04a8e63
 pkg-pinsocket-2x14-d1.0-pkg,7756d068-f109-4cbb-a349-09474890595b
 pkg-pinsocket-2x14-d1.0-polygon-contour,6bd14036-01cd-4803-b8f7-24c66f05b95f
+pkg-pinsocket-2x14-d1.0-polygon-courtyard,b1ba8ad8-cb68-4242-990c-3fb397040258
+pkg-pinsocket-2x14-d1.0-polygon-outline,9388bbf7-c80c-4144-afa7-266ba7065f78
 pkg-pinsocket-2x14-d1.0-text-name,8e082e6e-176d-4031-9fc5-8b21e6d3964c
 pkg-pinsocket-2x14-d1.0-text-value,d64e1d16-b9bd-43b8-ad87-d38f6480c8ce
 pkg-pinsocket-2x14-d1.1-3d,16164af5-0987-4c45-aa6f-f396b7db1af0
@@ -19266,6 +20008,8 @@ pkg-pinsocket-2x14-d1.1-pad-8,e34f649b-5ddf-4413-98c8-d7fc3f53a022
 pkg-pinsocket-2x14-d1.1-pad-9,b34900ca-66b8-4c16-81b3-8cf4b9b5f2cc
 pkg-pinsocket-2x14-d1.1-pkg,8859c7af-d8de-4ed1-a9fe-927f353e1cfa
 pkg-pinsocket-2x14-d1.1-polygon-contour,0d33f968-4b66-42ef-b5ec-144d6c90da6c
+pkg-pinsocket-2x14-d1.1-polygon-courtyard,f85219a1-341a-4485-bc66-a253389edda0
+pkg-pinsocket-2x14-d1.1-polygon-outline,995acaf0-7677-408f-a7dc-156beff30076
 pkg-pinsocket-2x14-d1.1-text-name,e23e235c-e93f-4e46-8137-86dcabe67e4d
 pkg-pinsocket-2x14-d1.1-text-value,7a5141dc-0df7-4866-8a44-10d6193da10c
 pkg-pinsocket-2x15-d0.9-3d,442a4d63-21d6-4eb1-8627-3a92bb0b2fce
@@ -19302,6 +20046,8 @@ pkg-pinsocket-2x15-d0.9-pad-8,b9475edc-1543-4edc-be7f-c6825993ffb7
 pkg-pinsocket-2x15-d0.9-pad-9,2b9bb059-e10b-45eb-822e-c9ec2b4eb79b
 pkg-pinsocket-2x15-d0.9-pkg,3ccc52a4-72f8-4cec-ba87-0901bbbfaff1
 pkg-pinsocket-2x15-d0.9-polygon-contour,f39dd986-2d3f-464b-b69d-c2cdc4c860a1
+pkg-pinsocket-2x15-d0.9-polygon-courtyard,5b4ea26e-78e6-40f5-a91d-900be691885a
+pkg-pinsocket-2x15-d0.9-polygon-outline,f4c2e049-d98d-4fb5-b23f-8050647e8941
 pkg-pinsocket-2x15-d0.9-text-name,614494c9-4f1d-457a-9ffa-effe7dc7fd0e
 pkg-pinsocket-2x15-d0.9-text-value,9dc48922-9681-4919-a808-b3d623db9083
 pkg-pinsocket-2x15-d1.0-3d,eee2a9d9-1d41-46ee-a073-60508a4b5063
@@ -19338,6 +20084,8 @@ pkg-pinsocket-2x15-d1.0-pad-8,634b4a98-e632-4385-b16f-8a270ed6ab29
 pkg-pinsocket-2x15-d1.0-pad-9,c7d45e17-07ac-47ef-a416-99e3d67f8bad
 pkg-pinsocket-2x15-d1.0-pkg,7f4722e7-b3d7-4d8d-95d1-759a4fffa4db
 pkg-pinsocket-2x15-d1.0-polygon-contour,8536d793-de22-4c1d-b393-572260eca2f2
+pkg-pinsocket-2x15-d1.0-polygon-courtyard,8d0447d1-d256-44c8-bf8f-9ccadc0e631d
+pkg-pinsocket-2x15-d1.0-polygon-outline,e561d801-98cf-46f5-bc43-7bd5ccc22913
 pkg-pinsocket-2x15-d1.0-text-name,8b36ce81-9170-4245-ad5e-9ba18155191b
 pkg-pinsocket-2x15-d1.0-text-value,22fe88c5-e53e-43b2-a96a-c4527d2f7b24
 pkg-pinsocket-2x15-d1.1-3d,18c4586a-406f-4fcd-ab34-2ca64ed9a85f
@@ -19374,6 +20122,8 @@ pkg-pinsocket-2x15-d1.1-pad-8,79c82950-fcee-4cab-9df9-d9e55c41926e
 pkg-pinsocket-2x15-d1.1-pad-9,82ddc574-f6bf-48c0-a581-ca9e3ae05834
 pkg-pinsocket-2x15-d1.1-pkg,c51c154b-82fc-48e4-811f-929fd5176d9f
 pkg-pinsocket-2x15-d1.1-polygon-contour,c75a0a8f-6a27-4422-aa83-10d7fbe68997
+pkg-pinsocket-2x15-d1.1-polygon-courtyard,a36dfab0-1c9b-44d7-8ad0-d84d2e83bcd5
+pkg-pinsocket-2x15-d1.1-polygon-outline,24667e29-87cf-47f5-afb0-2f2e0c5a53d8
 pkg-pinsocket-2x15-d1.1-text-name,2ddd5824-5af1-4679-8bf2-ffa41740e6b3
 pkg-pinsocket-2x15-d1.1-text-value,527b8d07-9539-4baf-80f4-907c6595d247
 pkg-pinsocket-2x16-d0.9-3d,04aa1120-b315-47e6-a3cf-e3775617a97d
@@ -19412,6 +20162,8 @@ pkg-pinsocket-2x16-d0.9-pad-8,da213497-3dcc-4186-9dc4-fbf80b83d9f4
 pkg-pinsocket-2x16-d0.9-pad-9,8fe7a934-1459-40b5-ad91-7d840625acba
 pkg-pinsocket-2x16-d0.9-pkg,dc8ba617-a958-4234-a83d-da70ff7a2b8b
 pkg-pinsocket-2x16-d0.9-polygon-contour,e9a774d7-4077-4dde-b56b-9b8c6f6d18c1
+pkg-pinsocket-2x16-d0.9-polygon-courtyard,89b27cc4-e211-4ff1-9fd0-c0e59935845f
+pkg-pinsocket-2x16-d0.9-polygon-outline,a6ed4f18-86ee-4814-98f4-d2205f89f7b2
 pkg-pinsocket-2x16-d0.9-text-name,dbadf58a-6a63-4a6d-8289-ef4c4946922a
 pkg-pinsocket-2x16-d0.9-text-value,3b0c7da6-2ee6-4d05-9cab-946a0d5ced55
 pkg-pinsocket-2x16-d1.0-3d,89a5a3ac-7554-4d9d-8ed9-a7d1097d0005
@@ -19450,6 +20202,8 @@ pkg-pinsocket-2x16-d1.0-pad-8,2c3d9b75-bfb0-4738-bada-8d0d358c70a9
 pkg-pinsocket-2x16-d1.0-pad-9,1cbb4afd-5591-4f29-8dbe-a48d1e4dd9ac
 pkg-pinsocket-2x16-d1.0-pkg,af626199-2c69-4ad1-978f-a1a4d8b79027
 pkg-pinsocket-2x16-d1.0-polygon-contour,3f3ce934-3bd6-40aa-8dde-182496acecf7
+pkg-pinsocket-2x16-d1.0-polygon-courtyard,67aa942e-7af5-4f9e-8f38-029a74f96791
+pkg-pinsocket-2x16-d1.0-polygon-outline,87cf0cdb-3065-424a-971c-f2ae7710096b
 pkg-pinsocket-2x16-d1.0-text-name,44acd6d9-9444-4c9f-a1d6-dd4d66551405
 pkg-pinsocket-2x16-d1.0-text-value,14cf2199-4408-43c2-a038-9df2cd24c19f
 pkg-pinsocket-2x16-d1.1-3d,d82466a9-0a2f-41be-b597-a948d2463514
@@ -19488,6 +20242,8 @@ pkg-pinsocket-2x16-d1.1-pad-8,c716ec06-02a6-4d66-953e-101402b1b9a6
 pkg-pinsocket-2x16-d1.1-pad-9,793ded71-9453-4dfb-bf5e-2be931200c5c
 pkg-pinsocket-2x16-d1.1-pkg,53dd77b3-bbd3-4acf-93b9-8392607f2e84
 pkg-pinsocket-2x16-d1.1-polygon-contour,0dcaf33c-3e77-4c4c-9d7b-074a93fe1f04
+pkg-pinsocket-2x16-d1.1-polygon-courtyard,b7b97fc0-6bcf-4ff5-94b8-80b703db837b
+pkg-pinsocket-2x16-d1.1-polygon-outline,bdc64bd2-cfbb-44b4-91fa-493f0a4414ad
 pkg-pinsocket-2x16-d1.1-text-name,7519d560-4705-4528-987c-f827a8c7f2b5
 pkg-pinsocket-2x16-d1.1-text-value,74713129-7a75-484b-a579-d373280f949c
 pkg-pinsocket-2x17-d0.9-3d,6e6c4b8b-a63f-4ec4-8b18-000a4b3b43d3
@@ -19528,6 +20284,8 @@ pkg-pinsocket-2x17-d0.9-pad-8,4ac27b17-c411-4c7a-b2f4-59b2fd9429c1
 pkg-pinsocket-2x17-d0.9-pad-9,8d7dfd68-d635-42d7-ab52-af01365b0f0a
 pkg-pinsocket-2x17-d0.9-pkg,6cff9897-446a-4d2e-830e-06bd46184cb2
 pkg-pinsocket-2x17-d0.9-polygon-contour,9e5f4d4f-f262-4db6-8736-0ab905e3d970
+pkg-pinsocket-2x17-d0.9-polygon-courtyard,1fd76504-037c-48d8-b106-9004a5d0f29a
+pkg-pinsocket-2x17-d0.9-polygon-outline,a467e5c3-58a8-4a9d-9b4f-1188f9b6ab6e
 pkg-pinsocket-2x17-d0.9-text-name,7d3a997d-d63b-44ff-ab63-6f6ae25b4a96
 pkg-pinsocket-2x17-d0.9-text-value,301c29bd-28ef-4b21-ae20-895db1e8b5b7
 pkg-pinsocket-2x17-d1.0-3d,aa36bf0d-d8c1-475b-ba5e-ee2b157517a4
@@ -19568,6 +20326,8 @@ pkg-pinsocket-2x17-d1.0-pad-8,7418b07d-8fce-479e-b46d-dcf6d59eb5e5
 pkg-pinsocket-2x17-d1.0-pad-9,7b107430-5fdb-4130-8b46-23474a309eb4
 pkg-pinsocket-2x17-d1.0-pkg,e8e2a663-5348-477c-b17a-002377285bf8
 pkg-pinsocket-2x17-d1.0-polygon-contour,8fb2bf95-7979-4801-a8d1-e82042cb36e6
+pkg-pinsocket-2x17-d1.0-polygon-courtyard,4dff1258-f441-4d2c-960c-216e25f5d7cb
+pkg-pinsocket-2x17-d1.0-polygon-outline,039f2369-5392-4d3d-a13e-89bc81237b35
 pkg-pinsocket-2x17-d1.0-text-name,d948b000-f41e-44c7-af61-9775167b6176
 pkg-pinsocket-2x17-d1.0-text-value,30d119bb-ea5e-41bf-95bd-d73496cedeef
 pkg-pinsocket-2x17-d1.1-3d,b00b126b-8c59-41da-b880-3a72e18ec6c1
@@ -19608,6 +20368,8 @@ pkg-pinsocket-2x17-d1.1-pad-8,7a002bb7-cb00-481a-abd0-857e4550a553
 pkg-pinsocket-2x17-d1.1-pad-9,4377a717-5223-4ff9-acfd-ea6aa27b2af9
 pkg-pinsocket-2x17-d1.1-pkg,1411994a-9143-4460-a6ad-cf52e507f73f
 pkg-pinsocket-2x17-d1.1-polygon-contour,dce64eab-ae14-4e29-823a-19571d052289
+pkg-pinsocket-2x17-d1.1-polygon-courtyard,1d2837e5-3bbb-496d-b187-56b8efc19d7d
+pkg-pinsocket-2x17-d1.1-polygon-outline,1c2540d3-9066-4cce-bbfa-f545a2d88abf
 pkg-pinsocket-2x17-d1.1-text-name,83bafd3a-85e2-463e-b6b2-2ece7ddd90d6
 pkg-pinsocket-2x17-d1.1-text-value,6433f633-ff41-4b4c-b9a0-b4c6a12af842
 pkg-pinsocket-2x18-d0.9-3d,9adb57a5-9857-4f72-91a0-078d4b307f4e
@@ -19650,6 +20412,8 @@ pkg-pinsocket-2x18-d0.9-pad-8,2f1a2187-8c67-45f6-aba3-ef9e1578bdf0
 pkg-pinsocket-2x18-d0.9-pad-9,d1f8edcd-c7e8-4fad-a0d7-282ead1bf284
 pkg-pinsocket-2x18-d0.9-pkg,c3874255-68c0-4dd8-833f-879870b1fb1c
 pkg-pinsocket-2x18-d0.9-polygon-contour,c56e6dd7-3c8c-4dc8-a5df-cb7fa47de773
+pkg-pinsocket-2x18-d0.9-polygon-courtyard,192d62ee-bd6c-4add-a95a-fe90df4c247e
+pkg-pinsocket-2x18-d0.9-polygon-outline,b42c3b79-6ad4-430f-93b9-7c674c66c471
 pkg-pinsocket-2x18-d0.9-text-name,69d32578-bcc7-435f-aeaf-1d909fe9eb8b
 pkg-pinsocket-2x18-d0.9-text-value,62e37b62-6b20-445e-b4be-20c23303dc73
 pkg-pinsocket-2x18-d1.0-3d,a6e3a707-2647-4a67-8721-955b9520d212
@@ -19692,6 +20456,8 @@ pkg-pinsocket-2x18-d1.0-pad-8,7b5b6cfd-fa63-4d2d-b8ac-07d560f56326
 pkg-pinsocket-2x18-d1.0-pad-9,4b51e483-f9ce-46c7-aa2d-7d32463ae580
 pkg-pinsocket-2x18-d1.0-pkg,ec25138d-cb21-48d9-b9fb-f4833e8e1a67
 pkg-pinsocket-2x18-d1.0-polygon-contour,aa6698de-5b78-401c-8cb5-62cdc47a2dc0
+pkg-pinsocket-2x18-d1.0-polygon-courtyard,fa721d1a-9833-4410-861d-d94ed27eeed6
+pkg-pinsocket-2x18-d1.0-polygon-outline,9622aac6-3242-452f-a707-0e9258538ac9
 pkg-pinsocket-2x18-d1.0-text-name,1c698bc7-d984-407d-bd3d-0e190453adf8
 pkg-pinsocket-2x18-d1.0-text-value,13ddc754-f1d4-4058-95c4-7dd8e03a7923
 pkg-pinsocket-2x18-d1.1-3d,385fc226-5155-43b4-8cea-3b4f95c537a0
@@ -19734,6 +20500,8 @@ pkg-pinsocket-2x18-d1.1-pad-8,6f113775-35ed-443c-8e32-b994807d756c
 pkg-pinsocket-2x18-d1.1-pad-9,91bf86fd-1d73-476a-818f-3252a01ce55b
 pkg-pinsocket-2x18-d1.1-pkg,cf6502f5-cdfa-4d95-804a-3cc398500647
 pkg-pinsocket-2x18-d1.1-polygon-contour,9daa8bcf-3aa6-4b81-b177-e8ee20279ba7
+pkg-pinsocket-2x18-d1.1-polygon-courtyard,45d8aaf4-20cb-4ce9-a5dd-60d5fd238c8a
+pkg-pinsocket-2x18-d1.1-polygon-outline,206293d2-ecea-4c32-95b5-d028de9e832d
 pkg-pinsocket-2x18-d1.1-text-name,baa5e6fa-6a78-4e67-a197-bba1394dea8e
 pkg-pinsocket-2x18-d1.1-text-value,639d5902-9992-4c8c-bf79-59b168d54740
 pkg-pinsocket-2x19-d0.9-3d,b0b7a44a-e966-442f-9f9d-81a6465ef7bc
@@ -19778,6 +20546,8 @@ pkg-pinsocket-2x19-d0.9-pad-8,818f98e4-f4e3-4aea-a61b-b0f04dab6597
 pkg-pinsocket-2x19-d0.9-pad-9,d52cfdae-2cdb-4715-b3a5-05f8bc22ab31
 pkg-pinsocket-2x19-d0.9-pkg,309c7348-c97e-47cc-a76d-5e06e0651a8a
 pkg-pinsocket-2x19-d0.9-polygon-contour,6b448808-7f15-4bda-8b9f-446c10346d27
+pkg-pinsocket-2x19-d0.9-polygon-courtyard,430af02a-1c7c-4f00-a618-cef40617ea51
+pkg-pinsocket-2x19-d0.9-polygon-outline,5da74c93-ba03-4079-8705-31963a486bd4
 pkg-pinsocket-2x19-d0.9-text-name,0d9debe2-5fcf-432d-8acd-3704d5b11c39
 pkg-pinsocket-2x19-d0.9-text-value,7a09f796-fe17-4eb6-a067-a0e5be67020f
 pkg-pinsocket-2x19-d1.0-3d,9d17302e-000f-4777-bf15-7c0ae12a297c
@@ -19822,6 +20592,8 @@ pkg-pinsocket-2x19-d1.0-pad-8,8380b6c4-11ef-4791-b4e0-420f3b379a6b
 pkg-pinsocket-2x19-d1.0-pad-9,d499bc7a-7785-42d1-a09f-041692001d8b
 pkg-pinsocket-2x19-d1.0-pkg,fc04ed0b-3821-440c-99dc-b66d3d7cc210
 pkg-pinsocket-2x19-d1.0-polygon-contour,1ddd23f4-631d-44c3-a5d9-32d3a6738e96
+pkg-pinsocket-2x19-d1.0-polygon-courtyard,0cd9539d-029e-4383-a4d8-95ab4517a8d7
+pkg-pinsocket-2x19-d1.0-polygon-outline,3d0d020f-db1b-490d-a228-50c0e1e0d1c9
 pkg-pinsocket-2x19-d1.0-text-name,3e814bfd-70dd-4051-92a3-3e23b4e52ba0
 pkg-pinsocket-2x19-d1.0-text-value,b3d365cc-e47d-474b-96ac-9e478ff2eec9
 pkg-pinsocket-2x19-d1.1-3d,d01b0831-c4ce-452c-915c-6c76dfc648e2
@@ -19866,6 +20638,8 @@ pkg-pinsocket-2x19-d1.1-pad-8,71b1c2dd-521e-45a2-bb33-1100e7892085
 pkg-pinsocket-2x19-d1.1-pad-9,fd4de1a9-96a7-4caf-8b63-ce4220b00705
 pkg-pinsocket-2x19-d1.1-pkg,739dffdd-7845-41e7-be0d-1f8ca7e189f3
 pkg-pinsocket-2x19-d1.1-polygon-contour,e6d03cd9-4f97-40cd-aab2-685dc7099508
+pkg-pinsocket-2x19-d1.1-polygon-courtyard,ae1b8bd7-ae4d-4652-a461-2084af2078ed
+pkg-pinsocket-2x19-d1.1-polygon-outline,2e344ae1-cf43-4cd7-b5d9-d05face9dbe1
 pkg-pinsocket-2x19-d1.1-text-name,a6f23710-80f5-4757-baf6-52bb02b33b6e
 pkg-pinsocket-2x19-d1.1-text-value,9410f7fc-d1fe-42b3-86e6-9075bd3b6734
 pkg-pinsocket-2x2-d0.9-3d,1ce544cc-bf99-4161-992e-9fee85f76ad8
@@ -19876,6 +20650,8 @@ pkg-pinsocket-2x2-d0.9-pad-2,b586082b-1d95-421e-9f47-7164f92c9a7e
 pkg-pinsocket-2x2-d0.9-pad-3,7e2489de-468b-45e2-a0ba-db995a2b3529
 pkg-pinsocket-2x2-d0.9-pkg,6af7870d-d544-41b6-b047-930f639a697e
 pkg-pinsocket-2x2-d0.9-polygon-contour,13b93d6b-1232-436b-b138-4e67bd307ee9
+pkg-pinsocket-2x2-d0.9-polygon-courtyard,049ec48e-e83b-43c4-8856-d975eb6acd16
+pkg-pinsocket-2x2-d0.9-polygon-outline,00be7853-b5a0-4906-92ba-090e48d3d806
 pkg-pinsocket-2x2-d0.9-text-name,565b2661-5802-4e23-ad06-99dd85e0a0bb
 pkg-pinsocket-2x2-d0.9-text-value,44b56b9e-5a1c-4433-ac56-0ac28d291799
 pkg-pinsocket-2x2-d1.0-3d,b2a0ad7d-b27b-4e95-8f0b-177ca031cf77
@@ -19886,6 +20662,8 @@ pkg-pinsocket-2x2-d1.0-pad-2,6c3dfc2c-20c2-4edc-864b-4cd3eba6c366
 pkg-pinsocket-2x2-d1.0-pad-3,bcbd562b-47c2-4e5b-96bb-5ce16deb8cf6
 pkg-pinsocket-2x2-d1.0-pkg,420eb6bb-be27-4eb0-8bd7-c5ecf3f12c47
 pkg-pinsocket-2x2-d1.0-polygon-contour,10811d6a-e6e0-479f-9675-c04b8cf10893
+pkg-pinsocket-2x2-d1.0-polygon-courtyard,e056e1f3-4845-4b7c-b0be-e261406ae3f5
+pkg-pinsocket-2x2-d1.0-polygon-outline,f72cf1b2-ed7d-4e5c-9870-e2b626961418
 pkg-pinsocket-2x2-d1.0-text-name,21064c5f-512f-4d74-a0f2-89d9b622aa88
 pkg-pinsocket-2x2-d1.0-text-value,3551a6bf-9a66-4d03-8dd1-c856aa410d7d
 pkg-pinsocket-2x2-d1.1-3d,53a5e72c-baf8-48ba-92f3-4e8057518e0b
@@ -19896,6 +20674,8 @@ pkg-pinsocket-2x2-d1.1-pad-2,ddf8557f-a3ac-4e2b-9070-0e6f3d34e887
 pkg-pinsocket-2x2-d1.1-pad-3,334dd52b-8919-484c-ab0f-2af0ba6a1d59
 pkg-pinsocket-2x2-d1.1-pkg,028f6731-1232-4d24-b4af-8dbbea798c4b
 pkg-pinsocket-2x2-d1.1-polygon-contour,72437da7-56a6-4a0d-b6c7-6c5a927fc294
+pkg-pinsocket-2x2-d1.1-polygon-courtyard,902a19e8-923f-4551-8136-a33f0e7d259c
+pkg-pinsocket-2x2-d1.1-polygon-outline,1ccfe67d-fbce-43e6-a9a4-aaada55bf5d7
 pkg-pinsocket-2x2-d1.1-text-name,7081e864-4d6c-47fa-bb7a-71de7f33b690
 pkg-pinsocket-2x2-d1.1-text-value,bdab2edc-9f0d-47cd-9bb1-fafd80742daa
 pkg-pinsocket-2x20-d0.9-3d,56252e7e-57ea-4aa8-8841-17945bba6885
@@ -19942,6 +20722,8 @@ pkg-pinsocket-2x20-d0.9-pad-8,b02a6c7c-9ded-46ff-b69d-f4713deb482d
 pkg-pinsocket-2x20-d0.9-pad-9,8adafcfc-ecaa-4e6b-96dd-8ae3ad3609a8
 pkg-pinsocket-2x20-d0.9-pkg,3590b14c-15eb-4598-8580-57b04b2e98ae
 pkg-pinsocket-2x20-d0.9-polygon-contour,727141db-4991-4a0f-99c0-0215c54cc4e9
+pkg-pinsocket-2x20-d0.9-polygon-courtyard,7f19b12b-16fd-407f-92cb-f7247b0b559b
+pkg-pinsocket-2x20-d0.9-polygon-outline,b74411cc-a161-41af-9d66-8e4509bb223b
 pkg-pinsocket-2x20-d0.9-text-name,fc6dbb87-b88d-4504-ad6d-1092c7b5cb74
 pkg-pinsocket-2x20-d0.9-text-value,cfd532b6-d711-4bd7-a290-a8b344531506
 pkg-pinsocket-2x20-d1.0-3d,7d35f755-b53b-4d99-8b26-718b0b1efc58
@@ -19988,6 +20770,8 @@ pkg-pinsocket-2x20-d1.0-pad-8,20ed528d-d2ba-4800-af1d-9a917f68f33a
 pkg-pinsocket-2x20-d1.0-pad-9,35930bbe-27fb-4d0a-be34-3df180b7136b
 pkg-pinsocket-2x20-d1.0-pkg,57930afd-9054-4868-9cac-201d9ad45b29
 pkg-pinsocket-2x20-d1.0-polygon-contour,02e76425-ee17-4552-b5f1-9b8e89e167d4
+pkg-pinsocket-2x20-d1.0-polygon-courtyard,b7c07419-c2ed-4620-a0f1-baa4e5d5a207
+pkg-pinsocket-2x20-d1.0-polygon-outline,f591e6cd-36ee-468b-b85c-7df48adbeaa9
 pkg-pinsocket-2x20-d1.0-text-name,72a9e211-80ab-4904-be7d-ae4843c76607
 pkg-pinsocket-2x20-d1.0-text-value,fed430ab-9d1e-4ee5-a791-ee35f7429e6f
 pkg-pinsocket-2x20-d1.1-3d,637f2842-d473-4822-867b-c23eaf5853b4
@@ -20034,6 +20818,8 @@ pkg-pinsocket-2x20-d1.1-pad-8,b8be9a19-d0fe-40ba-ae22-f3376bc1a252
 pkg-pinsocket-2x20-d1.1-pad-9,bea9f294-69c4-4eb2-965c-a11d4adb215e
 pkg-pinsocket-2x20-d1.1-pkg,b60c7f45-7318-4e9d-b7ac-590ff8a5dd80
 pkg-pinsocket-2x20-d1.1-polygon-contour,8a56e437-ad77-44f1-92ba-1b2993e897fe
+pkg-pinsocket-2x20-d1.1-polygon-courtyard,3b84fdeb-8021-4473-a253-21d52c69c5cf
+pkg-pinsocket-2x20-d1.1-polygon-outline,eb5aad9c-1797-4005-8ff1-67bd12702264
 pkg-pinsocket-2x20-d1.1-text-name,75c27d20-ea6f-41f5-9e84-566fd2fffb6b
 pkg-pinsocket-2x20-d1.1-text-value,63293ec0-c74a-45a3-945d-6f0408fb505c
 pkg-pinsocket-2x21-d0.9-3d,8a3fafdf-4898-4813-a6a6-7c457fc12812
@@ -20082,6 +20868,8 @@ pkg-pinsocket-2x21-d0.9-pad-8,1bd20297-82a0-42bd-9b64-f95a4973d7c9
 pkg-pinsocket-2x21-d0.9-pad-9,e9260e5d-e2a2-4d5c-b56f-e76ae89c0d35
 pkg-pinsocket-2x21-d0.9-pkg,316ae1d0-7ec8-498a-9696-90f148c5ad6e
 pkg-pinsocket-2x21-d0.9-polygon-contour,b4b4d8ba-1673-4e41-a5c6-41804e06e072
+pkg-pinsocket-2x21-d0.9-polygon-courtyard,e145625f-39d1-4b38-a9bd-098f3f844509
+pkg-pinsocket-2x21-d0.9-polygon-outline,13c4f8cd-7fcf-44f5-a3ca-d6bad87128c5
 pkg-pinsocket-2x21-d0.9-text-name,ef4b518c-9d2d-43a0-9448-80955123532f
 pkg-pinsocket-2x21-d0.9-text-value,2a9ab0a2-7b38-473b-af8b-b819c3e86b55
 pkg-pinsocket-2x21-d1.0-3d,8b29cfd7-3814-4cd4-bde7-5c550d2f6c11
@@ -20130,6 +20918,8 @@ pkg-pinsocket-2x21-d1.0-pad-8,157f2d73-8949-4ad8-aa00-4a4de78da818
 pkg-pinsocket-2x21-d1.0-pad-9,2e041f8f-ddb0-484b-aca9-e616e453c13e
 pkg-pinsocket-2x21-d1.0-pkg,ddf16ce7-873c-46cd-9871-119f67e2388d
 pkg-pinsocket-2x21-d1.0-polygon-contour,49683c22-c294-40f0-a31e-f30dd67483a9
+pkg-pinsocket-2x21-d1.0-polygon-courtyard,5835cb33-9e64-48c7-8ac9-a623fc256ee2
+pkg-pinsocket-2x21-d1.0-polygon-outline,550e2e05-aa24-4f85-bc7d-cd62a6938201
 pkg-pinsocket-2x21-d1.0-text-name,1bc2fa2e-6ae5-4edf-94bf-3ecd835b2466
 pkg-pinsocket-2x21-d1.0-text-value,d28cda5f-ca15-45a0-96da-32518e1211bf
 pkg-pinsocket-2x21-d1.1-3d,1820f887-339a-4d00-9484-b6c473e65209
@@ -20178,6 +20968,8 @@ pkg-pinsocket-2x21-d1.1-pad-8,f1331cf2-cb63-415d-b63c-692469abd87d
 pkg-pinsocket-2x21-d1.1-pad-9,ffa92433-07d6-4ce9-9ccd-8b6512b872f1
 pkg-pinsocket-2x21-d1.1-pkg,52044f42-66c7-40ca-9a5d-a4ba6e29a548
 pkg-pinsocket-2x21-d1.1-polygon-contour,9020328c-3f6c-4ef8-8772-085f7e57c6f2
+pkg-pinsocket-2x21-d1.1-polygon-courtyard,49fc3335-0afe-4e03-a9c2-b24b802bec1b
+pkg-pinsocket-2x21-d1.1-polygon-outline,b0c38a28-520b-4b70-a625-245187fb1832
 pkg-pinsocket-2x21-d1.1-text-name,19d10b03-d4a5-4f4a-904c-75b661bced00
 pkg-pinsocket-2x21-d1.1-text-value,46e7b9b8-d4cd-459e-a8a3-a08cd7bb737b
 pkg-pinsocket-2x22-d0.9-3d,0cae24aa-c822-4a70-ab5e-71be2cb41e73
@@ -20228,6 +21020,8 @@ pkg-pinsocket-2x22-d0.9-pad-8,53c7aa6a-adfc-49be-80a7-36eb73e524f7
 pkg-pinsocket-2x22-d0.9-pad-9,85dd2525-98d5-4764-83a6-8e1f01467f73
 pkg-pinsocket-2x22-d0.9-pkg,cb828b6c-9bd5-4ba6-90d9-03b7732070de
 pkg-pinsocket-2x22-d0.9-polygon-contour,9d9243a4-150b-4ffe-acc9-3d79a971579d
+pkg-pinsocket-2x22-d0.9-polygon-courtyard,469ba226-4093-42a5-889f-4a684c663476
+pkg-pinsocket-2x22-d0.9-polygon-outline,adc000f7-5d82-4884-b6b3-ef590378a7f5
 pkg-pinsocket-2x22-d0.9-text-name,cb5b9a95-f789-453f-9bae-56653d83d770
 pkg-pinsocket-2x22-d0.9-text-value,5fe0238b-41d8-4e6c-96dd-69dfb6e4f4fa
 pkg-pinsocket-2x22-d1.0-3d,435b511e-2e68-459c-8686-57f513614cad
@@ -20278,6 +21072,8 @@ pkg-pinsocket-2x22-d1.0-pad-8,4a45df7a-114a-49c2-8dd8-bec297144c4a
 pkg-pinsocket-2x22-d1.0-pad-9,1d893689-ce4f-45af-a411-1bc77f9330c9
 pkg-pinsocket-2x22-d1.0-pkg,8655b14d-e681-4635-829b-45fbe92d2c4f
 pkg-pinsocket-2x22-d1.0-polygon-contour,29a5dbd3-4eed-474d-8a67-770ba4f54480
+pkg-pinsocket-2x22-d1.0-polygon-courtyard,6b942464-235c-42ce-8b8b-bd72c028998f
+pkg-pinsocket-2x22-d1.0-polygon-outline,1af366b1-e997-4cf9-9052-10cd668e70d2
 pkg-pinsocket-2x22-d1.0-text-name,1354018d-d14a-437c-9caf-cb4da03240ac
 pkg-pinsocket-2x22-d1.0-text-value,17e3835e-2f8b-472b-969d-73e17fa23649
 pkg-pinsocket-2x22-d1.1-3d,c96d326e-90f8-4ee7-9925-0a4019a2b1dc
@@ -20328,6 +21124,8 @@ pkg-pinsocket-2x22-d1.1-pad-8,b8222398-a4ed-4c64-8738-c2fae6db8838
 pkg-pinsocket-2x22-d1.1-pad-9,a8b93c15-ca01-43f7-9e8d-e31265292310
 pkg-pinsocket-2x22-d1.1-pkg,21f68f80-02c9-42d8-a50d-256bafbe80e7
 pkg-pinsocket-2x22-d1.1-polygon-contour,447b11d9-7de4-4c2f-ac6a-8d332d003d0b
+pkg-pinsocket-2x22-d1.1-polygon-courtyard,5b6aa91b-ad33-4415-963c-061baa836f79
+pkg-pinsocket-2x22-d1.1-polygon-outline,f4e40ef2-556d-4861-8e3a-632938aec1af
 pkg-pinsocket-2x22-d1.1-text-name,bacd51e9-1c3e-495b-b571-bd8d8da81a6f
 pkg-pinsocket-2x22-d1.1-text-value,1ea76eb2-9c9d-4b0a-aea1-fe9837b50d9f
 pkg-pinsocket-2x23-d0.9-3d,e4aca3bd-d467-425e-8e77-37d419be9556
@@ -20380,6 +21178,8 @@ pkg-pinsocket-2x23-d0.9-pad-8,6ea45458-0ae0-4f2b-be65-bd60d744e133
 pkg-pinsocket-2x23-d0.9-pad-9,5f168b41-5e8a-454d-9fcc-5bf52072960c
 pkg-pinsocket-2x23-d0.9-pkg,72b0ee75-ac46-4afc-97ce-848695a310b3
 pkg-pinsocket-2x23-d0.9-polygon-contour,fbbab198-2b89-4f16-8c45-c504c726fe9f
+pkg-pinsocket-2x23-d0.9-polygon-courtyard,d7a20184-addf-4cf7-9722-476c400389c1
+pkg-pinsocket-2x23-d0.9-polygon-outline,4b8af43e-d358-4c2d-b8c6-2e1e442cab5e
 pkg-pinsocket-2x23-d0.9-text-name,50ea5b78-08b2-4c9e-bb64-e41f5e7deee0
 pkg-pinsocket-2x23-d0.9-text-value,78ca4adc-0d2a-4c66-8031-761051fbe4bf
 pkg-pinsocket-2x23-d1.0-3d,71191b41-a052-4ef3-8419-4a5948a17dcf
@@ -20432,6 +21232,8 @@ pkg-pinsocket-2x23-d1.0-pad-8,50e3e195-d71d-4820-aef0-3f03b534c429
 pkg-pinsocket-2x23-d1.0-pad-9,66ffa4a2-b8d3-46a3-8d2a-754a8bd06d1b
 pkg-pinsocket-2x23-d1.0-pkg,4bbdf1a2-e868-483e-9451-13bb6a1a55e3
 pkg-pinsocket-2x23-d1.0-polygon-contour,6b19de4e-33b8-47f1-b4da-0a4183623770
+pkg-pinsocket-2x23-d1.0-polygon-courtyard,4360800c-f723-4ad8-8133-accdf0c349ac
+pkg-pinsocket-2x23-d1.0-polygon-outline,b1c87ec6-80f4-4fa1-92be-7a9e3a97ff68
 pkg-pinsocket-2x23-d1.0-text-name,5e774484-9e0c-4395-b576-823587e08eb3
 pkg-pinsocket-2x23-d1.0-text-value,efa9c128-27e0-4e8a-914b-106cf415bdf9
 pkg-pinsocket-2x23-d1.1-3d,ab31e4c1-4989-4271-87b2-b871ae031bc8
@@ -20484,6 +21286,8 @@ pkg-pinsocket-2x23-d1.1-pad-8,9694479c-2a54-4a11-80fe-2cbae92d6b20
 pkg-pinsocket-2x23-d1.1-pad-9,1da91874-d331-444e-bee5-d335d2215532
 pkg-pinsocket-2x23-d1.1-pkg,e5a6cbae-df34-4728-8848-b06ff5a0bd0c
 pkg-pinsocket-2x23-d1.1-polygon-contour,0f286d68-e252-469f-bb66-58f9db9351c4
+pkg-pinsocket-2x23-d1.1-polygon-courtyard,2531e5aa-2dc4-4bc0-95fd-6ab0cb317c29
+pkg-pinsocket-2x23-d1.1-polygon-outline,0fb5daff-9830-48e0-b4da-09e207037f14
 pkg-pinsocket-2x23-d1.1-text-name,6f71373d-5395-4d86-b7d4-3480eddf57a9
 pkg-pinsocket-2x23-d1.1-text-value,3d181e58-79e7-42fa-a5b0-8c0fc0a76d3d
 pkg-pinsocket-2x24-d0.9-3d,5e334d90-fb24-4e92-a576-c23f331ceb11
@@ -20538,6 +21342,8 @@ pkg-pinsocket-2x24-d0.9-pad-8,6b0f5e06-7fdf-4c9e-8e72-f59f5d2b4c50
 pkg-pinsocket-2x24-d0.9-pad-9,fb2b6afa-89a4-4469-8e88-77a87431db52
 pkg-pinsocket-2x24-d0.9-pkg,358f1c22-d1ac-42bc-bea0-34ecb9e4bf9d
 pkg-pinsocket-2x24-d0.9-polygon-contour,67d22be2-f368-4e82-9244-ed166013d72c
+pkg-pinsocket-2x24-d0.9-polygon-courtyard,a8ce0e1a-11e8-40c6-bbcc-b47e869a0c5d
+pkg-pinsocket-2x24-d0.9-polygon-outline,29cf3f38-d368-48a6-83b3-033d5cfb9a72
 pkg-pinsocket-2x24-d0.9-text-name,0348a004-508a-40e3-a2d6-7849d33d1bc4
 pkg-pinsocket-2x24-d0.9-text-value,ac3b2aed-327f-4874-bf72-650c4d36920a
 pkg-pinsocket-2x24-d1.0-3d,fc662105-d8ff-4dd7-a03e-f0995242e551
@@ -20592,6 +21398,8 @@ pkg-pinsocket-2x24-d1.0-pad-8,07177486-eeab-49e4-ab8a-7da5478d20a9
 pkg-pinsocket-2x24-d1.0-pad-9,40fd6bd9-53a3-4e9d-9a2f-866528dcba40
 pkg-pinsocket-2x24-d1.0-pkg,68e36dd4-7406-4cca-8d91-ce101abdf686
 pkg-pinsocket-2x24-d1.0-polygon-contour,512f7bdf-f1f4-42c2-8239-ad77bb30a287
+pkg-pinsocket-2x24-d1.0-polygon-courtyard,1cd9f528-a901-48d3-8086-ecbcff0aef86
+pkg-pinsocket-2x24-d1.0-polygon-outline,b3a92527-af03-4af0-ae97-41d39568b5ad
 pkg-pinsocket-2x24-d1.0-text-name,812b116a-a6b7-46f5-8201-e7d8d4b2c56e
 pkg-pinsocket-2x24-d1.0-text-value,d79dac48-919c-4ce7-b17d-266d0ac1b35c
 pkg-pinsocket-2x24-d1.1-3d,dec1137d-3e9f-45c1-a210-af8c24e53c5f
@@ -20646,6 +21454,8 @@ pkg-pinsocket-2x24-d1.1-pad-8,ad96a901-bd54-4023-b7cc-18c54084fe6e
 pkg-pinsocket-2x24-d1.1-pad-9,106e7205-b028-4901-b2fa-4c5476cf40c8
 pkg-pinsocket-2x24-d1.1-pkg,072eac31-d4b6-436b-b33e-d1a45bd85fc6
 pkg-pinsocket-2x24-d1.1-polygon-contour,e23d7451-c1e6-448b-89d2-23c33c7b1c2f
+pkg-pinsocket-2x24-d1.1-polygon-courtyard,bdbef85b-ab9e-4e08-8847-3da44e6c9c15
+pkg-pinsocket-2x24-d1.1-polygon-outline,12cdc045-7603-41be-bf31-9899b3207d5d
 pkg-pinsocket-2x24-d1.1-text-name,fb076400-fd15-4b21-a9ff-dc12da082bca
 pkg-pinsocket-2x24-d1.1-text-value,fe572e36-a1b5-4f72-918e-3b53d87d9163
 pkg-pinsocket-2x25-d0.9-3d,c008c68a-9366-4832-8f31-3bafb2cf39e2
@@ -20702,6 +21512,8 @@ pkg-pinsocket-2x25-d0.9-pad-8,db774817-b12e-497c-bbed-76f59929c932
 pkg-pinsocket-2x25-d0.9-pad-9,5f9a784e-2e2b-42d1-bf99-3663550f955d
 pkg-pinsocket-2x25-d0.9-pkg,36eb0d89-dcc3-459d-b769-f3c75cbc84a3
 pkg-pinsocket-2x25-d0.9-polygon-contour,ae51fb38-5255-45cf-803a-871a454bc7f9
+pkg-pinsocket-2x25-d0.9-polygon-courtyard,1eb5f04d-dfd2-4fec-85b2-f975dc643c5a
+pkg-pinsocket-2x25-d0.9-polygon-outline,242e6991-0542-4710-ad19-225a751cf98a
 pkg-pinsocket-2x25-d0.9-text-name,f0068413-8622-42b4-b902-e96fc910e665
 pkg-pinsocket-2x25-d0.9-text-value,ce5c4bbb-c06f-4088-ab36-d8ed07c8c5c2
 pkg-pinsocket-2x25-d1.0-3d,db3bd14f-1e08-4fa7-9f9f-359303be4d52
@@ -20758,6 +21570,8 @@ pkg-pinsocket-2x25-d1.0-pad-8,a4993dbe-1bdb-4c04-9eb2-e37c60f56756
 pkg-pinsocket-2x25-d1.0-pad-9,439e67e7-11c4-4dd0-815b-8aba8240e328
 pkg-pinsocket-2x25-d1.0-pkg,dca63e0e-6f6a-4a03-800f-2ce58388cad4
 pkg-pinsocket-2x25-d1.0-polygon-contour,b8fe7274-041f-4dc0-bed6-aee1c401973f
+pkg-pinsocket-2x25-d1.0-polygon-courtyard,f98ea13a-506d-47d3-bfa9-e7a24d4c869e
+pkg-pinsocket-2x25-d1.0-polygon-outline,d59ae8da-9043-4c96-88bc-b09b9f80781c
 pkg-pinsocket-2x25-d1.0-text-name,9b45ecd1-5ae1-43b7-80ae-e218dddc761b
 pkg-pinsocket-2x25-d1.0-text-value,66af595e-e8b3-4feb-a2af-30bb9cb2ef36
 pkg-pinsocket-2x25-d1.1-3d,925392a8-ea2e-4c2f-ad26-f0439748e9fc
@@ -20814,6 +21628,8 @@ pkg-pinsocket-2x25-d1.1-pad-8,35d3d324-9c65-4257-a594-d31d433b4515
 pkg-pinsocket-2x25-d1.1-pad-9,5fc87dbe-41b8-4db9-abba-1a7c7fe68f30
 pkg-pinsocket-2x25-d1.1-pkg,f63a6417-404f-4376-9464-1d2d8199bf56
 pkg-pinsocket-2x25-d1.1-polygon-contour,4f56ab89-1cba-4279-bbbb-30ca74b165e8
+pkg-pinsocket-2x25-d1.1-polygon-courtyard,cb744bc1-23be-4a44-ac92-97ed58768d4f
+pkg-pinsocket-2x25-d1.1-polygon-outline,bcfcac4d-e11a-47b0-b361-2afcf7433d05
 pkg-pinsocket-2x25-d1.1-text-name,5e7ec346-8a2d-4a1f-8b52-dd0a0ae8bfb9
 pkg-pinsocket-2x25-d1.1-text-value,f2ee3246-e9ca-4f74-aff7-2108ac3e45b6
 pkg-pinsocket-2x26-d0.9-3d,f76b862c-7541-47bb-9531-5a93be7fe156
@@ -20872,6 +21688,8 @@ pkg-pinsocket-2x26-d0.9-pad-8,1ffda902-5765-400c-9626-178231f526dd
 pkg-pinsocket-2x26-d0.9-pad-9,5337f340-1e85-4679-8a7b-bf2d1b7ef249
 pkg-pinsocket-2x26-d0.9-pkg,b2c45080-2722-4954-9ba7-002857a323f8
 pkg-pinsocket-2x26-d0.9-polygon-contour,110ea164-eb08-46fb-8e84-66ac6c79c133
+pkg-pinsocket-2x26-d0.9-polygon-courtyard,5fba0ef7-e438-4d0e-b2d7-9e78f4252418
+pkg-pinsocket-2x26-d0.9-polygon-outline,79ee9580-f477-4e96-b084-0af8d87ef5b3
 pkg-pinsocket-2x26-d0.9-text-name,2f9292b6-5a9b-45e3-85d6-f7f1a20ad713
 pkg-pinsocket-2x26-d0.9-text-value,4183f62a-9167-43f7-a2ba-cc6d8cd269c6
 pkg-pinsocket-2x26-d1.0-3d,e4fce565-9c68-466f-be88-acbc818b777b
@@ -20930,6 +21748,8 @@ pkg-pinsocket-2x26-d1.0-pad-8,02b4f8c2-5d3f-48fe-88ea-98cbde311279
 pkg-pinsocket-2x26-d1.0-pad-9,7df1005e-7851-41f4-988f-23bfeb02588f
 pkg-pinsocket-2x26-d1.0-pkg,24c2edc5-948a-475f-85b0-0dddf5f9a0c6
 pkg-pinsocket-2x26-d1.0-polygon-contour,ba38fa01-30a7-443c-ba3c-73f1e3e54bd8
+pkg-pinsocket-2x26-d1.0-polygon-courtyard,0a3ecf58-ec8d-4951-8ba4-974482a4d3eb
+pkg-pinsocket-2x26-d1.0-polygon-outline,c5bbddd1-b77d-4098-8ccf-11d759486beb
 pkg-pinsocket-2x26-d1.0-text-name,e5039ddd-46bd-467c-bbef-02dcf9730dc0
 pkg-pinsocket-2x26-d1.0-text-value,ed61f429-be89-4a86-bd86-95598e1466f9
 pkg-pinsocket-2x26-d1.1-3d,c75fd1c8-5045-43d3-bf1f-7ef03ef0012e
@@ -20988,6 +21808,8 @@ pkg-pinsocket-2x26-d1.1-pad-8,6b2978b8-d811-4c88-a052-9ecb4c1ec23f
 pkg-pinsocket-2x26-d1.1-pad-9,70288a75-0ad7-4222-a5a2-8cabef4b8256
 pkg-pinsocket-2x26-d1.1-pkg,8ca10d5b-29d1-4408-8c93-52e4e03b99c1
 pkg-pinsocket-2x26-d1.1-polygon-contour,b9cecc2f-5157-4617-beca-93b3ae9cd806
+pkg-pinsocket-2x26-d1.1-polygon-courtyard,7ba3694b-5d55-4686-a69f-f96f69c4ad15
+pkg-pinsocket-2x26-d1.1-polygon-outline,37a4e1ec-e017-479e-877b-e89103e339d9
 pkg-pinsocket-2x26-d1.1-text-name,754484f8-c1dc-4807-a331-4c6d43be62e8
 pkg-pinsocket-2x26-d1.1-text-value,46d47b98-d49f-4763-800a-205bf54e8900
 pkg-pinsocket-2x27-d0.9-3d,9d17e547-0b0b-41f7-b456-8e41624a79c8
@@ -21048,6 +21870,8 @@ pkg-pinsocket-2x27-d0.9-pad-8,afcb8e4d-a735-4f8d-9ebb-5ebe0dc4ee5b
 pkg-pinsocket-2x27-d0.9-pad-9,c292f086-f77c-4da4-80ad-c3a0ecedbf83
 pkg-pinsocket-2x27-d0.9-pkg,479690f0-7443-4565-88df-3af08da8d4c9
 pkg-pinsocket-2x27-d0.9-polygon-contour,8825910d-4425-4c06-8e41-aecf26373fd7
+pkg-pinsocket-2x27-d0.9-polygon-courtyard,6d1aa072-c223-4a41-b85d-1d51c9e4fc93
+pkg-pinsocket-2x27-d0.9-polygon-outline,05aeb366-7db7-403f-9038-996e5f5b5c9f
 pkg-pinsocket-2x27-d0.9-text-name,cdee963a-ccec-4913-bd33-3faa637a5c32
 pkg-pinsocket-2x27-d0.9-text-value,08835ff7-e540-427e-a2a9-2081e87b9a48
 pkg-pinsocket-2x27-d1.0-3d,ebb80500-fbc5-4487-b4ee-59a4bc9f17e5
@@ -21108,6 +21932,8 @@ pkg-pinsocket-2x27-d1.0-pad-8,2d254d62-0b48-411d-b2c5-55ffc7fa8c2d
 pkg-pinsocket-2x27-d1.0-pad-9,5ac9a9b9-4ec8-4b20-af90-2f941540292e
 pkg-pinsocket-2x27-d1.0-pkg,eacca5ac-8bd0-4602-b089-6d1ae709a4fc
 pkg-pinsocket-2x27-d1.0-polygon-contour,67b88442-666d-422c-b642-0d66acbece3a
+pkg-pinsocket-2x27-d1.0-polygon-courtyard,17fcfd7b-9f48-41e8-ab07-613eb9c15bd4
+pkg-pinsocket-2x27-d1.0-polygon-outline,7944a20e-8fd0-4e2f-acc4-cc10ad208349
 pkg-pinsocket-2x27-d1.0-text-name,e9df5df2-a0fc-40bc-91da-5c0e388acff1
 pkg-pinsocket-2x27-d1.0-text-value,2e798ddf-80df-4c6a-b678-52ad764535bf
 pkg-pinsocket-2x27-d1.1-3d,03b13ec0-adc5-4524-808e-4e572abcc5f3
@@ -21168,6 +21994,8 @@ pkg-pinsocket-2x27-d1.1-pad-8,d31be87c-1496-4389-bbc4-5fd878c671ef
 pkg-pinsocket-2x27-d1.1-pad-9,51642928-f9df-40cc-9298-ee3e3156313f
 pkg-pinsocket-2x27-d1.1-pkg,0933a6a8-186d-4bfa-82f5-d2e08b9831d6
 pkg-pinsocket-2x27-d1.1-polygon-contour,9cadbbfe-a7f3-4d72-a264-200c5e6c386d
+pkg-pinsocket-2x27-d1.1-polygon-courtyard,a80b3d7e-8c55-4a61-b780-d4538a3f5ca2
+pkg-pinsocket-2x27-d1.1-polygon-outline,17ef2e15-283f-4ffe-af67-be7cdead38e9
 pkg-pinsocket-2x27-d1.1-text-name,3d260136-e236-44f8-bbc7-7c1eca81729b
 pkg-pinsocket-2x27-d1.1-text-value,5a261c46-b1e2-4bab-b85c-8410e88b34d8
 pkg-pinsocket-2x28-d0.9-3d,a1f90ea4-d8d5-4970-bad4-d554826491ab
@@ -21230,6 +22058,8 @@ pkg-pinsocket-2x28-d0.9-pad-8,8db605a5-d0cf-4f3c-b588-151401d5968d
 pkg-pinsocket-2x28-d0.9-pad-9,dfef6eb5-c066-40c0-9b76-7826813bdb0c
 pkg-pinsocket-2x28-d0.9-pkg,8c56d253-537e-4da2-8945-0d6aa0eed924
 pkg-pinsocket-2x28-d0.9-polygon-contour,33926d31-afee-4ad3-8769-ec37d150081b
+pkg-pinsocket-2x28-d0.9-polygon-courtyard,4233be7c-5b58-48d9-9b7e-9864bece4e99
+pkg-pinsocket-2x28-d0.9-polygon-outline,f808ec69-f327-486a-bda6-dc442c1b3f18
 pkg-pinsocket-2x28-d0.9-text-name,3446f3c5-c3c8-42a3-9623-b70641bccc80
 pkg-pinsocket-2x28-d0.9-text-value,781dfa45-174e-4205-9fec-6fc37769c521
 pkg-pinsocket-2x28-d1.0-3d,6936c58f-9061-4065-aea6-60912d84db63
@@ -21292,6 +22122,8 @@ pkg-pinsocket-2x28-d1.0-pad-8,93383c6f-63ce-409a-b939-1717a952671c
 pkg-pinsocket-2x28-d1.0-pad-9,b2db81f9-e634-4f1b-b2c5-bd56793675cb
 pkg-pinsocket-2x28-d1.0-pkg,077f15b5-210a-4325-bb55-77f503cce922
 pkg-pinsocket-2x28-d1.0-polygon-contour,1b710991-b8e6-447c-824b-b1d337043464
+pkg-pinsocket-2x28-d1.0-polygon-courtyard,42658e7a-240a-422e-9414-db45f4f7620f
+pkg-pinsocket-2x28-d1.0-polygon-outline,cf1cf162-013b-48cd-994d-bf56ff177a92
 pkg-pinsocket-2x28-d1.0-text-name,305d28f5-bed5-4e98-bed3-db8bdc7affdc
 pkg-pinsocket-2x28-d1.0-text-value,9f02999b-1f00-4628-8b1c-17698d6d6443
 pkg-pinsocket-2x28-d1.1-3d,e17a3eeb-fb74-4af7-9b44-e813ca536d0a
@@ -21354,6 +22186,8 @@ pkg-pinsocket-2x28-d1.1-pad-8,dc65c8e4-0664-493f-8aa4-fe7ff2f59df7
 pkg-pinsocket-2x28-d1.1-pad-9,466299c2-e044-4d04-8ccb-754fc36241fb
 pkg-pinsocket-2x28-d1.1-pkg,d0488e92-bbf3-4672-aea5-27e8889f2c93
 pkg-pinsocket-2x28-d1.1-polygon-contour,b727d87b-b2c5-4008-b4d4-8b1f8a7c175d
+pkg-pinsocket-2x28-d1.1-polygon-courtyard,2bb7d08d-4288-4488-bea1-ee259aef1446
+pkg-pinsocket-2x28-d1.1-polygon-outline,01759cf4-ef7b-44dc-904c-7d4023ced799
 pkg-pinsocket-2x28-d1.1-text-name,2581304e-4f49-4890-84cb-44ccda8d11bf
 pkg-pinsocket-2x28-d1.1-text-value,08fc7aab-ede4-4bb1-b2e3-b116d6c19ae2
 pkg-pinsocket-2x29-d0.9-3d,f70d6373-5706-46e5-becc-2e0584e326a5
@@ -21418,6 +22252,8 @@ pkg-pinsocket-2x29-d0.9-pad-8,eed91340-56d1-4cf7-af14-1ba73678061c
 pkg-pinsocket-2x29-d0.9-pad-9,54effb2b-316a-45ee-9f4d-1526db5f2b16
 pkg-pinsocket-2x29-d0.9-pkg,693713a2-2412-4d29-a49d-487fc47d39e5
 pkg-pinsocket-2x29-d0.9-polygon-contour,0ee67a91-b546-4643-af6b-f6abbb167fc0
+pkg-pinsocket-2x29-d0.9-polygon-courtyard,ec91b022-b41d-4cd1-b598-e06fa9855667
+pkg-pinsocket-2x29-d0.9-polygon-outline,4cafbbdd-2f91-4d47-be93-04e9461fcc7f
 pkg-pinsocket-2x29-d0.9-text-name,ce216bdb-8971-4565-8533-e8331b9a64e4
 pkg-pinsocket-2x29-d0.9-text-value,461623c8-9d8d-4e55-8c22-97edb6bc784e
 pkg-pinsocket-2x29-d1.0-3d,71bc0701-8b18-4230-889a-e3517b34c666
@@ -21482,6 +22318,8 @@ pkg-pinsocket-2x29-d1.0-pad-8,569402a3-bfea-477e-944e-468e52e695d3
 pkg-pinsocket-2x29-d1.0-pad-9,ca2446be-efa4-4108-913a-cb7e9ff74158
 pkg-pinsocket-2x29-d1.0-pkg,fba9709b-70a9-446c-ad51-a380762de9a7
 pkg-pinsocket-2x29-d1.0-polygon-contour,d36c24b6-2682-4d7b-9eca-628d9ee6786b
+pkg-pinsocket-2x29-d1.0-polygon-courtyard,69513879-5e4d-455d-a83a-cda1fd4a94a1
+pkg-pinsocket-2x29-d1.0-polygon-outline,be067de2-c22e-4667-9603-751879949bbf
 pkg-pinsocket-2x29-d1.0-text-name,821bc5da-209c-48fd-ab77-4018b6387cdf
 pkg-pinsocket-2x29-d1.0-text-value,d60c50a5-a6bc-4ee9-86c3-a87b8cd87c2c
 pkg-pinsocket-2x29-d1.1-3d,8b54d45e-41ab-4240-9564-c6699ebe4760
@@ -21546,6 +22384,8 @@ pkg-pinsocket-2x29-d1.1-pad-8,c8da8196-364a-497b-913e-9151bc38403c
 pkg-pinsocket-2x29-d1.1-pad-9,c63e54bb-e2f2-44fd-bdba-2732b4247f9f
 pkg-pinsocket-2x29-d1.1-pkg,a54c126d-0306-4da8-86a2-8ff3499b7482
 pkg-pinsocket-2x29-d1.1-polygon-contour,ab0d2a73-6bd8-4da5-9e69-444d49025676
+pkg-pinsocket-2x29-d1.1-polygon-courtyard,147b13a3-ec21-46a7-8bbc-d434d7edea59
+pkg-pinsocket-2x29-d1.1-polygon-outline,bae73492-26ff-49fc-b52b-b18de0a41f94
 pkg-pinsocket-2x29-d1.1-text-name,39ed5f46-40d3-4442-b341-19dfa37af415
 pkg-pinsocket-2x29-d1.1-text-value,2f6b4a84-387d-4b7a-a019-65d097827d60
 pkg-pinsocket-2x3-d0.9-3d,53d2d935-4654-4477-bede-0381d227b629
@@ -21558,6 +22398,8 @@ pkg-pinsocket-2x3-d0.9-pad-4,3f622907-88a9-48fb-8d8b-da6a419ce0ec
 pkg-pinsocket-2x3-d0.9-pad-5,81153a80-7cce-45cf-af1e-01210914d83f
 pkg-pinsocket-2x3-d0.9-pkg,2cb295d7-caf5-40bc-953b-48da6163ccfd
 pkg-pinsocket-2x3-d0.9-polygon-contour,b6c5468c-0a36-4067-88ae-169e152b5cd1
+pkg-pinsocket-2x3-d0.9-polygon-courtyard,54bcb99c-a691-4aea-aa03-7086c98daf2b
+pkg-pinsocket-2x3-d0.9-polygon-outline,a5b308ec-ac6f-4629-9b76-198a1aa293bd
 pkg-pinsocket-2x3-d0.9-text-name,c839c022-cd71-41b7-8f16-b5b4cca22529
 pkg-pinsocket-2x3-d0.9-text-value,640b7b8f-4080-4c6b-9491-f58d29b0b7e4
 pkg-pinsocket-2x3-d1.0-3d,f1512bfa-0cf6-4669-a047-56299797c532
@@ -21570,6 +22412,8 @@ pkg-pinsocket-2x3-d1.0-pad-4,e7de7e56-7e45-4a38-8f1d-2f0cfee75209
 pkg-pinsocket-2x3-d1.0-pad-5,49075d58-789a-4980-844e-23b09702f611
 pkg-pinsocket-2x3-d1.0-pkg,70b65a4b-7568-4220-b43e-ac6a8fb0288b
 pkg-pinsocket-2x3-d1.0-polygon-contour,d4308484-bbdc-4bbf-8239-b513f4e7c5ea
+pkg-pinsocket-2x3-d1.0-polygon-courtyard,fdfb419f-c69e-4ab6-b34b-6b79799fa477
+pkg-pinsocket-2x3-d1.0-polygon-outline,a1c70b65-9751-4b0a-ae73-8c267d32e99a
 pkg-pinsocket-2x3-d1.0-text-name,98670bc8-3529-44d7-b117-d1ae1d892dff
 pkg-pinsocket-2x3-d1.0-text-value,0d587e5e-7597-42b8-adec-eb779d4cb49f
 pkg-pinsocket-2x3-d1.1-3d,5d6295a0-cffd-42ee-9101-697e16b288f7
@@ -21582,6 +22426,8 @@ pkg-pinsocket-2x3-d1.1-pad-4,fe60f928-8c02-4af5-ba0f-d2517c194f71
 pkg-pinsocket-2x3-d1.1-pad-5,51875204-fbcc-43e5-b46c-ec59075ef396
 pkg-pinsocket-2x3-d1.1-pkg,0281ad9c-1103-410a-a09e-21f330724a02
 pkg-pinsocket-2x3-d1.1-polygon-contour,5c27b69a-3050-423e-905f-b0d603f4dd41
+pkg-pinsocket-2x3-d1.1-polygon-courtyard,be3224a0-3be9-4156-8a5e-cc3db9fad885
+pkg-pinsocket-2x3-d1.1-polygon-outline,5bf47019-6d56-4e79-a547-1c9b781bba97
 pkg-pinsocket-2x3-d1.1-text-name,d6676ace-a1c7-45de-afbc-8134369cdd34
 pkg-pinsocket-2x3-d1.1-text-value,1ce936de-8f91-4fc5-acae-9b56b8b0168a
 pkg-pinsocket-2x30-d0.9-3d,2a277740-0ab8-407d-a3bc-d3156ba6eef1
@@ -21648,6 +22494,8 @@ pkg-pinsocket-2x30-d0.9-pad-8,c8fd265f-8cbb-4ffd-a48d-b6d227becd19
 pkg-pinsocket-2x30-d0.9-pad-9,0cad4be6-edfe-4946-b806-153d4b3aa81b
 pkg-pinsocket-2x30-d0.9-pkg,891e2e84-ced2-42e3-a93b-a8a8c25db6d9
 pkg-pinsocket-2x30-d0.9-polygon-contour,d296e24c-5e8e-494a-8a56-14c842e54a68
+pkg-pinsocket-2x30-d0.9-polygon-courtyard,8452bc4b-4b78-4213-9e0a-f97c58516dad
+pkg-pinsocket-2x30-d0.9-polygon-outline,e316776a-797f-4465-a708-fcf2c38565d2
 pkg-pinsocket-2x30-d0.9-text-name,92b3db9c-33eb-4322-88e1-b8d8a217cd46
 pkg-pinsocket-2x30-d0.9-text-value,09c72faf-a680-4359-abf9-049dece93eb6
 pkg-pinsocket-2x30-d1.0-3d,b973964a-4c03-4946-b395-dfcdbef405f7
@@ -21714,6 +22562,8 @@ pkg-pinsocket-2x30-d1.0-pad-8,a132eba8-6ccb-4a75-9d88-ee7648bf4d26
 pkg-pinsocket-2x30-d1.0-pad-9,8b9de0b1-3625-4686-91f7-3410efc73e21
 pkg-pinsocket-2x30-d1.0-pkg,7a6e0c85-cae9-47bf-a191-d23adc134e75
 pkg-pinsocket-2x30-d1.0-polygon-contour,915b4e4e-574d-4f14-9589-d5533dc303c6
+pkg-pinsocket-2x30-d1.0-polygon-courtyard,1bccdb03-53f3-4d17-ba09-b7205606f935
+pkg-pinsocket-2x30-d1.0-polygon-outline,23fa49f0-65e8-43e5-bfc9-0ef7755cb3f6
 pkg-pinsocket-2x30-d1.0-text-name,e50a43e4-71da-44d6-ac10-ef3de1be5b29
 pkg-pinsocket-2x30-d1.0-text-value,773fd825-123f-49c9-b76e-c29d15dc7e7e
 pkg-pinsocket-2x30-d1.1-3d,3ecb2288-76b9-4c30-811a-d22bcc3ff31a
@@ -21780,6 +22630,8 @@ pkg-pinsocket-2x30-d1.1-pad-8,9e8982dd-d817-43cb-b93d-8a269aa99aca
 pkg-pinsocket-2x30-d1.1-pad-9,8e699f71-4ea9-4f9c-a133-eb5df757dc45
 pkg-pinsocket-2x30-d1.1-pkg,78aab8b8-c58d-41b0-86ef-8cdf339951b8
 pkg-pinsocket-2x30-d1.1-polygon-contour,4c580f50-3f2c-453a-b0a3-61beac336ae0
+pkg-pinsocket-2x30-d1.1-polygon-courtyard,918cf389-3f7b-42b1-83b2-b5fba548c6fa
+pkg-pinsocket-2x30-d1.1-polygon-outline,c9e2bed6-a3a9-448a-9c68-41d59e2ac22d
 pkg-pinsocket-2x30-d1.1-text-name,0a2e54fe-c957-4cf8-b7a8-dd3efbd58778
 pkg-pinsocket-2x30-d1.1-text-value,83cdc0ff-16ea-4ae0-9734-9b20a5a1558d
 pkg-pinsocket-2x31-d0.9-3d,8ff76a58-d265-415e-b694-1da2f344d1cf
@@ -21848,6 +22700,8 @@ pkg-pinsocket-2x31-d0.9-pad-8,ab10e36a-4327-4d6e-939c-ef96e7c4251f
 pkg-pinsocket-2x31-d0.9-pad-9,fae9ab29-2c9e-40ac-b3af-a4721d70ec16
 pkg-pinsocket-2x31-d0.9-pkg,859667b2-ebf1-43d1-8ea1-5d0da56ff260
 pkg-pinsocket-2x31-d0.9-polygon-contour,116d67a0-c804-456f-8b7d-544e92e8dd39
+pkg-pinsocket-2x31-d0.9-polygon-courtyard,d578111e-e520-4eb3-a5b5-371d4e254abd
+pkg-pinsocket-2x31-d0.9-polygon-outline,95f3d613-dc3d-46a7-ab2c-1dd581703050
 pkg-pinsocket-2x31-d0.9-text-name,e33be256-de99-4fe2-82c8-22883707a3a2
 pkg-pinsocket-2x31-d0.9-text-value,912f66a2-7ba1-44e9-bdb2-38b45a34aaea
 pkg-pinsocket-2x31-d1.0-3d,b69838ba-077a-492f-8e1b-8715f2abc749
@@ -21916,6 +22770,8 @@ pkg-pinsocket-2x31-d1.0-pad-8,a74e3c8d-a45f-4239-b494-36add78ba034
 pkg-pinsocket-2x31-d1.0-pad-9,c5b028d2-f1b7-48c7-8bad-caf8348d5588
 pkg-pinsocket-2x31-d1.0-pkg,dabe6323-d951-4db0-94c0-2cd242ef51b4
 pkg-pinsocket-2x31-d1.0-polygon-contour,ebb2fd38-53eb-41ae-94eb-803101573773
+pkg-pinsocket-2x31-d1.0-polygon-courtyard,4fd3b6b8-af58-4ce7-a7e6-d91f2ee87163
+pkg-pinsocket-2x31-d1.0-polygon-outline,0eb62a43-0ea2-4a8e-b2e7-3b4721e580b9
 pkg-pinsocket-2x31-d1.0-text-name,cef76ee2-1ab2-464d-a9bf-1375d2f35fff
 pkg-pinsocket-2x31-d1.0-text-value,395d129a-7f4c-471f-8f44-fddc1410f505
 pkg-pinsocket-2x31-d1.1-3d,1f2a91bf-05c3-450c-9052-69c38ada74db
@@ -21984,6 +22840,8 @@ pkg-pinsocket-2x31-d1.1-pad-8,49101af6-9a21-484b-bc01-293a1bf5d043
 pkg-pinsocket-2x31-d1.1-pad-9,f8acca6d-80db-473d-b895-e9d5c4fbf644
 pkg-pinsocket-2x31-d1.1-pkg,90a4b737-e19f-4b4b-bf11-89fecfd7191e
 pkg-pinsocket-2x31-d1.1-polygon-contour,058456ed-919a-459a-ab94-ef42fd4f9b10
+pkg-pinsocket-2x31-d1.1-polygon-courtyard,f1921eb2-b9d4-4281-88f3-2a843109da78
+pkg-pinsocket-2x31-d1.1-polygon-outline,4925ae8a-a7b7-434a-9f23-49a13ba2be1b
 pkg-pinsocket-2x31-d1.1-text-name,e1d21000-fe92-487c-bea2-a7ce03ec0803
 pkg-pinsocket-2x31-d1.1-text-value,4f73e028-232f-4e7f-96dd-ade928a5f7a1
 pkg-pinsocket-2x32-d0.9-3d,ab5801dc-1573-4bd5-a618-4ed61bde769b
@@ -22054,6 +22912,8 @@ pkg-pinsocket-2x32-d0.9-pad-8,785d7661-60cb-4892-a762-4e27f4ed06f8
 pkg-pinsocket-2x32-d0.9-pad-9,7af6c02b-a7e2-47de-95a0-5d45d941144e
 pkg-pinsocket-2x32-d0.9-pkg,04e81862-7b23-435e-b621-5c3a3f6012f5
 pkg-pinsocket-2x32-d0.9-polygon-contour,f563a101-dd4d-4ade-9075-65e112342735
+pkg-pinsocket-2x32-d0.9-polygon-courtyard,b9a37c8b-a6c9-402b-90f7-02e36afaa0fb
+pkg-pinsocket-2x32-d0.9-polygon-outline,c8ad1600-c5a9-4dde-a655-0489252a73b4
 pkg-pinsocket-2x32-d0.9-text-name,2607d2ed-6380-4d9d-8ec4-89a43f3b97ba
 pkg-pinsocket-2x32-d0.9-text-value,fc123c57-5221-4206-a491-98d8791b02db
 pkg-pinsocket-2x32-d1.0-3d,edc6f95f-3b86-4267-bc06-f151e8c3dbe7
@@ -22124,6 +22984,8 @@ pkg-pinsocket-2x32-d1.0-pad-8,aead1b1f-2f6c-4f04-b119-8ca99d2b8b36
 pkg-pinsocket-2x32-d1.0-pad-9,98fbb69d-5a62-420f-ba9b-d801426358e7
 pkg-pinsocket-2x32-d1.0-pkg,77e56a1c-5b16-4148-ad86-2a4a303c7a06
 pkg-pinsocket-2x32-d1.0-polygon-contour,8a0097f3-e749-4137-ad18-a73649bed094
+pkg-pinsocket-2x32-d1.0-polygon-courtyard,63d1aca8-928c-4c13-b162-1cfd5e9a3940
+pkg-pinsocket-2x32-d1.0-polygon-outline,7272572b-774e-4d61-8a1b-1b673e44f7cd
 pkg-pinsocket-2x32-d1.0-text-name,ee13683a-98e4-40e2-92b8-e390870c3e35
 pkg-pinsocket-2x32-d1.0-text-value,c32cd405-6703-4b7b-bb8b-6575ef9a7f9a
 pkg-pinsocket-2x32-d1.1-3d,02f8c5ab-4c44-4bfc-a3e0-0a916908fb96
@@ -22194,6 +23056,8 @@ pkg-pinsocket-2x32-d1.1-pad-8,ff9406a3-f408-4a14-9ed7-724fe35411b2
 pkg-pinsocket-2x32-d1.1-pad-9,4d1ea269-7422-42e9-99b4-976337a55c9a
 pkg-pinsocket-2x32-d1.1-pkg,163f9fd9-9df3-4a73-9e76-8c6e1fd25730
 pkg-pinsocket-2x32-d1.1-polygon-contour,e4775879-6019-4568-9473-ec11940c21c6
+pkg-pinsocket-2x32-d1.1-polygon-courtyard,d0fe6edc-e905-41eb-aa3d-86a5b2c2aefb
+pkg-pinsocket-2x32-d1.1-polygon-outline,b1b7d4aa-bdfd-4b51-bef9-d2b8416772bb
 pkg-pinsocket-2x32-d1.1-text-name,127591b1-cccd-4b5b-8741-6f887c016e2e
 pkg-pinsocket-2x32-d1.1-text-value,b964d1d6-c123-48f9-889e-54d44e319847
 pkg-pinsocket-2x33-d0.9-3d,2bb0bfd0-a762-4490-9fbb-6882f795008b
@@ -22266,6 +23130,8 @@ pkg-pinsocket-2x33-d0.9-pad-8,ac5a6f97-b623-435e-8015-6fd53e52d565
 pkg-pinsocket-2x33-d0.9-pad-9,a8c76bfa-193e-4f9b-beb4-474c0ba051e1
 pkg-pinsocket-2x33-d0.9-pkg,0e95edb8-0bcb-46ae-b32e-a0c5e476bd74
 pkg-pinsocket-2x33-d0.9-polygon-contour,3e351253-7222-401c-90fd-95911220a4d6
+pkg-pinsocket-2x33-d0.9-polygon-courtyard,83877107-3973-435d-b199-d2ec1a779062
+pkg-pinsocket-2x33-d0.9-polygon-outline,67f76115-2953-4c48-adab-1025b69cfc90
 pkg-pinsocket-2x33-d0.9-text-name,df65142b-5dc3-4dff-ada0-a4870f6a5c7a
 pkg-pinsocket-2x33-d0.9-text-value,c0b8cc74-a398-4be5-97e2-9823ee0d28ef
 pkg-pinsocket-2x33-d1.0-3d,7fbd87bb-48a0-48ba-a549-28a49ef1c75d
@@ -22338,6 +23204,8 @@ pkg-pinsocket-2x33-d1.0-pad-8,b2831bec-84a0-40b4-a385-57d11ed3ad5b
 pkg-pinsocket-2x33-d1.0-pad-9,a6030170-f0e9-4e8e-a4d8-a9125475e587
 pkg-pinsocket-2x33-d1.0-pkg,4f91f309-3a6a-4705-a7c2-31180445c554
 pkg-pinsocket-2x33-d1.0-polygon-contour,13132b55-c1b6-48b2-9b7c-6e297ea12861
+pkg-pinsocket-2x33-d1.0-polygon-courtyard,994980d6-d750-4981-a27d-534022890b15
+pkg-pinsocket-2x33-d1.0-polygon-outline,5386cb87-e9cd-44be-abdd-c09374570315
 pkg-pinsocket-2x33-d1.0-text-name,37c2f4a9-c477-4900-aa64-81b44614cd35
 pkg-pinsocket-2x33-d1.0-text-value,2a913e06-f034-4621-8de5-27be5b6fa790
 pkg-pinsocket-2x33-d1.1-3d,b3b824bd-6361-4f23-bfa8-a82d8134aa94
@@ -22410,6 +23278,8 @@ pkg-pinsocket-2x33-d1.1-pad-8,394102ce-488f-4961-9ec2-7e0e63c1daa7
 pkg-pinsocket-2x33-d1.1-pad-9,124e177f-2d82-4958-8128-4482834cb4a3
 pkg-pinsocket-2x33-d1.1-pkg,f4578b09-180b-4cc5-8429-8a32ba064677
 pkg-pinsocket-2x33-d1.1-polygon-contour,f22d6171-fc46-457f-97ab-ef02930562b4
+pkg-pinsocket-2x33-d1.1-polygon-courtyard,0be93e09-6974-4da1-993d-8149f415cf17
+pkg-pinsocket-2x33-d1.1-polygon-outline,2e74c78d-78d3-478c-b176-d78152c7f801
 pkg-pinsocket-2x33-d1.1-text-name,a674eb34-faac-419c-a090-ccc6c59ab954
 pkg-pinsocket-2x33-d1.1-text-value,c9f3ce71-5766-4745-b4a4-6b68982b51bd
 pkg-pinsocket-2x34-d0.9-3d,93b17940-6c55-4625-a09d-92623eac97bd
@@ -22484,6 +23354,8 @@ pkg-pinsocket-2x34-d0.9-pad-8,fdefeed1-158f-4a0f-954f-39d03ec80c6c
 pkg-pinsocket-2x34-d0.9-pad-9,d3d95129-22f5-4fa9-ae9a-8805a9912dce
 pkg-pinsocket-2x34-d0.9-pkg,d702c8a5-e4c7-4db6-9629-765879534405
 pkg-pinsocket-2x34-d0.9-polygon-contour,e1b96abd-ecd9-4d5d-91b1-8ded2ca42cfe
+pkg-pinsocket-2x34-d0.9-polygon-courtyard,d3ad791f-ba82-4350-9f09-954a88491556
+pkg-pinsocket-2x34-d0.9-polygon-outline,56577cbd-dc85-4f7f-a283-0e3d61591858
 pkg-pinsocket-2x34-d0.9-text-name,fbc22256-f02a-48f2-89af-bcf79c3130be
 pkg-pinsocket-2x34-d0.9-text-value,6545737e-cf17-4f1b-a378-09a3a6b5a450
 pkg-pinsocket-2x34-d1.0-3d,ef1c10af-3e02-43ed-a1a4-b2caed854936
@@ -22558,6 +23430,8 @@ pkg-pinsocket-2x34-d1.0-pad-8,3878bec9-36ba-4f04-87d6-b0aecafaa792
 pkg-pinsocket-2x34-d1.0-pad-9,2d4df2a8-4e1c-4f87-938c-18d669cc5a3e
 pkg-pinsocket-2x34-d1.0-pkg,5c88fd57-986e-4754-bb95-b59300a7f036
 pkg-pinsocket-2x34-d1.0-polygon-contour,b61f5cd3-f1d5-4ad0-a70b-01f637d394a1
+pkg-pinsocket-2x34-d1.0-polygon-courtyard,22474838-4739-4199-bf99-1f65000cbcb0
+pkg-pinsocket-2x34-d1.0-polygon-outline,290e7dff-03d8-44a7-bb9f-cb7069a502be
 pkg-pinsocket-2x34-d1.0-text-name,8c3bc67c-afc2-403d-ae0a-aff65bb8f9f8
 pkg-pinsocket-2x34-d1.0-text-value,ddc18c29-79a9-4527-81ab-24a442986967
 pkg-pinsocket-2x34-d1.1-3d,469ccba7-f01d-4eeb-b7db-8aef9d0b4894
@@ -22632,6 +23506,8 @@ pkg-pinsocket-2x34-d1.1-pad-8,accf231c-6b93-4d5c-b410-76e6f01f9669
 pkg-pinsocket-2x34-d1.1-pad-9,09751e1a-2076-41f8-b2eb-7a0bcc730f53
 pkg-pinsocket-2x34-d1.1-pkg,e098edcd-9fc0-4896-9f4c-f5046be25823
 pkg-pinsocket-2x34-d1.1-polygon-contour,dee0487c-2887-4de2-971c-26a8cd7f217a
+pkg-pinsocket-2x34-d1.1-polygon-courtyard,5432afd0-d4be-4690-a9d7-87ff78199cd5
+pkg-pinsocket-2x34-d1.1-polygon-outline,41492945-6c56-488d-a46a-8214148f16be
 pkg-pinsocket-2x34-d1.1-text-name,2076eb2f-9d18-43e8-9334-b536859a86d0
 pkg-pinsocket-2x34-d1.1-text-value,62a1f2ed-a2cf-4eb8-ba3f-f62d23915791
 pkg-pinsocket-2x35-d0.9-3d,8f9b73cd-34d0-4f08-a5f5-d642dcab6579
@@ -22708,6 +23584,8 @@ pkg-pinsocket-2x35-d0.9-pad-8,e7649684-07b1-4197-91db-529a11129d2a
 pkg-pinsocket-2x35-d0.9-pad-9,0e1d078d-d38f-4d5a-a832-23f921f315c4
 pkg-pinsocket-2x35-d0.9-pkg,54317007-8e45-4cef-9e8c-a4964154ca8a
 pkg-pinsocket-2x35-d0.9-polygon-contour,a794fd1e-e361-43f4-8d44-0bf07c02a9a2
+pkg-pinsocket-2x35-d0.9-polygon-courtyard,c4c87c49-7329-447e-bfe5-1c5a51d00d56
+pkg-pinsocket-2x35-d0.9-polygon-outline,d9c6f555-1797-4d19-af12-d5943624e71c
 pkg-pinsocket-2x35-d0.9-text-name,50214296-448d-4c7c-a227-62ea91b50dc9
 pkg-pinsocket-2x35-d0.9-text-value,364f138b-fe37-45f3-a908-b9462f7c96eb
 pkg-pinsocket-2x35-d1.0-3d,ff1b7882-9762-4cf9-abef-0941f82f1515
@@ -22784,6 +23662,8 @@ pkg-pinsocket-2x35-d1.0-pad-8,10f59434-32af-4abd-bb24-dc92514ff864
 pkg-pinsocket-2x35-d1.0-pad-9,05210fe9-b477-4ef4-b672-33ca107be3ef
 pkg-pinsocket-2x35-d1.0-pkg,9b1caef0-010d-4aac-84b9-b6fe28c90c1b
 pkg-pinsocket-2x35-d1.0-polygon-contour,0b6129fc-59ef-400c-b0f8-65f3d4b77eb6
+pkg-pinsocket-2x35-d1.0-polygon-courtyard,9c17d487-a1e8-4d2b-a960-4829630a38f1
+pkg-pinsocket-2x35-d1.0-polygon-outline,179abda0-7d47-44b1-ab60-2b83477adf6e
 pkg-pinsocket-2x35-d1.0-text-name,82a5f79e-d9e5-4410-812c-7915ff1f5f34
 pkg-pinsocket-2x35-d1.0-text-value,e616f053-0fd2-4935-952a-fa9b56a6f00b
 pkg-pinsocket-2x35-d1.1-3d,f6b2a117-a05e-434c-a9a0-459d4d94caff
@@ -22860,6 +23740,8 @@ pkg-pinsocket-2x35-d1.1-pad-8,82230c01-dc89-49eb-9ce4-60c58fbf6b64
 pkg-pinsocket-2x35-d1.1-pad-9,1897b269-69c9-4b68-aa9e-89fc6afdbe36
 pkg-pinsocket-2x35-d1.1-pkg,bfade79a-1129-43d3-a0a9-5346b0a0ce4f
 pkg-pinsocket-2x35-d1.1-polygon-contour,e42d6500-a58f-478b-be97-b698d9b95f15
+pkg-pinsocket-2x35-d1.1-polygon-courtyard,832b0816-4cb6-4a2f-96b2-dda036143dfc
+pkg-pinsocket-2x35-d1.1-polygon-outline,f687c241-23c1-4994-b10a-56265d72d0e3
 pkg-pinsocket-2x35-d1.1-text-name,a9155115-e11e-4e4f-8191-c9894f18628d
 pkg-pinsocket-2x35-d1.1-text-value,d5b7b523-0019-4811-b23b-d460d65fcfb2
 pkg-pinsocket-2x36-d0.9-3d,7520a6d4-e8ab-4f15-9410-9e70acfeba2f
@@ -22938,6 +23820,8 @@ pkg-pinsocket-2x36-d0.9-pad-8,1102a7a4-172d-435b-a731-6399f69594b5
 pkg-pinsocket-2x36-d0.9-pad-9,aed6012c-b643-4efd-998c-cdebf77a2db7
 pkg-pinsocket-2x36-d0.9-pkg,0cb97c08-3e08-481e-8a0a-30689395c3d4
 pkg-pinsocket-2x36-d0.9-polygon-contour,4931c85f-9bec-435c-9c2d-40df4f512173
+pkg-pinsocket-2x36-d0.9-polygon-courtyard,656c22de-72ab-447c-9974-c229f9eeedc2
+pkg-pinsocket-2x36-d0.9-polygon-outline,206348f8-ef15-41a9-89d2-6fcf5bacc408
 pkg-pinsocket-2x36-d0.9-text-name,cbe08731-7e22-4d8e-a1d8-187c49c672c5
 pkg-pinsocket-2x36-d0.9-text-value,db719774-23d0-4081-93e6-7d0f34d4b5d8
 pkg-pinsocket-2x36-d1.0-3d,8800fcfd-3253-4941-8553-286ae83bf10b
@@ -23016,6 +23900,8 @@ pkg-pinsocket-2x36-d1.0-pad-8,2b625964-6872-4385-b9e7-073c0e1a0701
 pkg-pinsocket-2x36-d1.0-pad-9,568ae418-712a-4f81-9cf8-62c190417404
 pkg-pinsocket-2x36-d1.0-pkg,5dc89583-4fc3-4a12-81bc-6ec5cf3059db
 pkg-pinsocket-2x36-d1.0-polygon-contour,5148aef8-a821-4094-9808-7f5bc8e6db73
+pkg-pinsocket-2x36-d1.0-polygon-courtyard,a9abc0db-bac7-41a7-9d93-1903190b0ab8
+pkg-pinsocket-2x36-d1.0-polygon-outline,69ac0ae1-e18d-4c54-a2e8-b282c3d0bc5b
 pkg-pinsocket-2x36-d1.0-text-name,cdc2eb40-9471-4857-9152-02db24fdf018
 pkg-pinsocket-2x36-d1.0-text-value,8c0ecc41-5476-44a3-b02a-c263816ef540
 pkg-pinsocket-2x36-d1.1-3d,fceb445a-238e-45d2-92b5-5c6f6ea31d33
@@ -23094,6 +23980,8 @@ pkg-pinsocket-2x36-d1.1-pad-8,72b316a5-cfe6-4813-97d2-2d88c6afc017
 pkg-pinsocket-2x36-d1.1-pad-9,18c69767-5497-45aa-a444-267473a2c527
 pkg-pinsocket-2x36-d1.1-pkg,768bfe53-4141-47bb-a0ad-ba4e44b53b60
 pkg-pinsocket-2x36-d1.1-polygon-contour,1a919685-621f-45c3-9454-0536244b2a8b
+pkg-pinsocket-2x36-d1.1-polygon-courtyard,91e0cc1d-adc2-4409-a729-16e0fc60d514
+pkg-pinsocket-2x36-d1.1-polygon-outline,e58281b0-8c8a-4fd6-b04a-6d0726e133c8
 pkg-pinsocket-2x36-d1.1-text-name,dbb02de6-3384-41e0-9045-ad02730c8d4f
 pkg-pinsocket-2x36-d1.1-text-value,c0e51e49-ce5f-4da6-be58-fb0bd860c9ce
 pkg-pinsocket-2x37-d0.9-3d,1951e62d-24b4-49ae-8476-2a4e82cfc465
@@ -23174,6 +24062,8 @@ pkg-pinsocket-2x37-d0.9-pad-8,72da11be-9b7a-479e-912b-8b9141768d35
 pkg-pinsocket-2x37-d0.9-pad-9,0da9e005-459b-4f86-80bc-0dd0cbada688
 pkg-pinsocket-2x37-d0.9-pkg,bc0949dd-4753-4cc7-b326-1dd2c3df7c48
 pkg-pinsocket-2x37-d0.9-polygon-contour,fb394b78-ac81-41dc-8cb5-e6a95fbb15d5
+pkg-pinsocket-2x37-d0.9-polygon-courtyard,7badd0cf-438a-4403-8c3b-afc8db0628f7
+pkg-pinsocket-2x37-d0.9-polygon-outline,e6589991-50d5-4df2-977f-f8230fbd74c1
 pkg-pinsocket-2x37-d0.9-text-name,7c9c2968-6aea-4133-8d68-af82eecb7b74
 pkg-pinsocket-2x37-d0.9-text-value,cacd23dd-c7f0-4e9b-af41-d0a3deda6ea5
 pkg-pinsocket-2x37-d1.0-3d,834d3ba7-b653-4d9e-8aca-63ca2d21bc1a
@@ -23254,6 +24144,8 @@ pkg-pinsocket-2x37-d1.0-pad-8,25e010df-e263-439c-a208-daf7513c4b6e
 pkg-pinsocket-2x37-d1.0-pad-9,f618ccfb-7cf1-4b2f-956e-2b91df56c0d5
 pkg-pinsocket-2x37-d1.0-pkg,caf2f988-7d2b-44ec-bf99-d49f4f9b8454
 pkg-pinsocket-2x37-d1.0-polygon-contour,90493702-7e96-48f8-9017-a7b862906434
+pkg-pinsocket-2x37-d1.0-polygon-courtyard,2b592744-d078-4dc7-ba3f-d8a53c1d4e58
+pkg-pinsocket-2x37-d1.0-polygon-outline,dc89aca3-24d5-4192-850b-98f6ce436d91
 pkg-pinsocket-2x37-d1.0-text-name,a3bae953-608d-4672-ad38-380c72cfa06c
 pkg-pinsocket-2x37-d1.0-text-value,b22860c1-64f0-4cf8-8405-9a9e306ebabc
 pkg-pinsocket-2x37-d1.1-3d,f605c3f9-dba9-4876-b634-5bcf3cf0c7ad
@@ -23334,6 +24226,8 @@ pkg-pinsocket-2x37-d1.1-pad-8,a0af394b-527a-4e2d-9bf3-d955787633b2
 pkg-pinsocket-2x37-d1.1-pad-9,e5728cd0-ed23-4336-a68c-93188135df0e
 pkg-pinsocket-2x37-d1.1-pkg,57234c57-54d7-4d2c-8400-e4aa9876061d
 pkg-pinsocket-2x37-d1.1-polygon-contour,4c68c345-fd94-4410-8f78-7cc654f06f59
+pkg-pinsocket-2x37-d1.1-polygon-courtyard,33519cc7-6546-470a-b071-ae61c7b36113
+pkg-pinsocket-2x37-d1.1-polygon-outline,ed605e1d-1537-4daa-9e24-ec975efb1ab6
 pkg-pinsocket-2x37-d1.1-text-name,df33c485-c120-45da-87dc-8b1e1438d8a2
 pkg-pinsocket-2x37-d1.1-text-value,cd01c0a1-7407-478b-b556-911730b345cc
 pkg-pinsocket-2x38-d0.9-3d,6f30048a-be33-457c-b62a-2054ee6d6a3f
@@ -23416,6 +24310,8 @@ pkg-pinsocket-2x38-d0.9-pad-8,2e0a5678-f6e3-4433-9945-d4e50a864e2a
 pkg-pinsocket-2x38-d0.9-pad-9,257c5706-bd27-4cc2-8f4e-ce07097628e3
 pkg-pinsocket-2x38-d0.9-pkg,b93a9bde-fd17-4634-8328-2e13070abbf6
 pkg-pinsocket-2x38-d0.9-polygon-contour,4886e98b-a457-4d41-8cce-d6278173dea3
+pkg-pinsocket-2x38-d0.9-polygon-courtyard,05fe0378-b768-41d0-83f5-6e5a557682d4
+pkg-pinsocket-2x38-d0.9-polygon-outline,54e42baf-43e1-4a83-90c2-f94f32679c94
 pkg-pinsocket-2x38-d0.9-text-name,735435d6-a7b2-49cc-b2c6-f6efd53af9a3
 pkg-pinsocket-2x38-d0.9-text-value,9f0df460-110f-44c4-8f12-6586b5de6aa8
 pkg-pinsocket-2x38-d1.0-3d,2c66060e-51de-4843-a198-c180e64ef7a0
@@ -23498,6 +24394,8 @@ pkg-pinsocket-2x38-d1.0-pad-8,ac301afa-c6b7-46ec-90bf-6787aa78b4c4
 pkg-pinsocket-2x38-d1.0-pad-9,4212f4aa-6130-4d92-a4be-8525b965ac32
 pkg-pinsocket-2x38-d1.0-pkg,b2617cbb-6863-45c8-b817-6868f67bf681
 pkg-pinsocket-2x38-d1.0-polygon-contour,3baafe18-7b8e-4935-9ad6-cc5417e76a64
+pkg-pinsocket-2x38-d1.0-polygon-courtyard,0b05feec-282f-4145-baeb-e800d72702b7
+pkg-pinsocket-2x38-d1.0-polygon-outline,63f88473-a0fa-4692-8eb8-0adb9b341acc
 pkg-pinsocket-2x38-d1.0-text-name,204a7198-4087-4028-93f5-10c3c4f7cc4c
 pkg-pinsocket-2x38-d1.0-text-value,f1db7750-74b4-4c97-8587-34d1368d1767
 pkg-pinsocket-2x38-d1.1-3d,90ae745c-6520-442d-bbe7-b97ec69287df
@@ -23580,6 +24478,8 @@ pkg-pinsocket-2x38-d1.1-pad-8,b3058591-47c5-4795-a3cb-65d1f905de47
 pkg-pinsocket-2x38-d1.1-pad-9,4dde72fe-1769-43f9-8663-41b78a4e0818
 pkg-pinsocket-2x38-d1.1-pkg,c8edc41c-8b1d-4fa2-8f10-8b53a6a53af1
 pkg-pinsocket-2x38-d1.1-polygon-contour,e442de6c-20a9-483b-8654-170271160818
+pkg-pinsocket-2x38-d1.1-polygon-courtyard,f84dfeab-c9b2-435d-a79a-ae5fcc54b591
+pkg-pinsocket-2x38-d1.1-polygon-outline,ca67f762-d19b-47a1-8a40-393c48b5c6b0
 pkg-pinsocket-2x38-d1.1-text-name,dac9c8be-9140-481e-bb32-f7802e159185
 pkg-pinsocket-2x38-d1.1-text-value,3a609873-9298-48ab-8bf4-1e62c4ce82cd
 pkg-pinsocket-2x39-d0.9-3d,694efd16-5af8-40dd-94cf-262bd6f8b296
@@ -23664,6 +24564,8 @@ pkg-pinsocket-2x39-d0.9-pad-8,3c25ef9d-76f5-47eb-a2c7-2cfbe3eb8f21
 pkg-pinsocket-2x39-d0.9-pad-9,514cefea-e949-47f4-b535-4644b4b80c66
 pkg-pinsocket-2x39-d0.9-pkg,1cf8c08a-7234-4455-b71b-70ff8cd79f5a
 pkg-pinsocket-2x39-d0.9-polygon-contour,bbada31d-82a8-4c56-9d90-478706581557
+pkg-pinsocket-2x39-d0.9-polygon-courtyard,6197f787-36ba-4fde-9330-2db63f4e4015
+pkg-pinsocket-2x39-d0.9-polygon-outline,231966f3-4cf5-4862-bdb2-31fd7b14683d
 pkg-pinsocket-2x39-d0.9-text-name,dc891558-eaf5-4803-97d0-111592347714
 pkg-pinsocket-2x39-d0.9-text-value,a4c261fe-b005-433a-ace0-3796e26f0821
 pkg-pinsocket-2x39-d1.0-3d,9974115a-f228-4501-8814-d759657a496d
@@ -23748,6 +24650,8 @@ pkg-pinsocket-2x39-d1.0-pad-8,6ec26813-ced5-478f-8ebb-d7dc324a19dd
 pkg-pinsocket-2x39-d1.0-pad-9,5a760204-697d-489a-8091-6b59c1ca3516
 pkg-pinsocket-2x39-d1.0-pkg,29c37940-d8b7-4ce8-aebe-400d1671a5b8
 pkg-pinsocket-2x39-d1.0-polygon-contour,0b4fabe3-5ca4-4737-8fae-a177a87faa46
+pkg-pinsocket-2x39-d1.0-polygon-courtyard,89ef3384-a48c-41eb-8480-bdd11b3a7b5b
+pkg-pinsocket-2x39-d1.0-polygon-outline,8b90186e-0255-491b-939a-ea58d3302ff7
 pkg-pinsocket-2x39-d1.0-text-name,11292daa-9269-49bf-a58d-e25dc51325b8
 pkg-pinsocket-2x39-d1.0-text-value,418b7c11-befc-4163-aee9-641cf53e1992
 pkg-pinsocket-2x39-d1.1-3d,63e58066-a0f5-449b-af86-a21a26db2399
@@ -23832,6 +24736,8 @@ pkg-pinsocket-2x39-d1.1-pad-8,4c6213d5-4f15-4656-8728-e131b4b7ec7a
 pkg-pinsocket-2x39-d1.1-pad-9,40db421a-675f-4c03-b6ea-0dde193cc2ed
 pkg-pinsocket-2x39-d1.1-pkg,1d706876-d0fd-478a-bdca-4fe4d12ceb0a
 pkg-pinsocket-2x39-d1.1-polygon-contour,befa33ae-f3bf-4f88-a88d-43115de93d0c
+pkg-pinsocket-2x39-d1.1-polygon-courtyard,16c7176c-bb77-4d48-8090-1d9aeb1dc961
+pkg-pinsocket-2x39-d1.1-polygon-outline,2d94645a-f32c-4eb8-b39b-471d4a3ee3a3
 pkg-pinsocket-2x39-d1.1-text-name,62bc367c-e4a6-47cf-b775-8683848fb4d0
 pkg-pinsocket-2x39-d1.1-text-value,c5e0fb16-b7ed-473e-9d0d-6a4366563fb1
 pkg-pinsocket-2x4-d0.9-3d,6087f112-b376-4504-9af2-5266923484d0
@@ -23846,6 +24752,8 @@ pkg-pinsocket-2x4-d0.9-pad-6,fe11274e-ccae-42ad-865e-b1023b6f82e0
 pkg-pinsocket-2x4-d0.9-pad-7,a4f422cf-0d87-4332-bdd1-b501eb0f84dc
 pkg-pinsocket-2x4-d0.9-pkg,ced0c3c2-c223-4abb-8127-0d4cb1c8a6e1
 pkg-pinsocket-2x4-d0.9-polygon-contour,a2f2e121-a16f-4ba2-868a-fda366c5800a
+pkg-pinsocket-2x4-d0.9-polygon-courtyard,1e77ee11-5ab1-4228-beeb-bf98acda0413
+pkg-pinsocket-2x4-d0.9-polygon-outline,f6882689-fdd6-44b3-a5a1-812acb6a4873
 pkg-pinsocket-2x4-d0.9-text-name,3ec38bd5-8a92-49ab-bb35-9519f2b78bb3
 pkg-pinsocket-2x4-d0.9-text-value,73e1242c-853e-4f7c-9a44-3776a47aa1a8
 pkg-pinsocket-2x4-d1.0-3d,febc544f-ffca-40fa-a91a-9e40818a6348
@@ -23860,6 +24768,8 @@ pkg-pinsocket-2x4-d1.0-pad-6,f8d07c9c-d06f-4b3e-8521-86e33fe9d5a3
 pkg-pinsocket-2x4-d1.0-pad-7,0e2a8d54-61a3-4204-9bf1-edf049c03ef1
 pkg-pinsocket-2x4-d1.0-pkg,951816e7-28c0-478e-b4fa-87490c1519c3
 pkg-pinsocket-2x4-d1.0-polygon-contour,2b78c6b2-d906-46c1-b93e-a8f68b43b5c4
+pkg-pinsocket-2x4-d1.0-polygon-courtyard,e0b4fa33-f800-442e-b513-7e726b18199c
+pkg-pinsocket-2x4-d1.0-polygon-outline,b8583314-1b7a-49c5-a258-5618abea441d
 pkg-pinsocket-2x4-d1.0-text-name,6a1f12e7-a3b9-47b0-bf31-b8dd211e5af2
 pkg-pinsocket-2x4-d1.0-text-value,7389559e-bc1e-4869-9915-ff063daf8be0
 pkg-pinsocket-2x4-d1.1-3d,1809176a-b2c1-4bb5-b5c5-ac369560d43d
@@ -23874,6 +24784,8 @@ pkg-pinsocket-2x4-d1.1-pad-6,a2ccd8fd-08cd-47d1-b601-60d2bd9bf062
 pkg-pinsocket-2x4-d1.1-pad-7,4b78b9e6-f79d-45da-9955-1ab0d4c54802
 pkg-pinsocket-2x4-d1.1-pkg,05dc09cb-da76-4909-b5a9-84bc242bf0b4
 pkg-pinsocket-2x4-d1.1-polygon-contour,75d82cfc-0736-43e8-a16a-e53e800bb4c4
+pkg-pinsocket-2x4-d1.1-polygon-courtyard,b1d6f5e6-4f1e-4a6f-adfd-79201392bca1
+pkg-pinsocket-2x4-d1.1-polygon-outline,37f08407-e856-430a-a6e8-e521148d9907
 pkg-pinsocket-2x4-d1.1-text-name,ff0ea781-2282-42fb-8d90-6cfd9e4e74b9
 pkg-pinsocket-2x4-d1.1-text-value,6a5b03c8-3cbc-493f-88f3-7a319ca52c1b
 pkg-pinsocket-2x40-d0.9-3d,b997edda-9294-4ad9-ae58-129a9d667c3a
@@ -23960,6 +24872,8 @@ pkg-pinsocket-2x40-d0.9-pad-8,2615d850-c4c4-447b-a97f-64f8457621f1
 pkg-pinsocket-2x40-d0.9-pad-9,742040f7-aaa2-4d15-b61e-22920b0f55db
 pkg-pinsocket-2x40-d0.9-pkg,95c61be6-6160-47a0-b92a-e16bbc31b86c
 pkg-pinsocket-2x40-d0.9-polygon-contour,762e0907-dff6-4bf6-bd0d-94a72b656f62
+pkg-pinsocket-2x40-d0.9-polygon-courtyard,5b8f0094-b099-423e-975c-58c32545cf04
+pkg-pinsocket-2x40-d0.9-polygon-outline,f4f273b1-aaa7-4828-b789-5a8d7740d4fb
 pkg-pinsocket-2x40-d0.9-text-name,10d2277c-46bd-4988-92ba-e913c72d5cec
 pkg-pinsocket-2x40-d0.9-text-value,d777eb29-32ba-42c1-a3ec-d6cd8a0a8883
 pkg-pinsocket-2x40-d1.0-3d,523bd6e7-d566-4f4c-91da-bcda21685f19
@@ -24046,6 +24960,8 @@ pkg-pinsocket-2x40-d1.0-pad-8,da709cdd-a702-4265-b627-a3edafcbb42c
 pkg-pinsocket-2x40-d1.0-pad-9,1fbfc93c-59d4-45a3-9f37-4e0b3f7370a1
 pkg-pinsocket-2x40-d1.0-pkg,ffc780e1-67ef-4d98-9e42-2b515c8826c4
 pkg-pinsocket-2x40-d1.0-polygon-contour,e86a53e5-b0d1-400d-9051-c7caa9957b51
+pkg-pinsocket-2x40-d1.0-polygon-courtyard,fffe8007-7a77-44ad-8900-ac524775fdb1
+pkg-pinsocket-2x40-d1.0-polygon-outline,2816d6fb-4e72-4b98-ba55-470bfbeabb75
 pkg-pinsocket-2x40-d1.0-text-name,c1047a3b-6827-4370-9e58-11b35ff33195
 pkg-pinsocket-2x40-d1.0-text-value,80a717c4-6406-40a2-9980-79505b492c0f
 pkg-pinsocket-2x40-d1.1-3d,91803228-c0c2-4da9-b551-f6d8dc4a4edb
@@ -24132,6 +25048,8 @@ pkg-pinsocket-2x40-d1.1-pad-8,8935ade6-d714-418e-86b4-5fcb01933e65
 pkg-pinsocket-2x40-d1.1-pad-9,7fb8e331-6f9d-46cf-af32-4e728ab1b9b6
 pkg-pinsocket-2x40-d1.1-pkg,b7c3f6b4-3cfb-4673-810c-5cb865bc254d
 pkg-pinsocket-2x40-d1.1-polygon-contour,7fe05110-03e3-495d-bead-5800019986c4
+pkg-pinsocket-2x40-d1.1-polygon-courtyard,65524f04-f95c-444a-95b2-efde3595a79c
+pkg-pinsocket-2x40-d1.1-polygon-outline,672bc528-ba58-4954-8f36-f7a21cfc6f69
 pkg-pinsocket-2x40-d1.1-text-name,89804ca5-9145-4860-bdd0-a9a1d6c975a9
 pkg-pinsocket-2x40-d1.1-text-value,2103d3be-0e98-4cf4-81a7-9d4d569bc6b9
 pkg-pinsocket-2x5-d0.9-3d,657d7c82-a57a-4d3b-aa54-1e7499acdedf
@@ -24148,6 +25066,8 @@ pkg-pinsocket-2x5-d0.9-pad-8,fd793ba5-349b-432d-a4a7-d58236980dd1
 pkg-pinsocket-2x5-d0.9-pad-9,b7ed86bd-bddb-4253-855c-62e24c01b7f0
 pkg-pinsocket-2x5-d0.9-pkg,32bce4fa-5658-44f8-b7bb-e58976f743ea
 pkg-pinsocket-2x5-d0.9-polygon-contour,9591e596-9535-4da3-b4c2-12da1a7b23cd
+pkg-pinsocket-2x5-d0.9-polygon-courtyard,270be21b-f45b-42fc-a56b-85d93ffc8fa7
+pkg-pinsocket-2x5-d0.9-polygon-outline,298bc6b0-cb96-41ff-8d29-ada02dfefcec
 pkg-pinsocket-2x5-d0.9-text-name,8e3b2224-c042-4f5e-98e9-b6b9333bdddf
 pkg-pinsocket-2x5-d0.9-text-value,2a3c7550-328e-4d3e-a19c-290381afc061
 pkg-pinsocket-2x5-d1.0-3d,30bc0613-8f99-4db7-9f7a-5e01783e3406
@@ -24164,6 +25084,8 @@ pkg-pinsocket-2x5-d1.0-pad-8,8b0b8a91-3ae1-457e-b654-49926dca5dc3
 pkg-pinsocket-2x5-d1.0-pad-9,2d49e125-adee-4f71-b8f3-0ed111c13a00
 pkg-pinsocket-2x5-d1.0-pkg,7dd62edf-ef12-4100-9153-82249739799e
 pkg-pinsocket-2x5-d1.0-polygon-contour,e95d6af0-dd51-415d-9bf8-6789722fd1b0
+pkg-pinsocket-2x5-d1.0-polygon-courtyard,f1e54ced-6146-4d15-ab52-0fec5d3b02dd
+pkg-pinsocket-2x5-d1.0-polygon-outline,d9be75bc-72a2-4df2-9cc5-cc7ac6992772
 pkg-pinsocket-2x5-d1.0-text-name,721c76ff-e5b0-4489-b2bf-34fdf2dbcdf4
 pkg-pinsocket-2x5-d1.0-text-value,47e9616e-b7e7-4287-afcb-bdd7d0e495fd
 pkg-pinsocket-2x5-d1.1-3d,6006b683-2925-42db-9517-9ae6a62da14d
@@ -24180,6 +25102,8 @@ pkg-pinsocket-2x5-d1.1-pad-8,325ca169-85e2-41a5-bcad-07f593ddb67f
 pkg-pinsocket-2x5-d1.1-pad-9,747e645f-e1e5-4d86-bbde-8e190d5fa91c
 pkg-pinsocket-2x5-d1.1-pkg,fc194b4b-18e2-4d5c-9f35-deab608dfcd8
 pkg-pinsocket-2x5-d1.1-polygon-contour,6e40ce5e-dfe2-4360-a05b-9f6c308caa9c
+pkg-pinsocket-2x5-d1.1-polygon-courtyard,5f97fe90-8406-43eb-89ff-2299aebebe91
+pkg-pinsocket-2x5-d1.1-polygon-outline,20009c8e-1d8c-4175-ac79-a80f129cf36f
 pkg-pinsocket-2x5-d1.1-text-name,356de3ba-2d19-4383-9d6a-1d3920c8b91b
 pkg-pinsocket-2x5-d1.1-text-value,3c1e9c94-b68d-4176-9dc0-b5d2254f4eaa
 pkg-pinsocket-2x6-d0.9-3d,7a2d2e45-15b9-4f72-9261-e98e77b5c44b
@@ -24198,6 +25122,8 @@ pkg-pinsocket-2x6-d0.9-pad-8,10c0186c-dd94-4b00-ae5a-82f51f715e46
 pkg-pinsocket-2x6-d0.9-pad-9,56eb4c98-d489-4fc2-81c4-b0910689d042
 pkg-pinsocket-2x6-d0.9-pkg,77fd326a-7fea-4614-bf7d-cce9e980b5bd
 pkg-pinsocket-2x6-d0.9-polygon-contour,cec8740c-3ae1-446e-ae27-096330a71f2f
+pkg-pinsocket-2x6-d0.9-polygon-courtyard,8746940c-9c2b-4443-b999-ed1adc169463
+pkg-pinsocket-2x6-d0.9-polygon-outline,27b65069-d05a-4cd0-a572-45b0281fde97
 pkg-pinsocket-2x6-d0.9-text-name,bedbb09f-46ac-4db5-92ba-9a91d93d4cad
 pkg-pinsocket-2x6-d0.9-text-value,2ca6013a-5f56-40f8-99c5-424b5edf83a9
 pkg-pinsocket-2x6-d1.0-3d,c23421a1-c85d-41c7-b656-bb1352ccfc4b
@@ -24216,6 +25142,8 @@ pkg-pinsocket-2x6-d1.0-pad-8,6231c016-4e01-44f7-8971-39a7b94cbe9e
 pkg-pinsocket-2x6-d1.0-pad-9,2311354e-778b-4a13-9791-c67e26caa000
 pkg-pinsocket-2x6-d1.0-pkg,3af8f9da-d3c1-4411-8da8-977bc369d00f
 pkg-pinsocket-2x6-d1.0-polygon-contour,47304104-5818-4b4a-916c-b43fc19b8126
+pkg-pinsocket-2x6-d1.0-polygon-courtyard,c084522c-2ebf-4b57-8979-9621adc9da6e
+pkg-pinsocket-2x6-d1.0-polygon-outline,962f33d0-d63c-4c5e-a57c-74d664c847bb
 pkg-pinsocket-2x6-d1.0-text-name,cf19b1d8-c11e-427c-93df-aa1ea2275ddc
 pkg-pinsocket-2x6-d1.0-text-value,081750bd-0028-4ff2-8695-2f4b600bc03c
 pkg-pinsocket-2x6-d1.1-3d,c2dbe66c-fa0b-4d1e-bc80-4b9066341769
@@ -24234,6 +25162,8 @@ pkg-pinsocket-2x6-d1.1-pad-8,d62b0752-36f8-4682-afb5-b0b0df48221a
 pkg-pinsocket-2x6-d1.1-pad-9,8da34993-d493-4d7b-9d64-6c5d5770f103
 pkg-pinsocket-2x6-d1.1-pkg,3220b1bd-1bc3-4797-a66f-04bafeeec68a
 pkg-pinsocket-2x6-d1.1-polygon-contour,4268e7ba-20a5-4a06-869b-3e19ad3eca46
+pkg-pinsocket-2x6-d1.1-polygon-courtyard,1d1e0bd1-bf83-42c5-94dc-6225b148cba0
+pkg-pinsocket-2x6-d1.1-polygon-outline,61217df3-d591-4adb-b8e0-3df641953e8c
 pkg-pinsocket-2x6-d1.1-text-name,1be6ff7c-97a6-4635-8548-65e5cd91d752
 pkg-pinsocket-2x6-d1.1-text-value,0c6cc4bc-d053-454b-be7b-0b0da0e04306
 pkg-pinsocket-2x7-d0.9-3d,a5855f7d-7ddc-41d4-ab15-1a1be7118aa3
@@ -24254,6 +25184,8 @@ pkg-pinsocket-2x7-d0.9-pad-8,d4fe9258-998a-4278-9ff2-0e6345b21383
 pkg-pinsocket-2x7-d0.9-pad-9,0ec5f496-10f1-4b68-bb44-d8a101b6a419
 pkg-pinsocket-2x7-d0.9-pkg,09daa98c-5d11-4f97-b4b6-18cfe17b90ae
 pkg-pinsocket-2x7-d0.9-polygon-contour,a1d5689c-b683-40f8-bd38-e4a83c2d477e
+pkg-pinsocket-2x7-d0.9-polygon-courtyard,90dd38db-c498-4a31-a87d-e63ebc924e3d
+pkg-pinsocket-2x7-d0.9-polygon-outline,a9a81f06-1292-4d94-8ab9-bec604dfd56f
 pkg-pinsocket-2x7-d0.9-text-name,1d014e92-16da-487a-96c0-c94e1acb432e
 pkg-pinsocket-2x7-d0.9-text-value,56083f54-0040-47fd-9afc-8600b6de2bc2
 pkg-pinsocket-2x7-d1.0-3d,ded65372-5e6d-476c-97f9-1917785b1142
@@ -24274,6 +25206,8 @@ pkg-pinsocket-2x7-d1.0-pad-8,e7bcf8fa-9b69-49b6-9cb9-233feefc6caa
 pkg-pinsocket-2x7-d1.0-pad-9,29226e65-1371-4a1d-ac81-fe8cd7f62e8b
 pkg-pinsocket-2x7-d1.0-pkg,220a6bbc-07dd-44e5-9318-5f713857a4a7
 pkg-pinsocket-2x7-d1.0-polygon-contour,8a58008a-5659-4b36-aa7f-c6c3bfd77e44
+pkg-pinsocket-2x7-d1.0-polygon-courtyard,dca1ffb5-4f1d-4b9f-8d56-f51e41727e2f
+pkg-pinsocket-2x7-d1.0-polygon-outline,73d1cdbc-6470-4de8-b39f-114a9818441b
 pkg-pinsocket-2x7-d1.0-text-name,8076f7b1-b9af-4bdf-b486-0333f29d2ed2
 pkg-pinsocket-2x7-d1.0-text-value,269cb714-8572-43bd-a541-64e4a8f123ad
 pkg-pinsocket-2x7-d1.1-3d,3f4805a9-d347-4bbc-9267-81caf0f76e5e
@@ -24294,6 +25228,8 @@ pkg-pinsocket-2x7-d1.1-pad-8,9f4b5b00-3078-4754-9f75-2f079fa541a6
 pkg-pinsocket-2x7-d1.1-pad-9,152a7d24-ca59-4939-b3d9-e9205ef3e1bd
 pkg-pinsocket-2x7-d1.1-pkg,9376597e-4e03-46d1-a869-e7d060fc471b
 pkg-pinsocket-2x7-d1.1-polygon-contour,6958b88b-a0d9-45ae-9ae0-48f0b41d419a
+pkg-pinsocket-2x7-d1.1-polygon-courtyard,d1ae44d6-8de0-4864-8135-5a5d94f4e1e3
+pkg-pinsocket-2x7-d1.1-polygon-outline,9ed4a31b-1700-4eb6-8271-c927586881d2
 pkg-pinsocket-2x7-d1.1-text-name,a95250af-bcae-4562-ae3a-d10f3f617e3e
 pkg-pinsocket-2x7-d1.1-text-value,fa68656d-880d-4526-bb96-be23cb08de93
 pkg-pinsocket-2x8-d0.9-3d,c2e3d283-b102-4b46-9f9f-9fcd0e4f3f61
@@ -24316,6 +25252,8 @@ pkg-pinsocket-2x8-d0.9-pad-8,7cf8675f-e543-466d-b548-15cbcf7de5aa
 pkg-pinsocket-2x8-d0.9-pad-9,303c202d-b2cb-4e7d-a31c-c20af7c72a3a
 pkg-pinsocket-2x8-d0.9-pkg,6c5a3d58-d5a3-4ee4-99f3-9f443775b5d0
 pkg-pinsocket-2x8-d0.9-polygon-contour,2982ff7f-fb89-4064-b4cd-6036b3a458e6
+pkg-pinsocket-2x8-d0.9-polygon-courtyard,9de22435-536c-425d-ae79-cca4edec1de6
+pkg-pinsocket-2x8-d0.9-polygon-outline,1f5d5b7b-f59d-4241-9d80-df8fa9958b41
 pkg-pinsocket-2x8-d0.9-text-name,1c8a6d96-af43-46e8-b0bb-2e7b21b32ab4
 pkg-pinsocket-2x8-d0.9-text-value,038de4c6-a0aa-4e4f-a079-bc22ee3d0953
 pkg-pinsocket-2x8-d1.0-3d,75ac81d5-f11e-473b-a296-e7afb1d7a0f3
@@ -24338,6 +25276,8 @@ pkg-pinsocket-2x8-d1.0-pad-8,5b263a92-cc30-4112-914a-5cc47d432419
 pkg-pinsocket-2x8-d1.0-pad-9,6e06585e-8ba5-44fb-ac24-a80842ba2ed6
 pkg-pinsocket-2x8-d1.0-pkg,6beb50da-5864-4f01-a819-c65f9aaaef9c
 pkg-pinsocket-2x8-d1.0-polygon-contour,2dc420ad-9e2c-43cf-8a98-3915219225c8
+pkg-pinsocket-2x8-d1.0-polygon-courtyard,a501bc81-5bdf-4624-8e22-65d4166f6261
+pkg-pinsocket-2x8-d1.0-polygon-outline,b5c9fc66-d64e-4e97-b846-5244df933f59
 pkg-pinsocket-2x8-d1.0-text-name,7f3ddb84-7c2d-4d44-ae09-0209c9e20027
 pkg-pinsocket-2x8-d1.0-text-value,c53c6ef9-b3a8-4b15-86f2-23f0cd45d0da
 pkg-pinsocket-2x8-d1.1-3d,987b4e54-47ec-44ef-95b9-134ec5236edc
@@ -24360,6 +25300,8 @@ pkg-pinsocket-2x8-d1.1-pad-8,e0655743-3b1b-4672-a593-97dec1a98782
 pkg-pinsocket-2x8-d1.1-pad-9,9d0e4a54-9083-4d2a-8ed2-54969a156b14
 pkg-pinsocket-2x8-d1.1-pkg,cd459585-1cb1-4e2a-9d3d-79727e664afc
 pkg-pinsocket-2x8-d1.1-polygon-contour,e6475314-b5cc-4a8b-8870-7e7a02465b1d
+pkg-pinsocket-2x8-d1.1-polygon-courtyard,29cc5aee-d3fd-484b-8e9c-b763fcfb8d85
+pkg-pinsocket-2x8-d1.1-polygon-outline,1657f92d-f20a-4ad6-ac15-9a351c1b2f7c
 pkg-pinsocket-2x8-d1.1-text-name,7e106614-5aee-4791-9b8c-a8a586f17d43
 pkg-pinsocket-2x8-d1.1-text-value,c8304adc-b7dc-49c5-8164-dfe3ebd8d92f
 pkg-pinsocket-2x9-d0.9-3d,9d6eac21-d2e8-4217-ab4b-8d9975ac06f4
@@ -24384,6 +25326,8 @@ pkg-pinsocket-2x9-d0.9-pad-8,5037facc-29de-4556-8c21-9597f923710c
 pkg-pinsocket-2x9-d0.9-pad-9,ba2496e2-120e-44f0-a502-c56220a17195
 pkg-pinsocket-2x9-d0.9-pkg,b3598ac9-711b-4b52-a2c9-9908a0baf873
 pkg-pinsocket-2x9-d0.9-polygon-contour,121bae36-9a8d-4b77-9390-045d08afddf0
+pkg-pinsocket-2x9-d0.9-polygon-courtyard,fc6d47bd-20ce-4d6e-9fb2-9e9dae71823a
+pkg-pinsocket-2x9-d0.9-polygon-outline,f80855aa-0b56-45a0-aacc-f5eb74a72551
 pkg-pinsocket-2x9-d0.9-text-name,dfef1dfb-01d8-4488-8151-34b83532c88f
 pkg-pinsocket-2x9-d0.9-text-value,c13f9a37-a31b-4e89-83c3-d8b6a9b19e97
 pkg-pinsocket-2x9-d1.0-3d,cacb56ed-3fad-4f6a-8c72-39b9a33edda3
@@ -24408,6 +25352,8 @@ pkg-pinsocket-2x9-d1.0-pad-8,a0f57acb-e170-4aae-8443-10401ca18f1d
 pkg-pinsocket-2x9-d1.0-pad-9,1b67fd50-bdfc-429b-b898-444a162cc5e9
 pkg-pinsocket-2x9-d1.0-pkg,bcd17551-abec-4df4-b875-b5a5641255b7
 pkg-pinsocket-2x9-d1.0-polygon-contour,2a0c4426-08ed-4194-b368-d20c591bc09c
+pkg-pinsocket-2x9-d1.0-polygon-courtyard,af8f5c88-02ed-4831-9410-c2bce2081821
+pkg-pinsocket-2x9-d1.0-polygon-outline,d1960c1a-5400-4a35-a233-3fe57fdc3cd9
 pkg-pinsocket-2x9-d1.0-text-name,de9bde18-7fda-4885-bc50-ff46eddf34ff
 pkg-pinsocket-2x9-d1.0-text-value,4cecc2bd-051b-48ef-8df5-32f01d6edca7
 pkg-pinsocket-2x9-d1.1-3d,a5e8c959-32b4-4f77-bdaa-8874dbe63ac8
@@ -24432,6 +25378,8 @@ pkg-pinsocket-2x9-d1.1-pad-8,915dc70a-49b0-4fff-b636-e90761e31958
 pkg-pinsocket-2x9-d1.1-pad-9,62c33149-adaf-4bed-83b7-277fb5c0ad91
 pkg-pinsocket-2x9-d1.1-pkg,795bac12-5a0f-4b5d-bedd-27024c19f534
 pkg-pinsocket-2x9-d1.1-polygon-contour,ab10c813-a554-4cb4-8326-b56799493f32
+pkg-pinsocket-2x9-d1.1-polygon-courtyard,8401929f-618b-4466-9fda-c1925297d9d9
+pkg-pinsocket-2x9-d1.1-polygon-outline,ece11074-ad4c-4358-aae6-29ab0aa55c4e
 pkg-pinsocket-2x9-d1.1-text-name,fda8c76f-d7dc-49b1-8b36-84d381208ca1
 pkg-pinsocket-2x9-d1.1-text-value,21be0b71-9ad2-4c54-9fcb-343af9afbe8e
 pkg-wireconnector-1x1-d0.9-footprint-default,1c041b59-6950-4f2f-bfd2-9fb28256fd5a
@@ -24444,6 +25392,8 @@ pkg-wireconnector-1x1-d1.0-footprint-default,c370da74-69b1-43d3-b591-d4c0c9e9c21
 pkg-wireconnector-1x1-d1.0-pad-0,b08d384f-b995-47b6-8544-8b4ef60cc4eb
 pkg-wireconnector-1x1-d1.0-pkg,37ff1272-f6d3-4bbc-abb9-52e9f5743cdc
 pkg-wireconnector-1x1-d1.0-polygon-contour,34ca1f4f-38d0-4d9f-93e3-9bc68f445b7e
+pkg-wireconnector-1x1-d1.0-polygon-courtyard,200065f7-bd40-49c0-8c0f-6dfcdd0320a3
+pkg-wireconnector-1x1-d1.0-polygon-outline,c27a6f8a-8907-4066-bd59-dcf48487ac00
 pkg-wireconnector-1x1-d1.0-text-name,bd12a622-e916-4408-b214-0a2493ef3372
 pkg-wireconnector-1x1-d1.0-text-value,48d0170d-a157-47d7-9c2b-b945a7b5fd85
 pkg-wireconnector-1x1-d1.1-footprint-default,5ac00fb0-ffb5-4765-a68e-c5c11de68165
@@ -24480,6 +25430,8 @@ pkg-wireconnector-1x10-d1.0-pad-8,5ffc7f95-9f93-44e8-a1fe-036f001045fe
 pkg-wireconnector-1x10-d1.0-pad-9,ea451c7f-07ee-443c-8b2b-e34938b26c2d
 pkg-wireconnector-1x10-d1.0-pkg,7d745daf-5058-45db-a082-98b91e654989
 pkg-wireconnector-1x10-d1.0-polygon-contour,fd57ec86-f183-4696-b818-dd8287162d44
+pkg-wireconnector-1x10-d1.0-polygon-courtyard,524bbeb1-5e25-47f6-8372-a6827762ea88
+pkg-wireconnector-1x10-d1.0-polygon-outline,8ce9facb-505a-4c4c-a315-b0df8a422f11
 pkg-wireconnector-1x10-d1.0-text-name,a7319e77-a2d1-4f3c-9b06-1118dafd5646
 pkg-wireconnector-1x10-d1.0-text-value,79ae5d68-10d5-4215-aa93-368a09ddb038
 pkg-wireconnector-1x10-d1.1-footprint-default,91b0de0e-bbbb-49ea-ab5f-ff1b71f2020d
@@ -24511,6 +25463,8 @@ pkg-wireconnector-1x11-d1.0-pad-8,88e07698-72b1-4512-b172-69a815fae703
 pkg-wireconnector-1x11-d1.0-pad-9,1136b50a-72ab-43d0-b703-264331084d18
 pkg-wireconnector-1x11-d1.0-pkg,ca6bab96-1950-4c12-9d9e-5be1b8789235
 pkg-wireconnector-1x11-d1.0-polygon-contour,cb0c368f-f44a-4207-84d6-dbd95adb37af
+pkg-wireconnector-1x11-d1.0-polygon-courtyard,d937f7ff-bb50-4f33-92f0-57f7d4f0d03b
+pkg-wireconnector-1x11-d1.0-polygon-outline,eb32e999-6488-4f7a-b8e8-7621c6f8ac72
 pkg-wireconnector-1x11-d1.0-text-name,0535a5e0-fd6b-45d9-bc91-394545a9211a
 pkg-wireconnector-1x11-d1.0-text-value,7b1b2eb6-c6c1-4145-ae2e-3ed39f0c22ac
 pkg-wireconnector-1x12-d1.0-footprint-default,bd836461-d5e2-411f-aa99-3d61ab5073fd
@@ -24528,6 +25482,8 @@ pkg-wireconnector-1x12-d1.0-pad-8,868c6b43-3d84-4786-b4a6-42de82206dd3
 pkg-wireconnector-1x12-d1.0-pad-9,5309acca-d9e5-4868-bc13-a00749941079
 pkg-wireconnector-1x12-d1.0-pkg,5b4f074d-2e91-480b-8dd9-82ac3612c8d5
 pkg-wireconnector-1x12-d1.0-polygon-contour,db0101d1-fa58-4f74-a55f-720a7727331f
+pkg-wireconnector-1x12-d1.0-polygon-courtyard,596fde83-9858-48a7-972f-d95f63485c5d
+pkg-wireconnector-1x12-d1.0-polygon-outline,fe1492de-acc9-4801-92c1-b65a5a02874d
 pkg-wireconnector-1x12-d1.0-text-name,2fdc9c3c-0ee4-4e56-995f-60b86bb3da9d
 pkg-wireconnector-1x12-d1.0-text-value,746dd282-ab27-43d4-8ef4-2438446e6ead
 pkg-wireconnector-1x13-d1.0-footprint-default,849990e2-4bea-41af-8e66-d9912cfdd4a9
@@ -24546,6 +25502,8 @@ pkg-wireconnector-1x13-d1.0-pad-8,7036bdf0-2387-47e2-9693-86b9e092d871
 pkg-wireconnector-1x13-d1.0-pad-9,10a18257-3f9a-4737-ae24-26ca40133ada
 pkg-wireconnector-1x13-d1.0-pkg,6af0efab-3799-4b15-a9a7-0bdd5525444c
 pkg-wireconnector-1x13-d1.0-polygon-contour,f43f2b10-17e3-489e-953d-c5d7a27d51e0
+pkg-wireconnector-1x13-d1.0-polygon-courtyard,bcd4942c-04f1-45fe-8da6-7307bb225d58
+pkg-wireconnector-1x13-d1.0-polygon-outline,61599554-e46e-4925-ad92-987f84534881
 pkg-wireconnector-1x13-d1.0-text-name,2c2efb6f-6fcf-42bd-bef9-4e22cfeefa27
 pkg-wireconnector-1x13-d1.0-text-value,64a1c3f4-27e8-44f5-a438-c89ba3be0348
 pkg-wireconnector-1x14-d1.0-footprint-default,db6af05e-c9c8-4aab-b083-90c729fd364f
@@ -24565,6 +25523,8 @@ pkg-wireconnector-1x14-d1.0-pad-8,ae358ec6-ffe1-4c95-a81a-24028185844b
 pkg-wireconnector-1x14-d1.0-pad-9,668d4aea-60d1-4970-8db7-964bb26c3300
 pkg-wireconnector-1x14-d1.0-pkg,43df3e93-3289-4e44-aea3-048650accdf6
 pkg-wireconnector-1x14-d1.0-polygon-contour,90662293-392d-42d5-b7c4-ea00165bea06
+pkg-wireconnector-1x14-d1.0-polygon-courtyard,30b46ab7-75a6-4dcb-bd8b-ff285109da7f
+pkg-wireconnector-1x14-d1.0-polygon-outline,c8e0fc4c-ee89-45d5-917a-08dbf0e1588e
 pkg-wireconnector-1x14-d1.0-text-name,f24479c9-e98f-4843-af7f-8cba9d69b409
 pkg-wireconnector-1x14-d1.0-text-value,71646abb-1f91-4a42-8435-0d66b2b3fc15
 pkg-wireconnector-1x15-d1.0-footprint-default,16eb086d-f37d-4d30-a92a-9c8703358d9d
@@ -24585,6 +25545,8 @@ pkg-wireconnector-1x15-d1.0-pad-8,98f65300-3cbf-4a99-9872-9d8b3470541a
 pkg-wireconnector-1x15-d1.0-pad-9,5e82a713-cf12-4688-b74b-c6f2f504bf6d
 pkg-wireconnector-1x15-d1.0-pkg,9f718c2d-8470-4da6-a967-1baab0a9dc45
 pkg-wireconnector-1x15-d1.0-polygon-contour,c064d127-24ba-4a0c-ba71-84885e0464da
+pkg-wireconnector-1x15-d1.0-polygon-courtyard,e5fb4943-4966-4324-a69d-894e3e898381
+pkg-wireconnector-1x15-d1.0-polygon-outline,0c1228f5-3489-41d4-a141-ec59197ec514
 pkg-wireconnector-1x15-d1.0-text-name,a93e1b46-f549-4e7f-85df-990f1e2d6e1a
 pkg-wireconnector-1x15-d1.0-text-value,69d4aee4-9055-4647-af81-1f520660d8a3
 pkg-wireconnector-1x16-d1.0-footprint-default,b07435c1-1e85-4f6e-89da-dfbc4713ccde
@@ -24606,6 +25568,8 @@ pkg-wireconnector-1x16-d1.0-pad-8,1bce31ef-e075-48cd-9001-d46bfde91b8a
 pkg-wireconnector-1x16-d1.0-pad-9,821389a6-23c0-4f51-8071-9e36080cba60
 pkg-wireconnector-1x16-d1.0-pkg,40c80934-5d5a-42d9-a27d-bb7460d95f15
 pkg-wireconnector-1x16-d1.0-polygon-contour,f9a65116-9f13-4460-a931-867de849004d
+pkg-wireconnector-1x16-d1.0-polygon-courtyard,bcd5421e-b044-407b-a4c6-bfbdd8ada949
+pkg-wireconnector-1x16-d1.0-polygon-outline,24334dd0-6337-4b0d-b134-fd4dcbadbfc5
 pkg-wireconnector-1x16-d1.0-text-name,85062ef9-c44a-4849-b9b4-2aa8083b85b9
 pkg-wireconnector-1x16-d1.0-text-value,42174f0d-b1f3-4a49-982d-282c1f0fc996
 pkg-wireconnector-1x17-d1.0-footprint-default,8d4f7b4f-05cc-4045-8a4a-4402fd6aeca7
@@ -24628,6 +25592,8 @@ pkg-wireconnector-1x17-d1.0-pad-8,63dfe433-393e-458a-aafe-2a50f0ce1c0c
 pkg-wireconnector-1x17-d1.0-pad-9,725f72e3-059b-44c1-b015-491e963288d9
 pkg-wireconnector-1x17-d1.0-pkg,2eff9cbd-8eea-478e-a477-14d9d496cc5b
 pkg-wireconnector-1x17-d1.0-polygon-contour,7e34314e-f03e-452b-920d-620e20bb1367
+pkg-wireconnector-1x17-d1.0-polygon-courtyard,57d5128a-78be-445a-aba7-09fb39f41f7a
+pkg-wireconnector-1x17-d1.0-polygon-outline,c440506e-c4e2-4a03-ae88-2265fa53128d
 pkg-wireconnector-1x17-d1.0-text-name,9c480b67-4283-43f7-82d6-cfccfcb39535
 pkg-wireconnector-1x17-d1.0-text-value,f50c05a5-beae-4f77-8494-44225452d862
 pkg-wireconnector-1x18-d1.0-footprint-default,eb1a5033-6b61-4907-b6bc-dff79ac0a36f
@@ -24651,6 +25617,8 @@ pkg-wireconnector-1x18-d1.0-pad-8,9f90a193-06df-486f-84f7-de17ce1bc3e2
 pkg-wireconnector-1x18-d1.0-pad-9,05fe6fc2-1714-485b-9433-673a135de1bb
 pkg-wireconnector-1x18-d1.0-pkg,814d7c23-6185-4f6c-a31a-45026d1da5ca
 pkg-wireconnector-1x18-d1.0-polygon-contour,5d2801a6-bf9e-4c71-90b2-124c40aef78c
+pkg-wireconnector-1x18-d1.0-polygon-courtyard,df03efe7-badd-4270-ac64-188806428304
+pkg-wireconnector-1x18-d1.0-polygon-outline,66d9211b-6587-4413-a82c-58283c3c324d
 pkg-wireconnector-1x18-d1.0-text-name,ce034f57-a497-4db4-862b-2cea692afc4e
 pkg-wireconnector-1x18-d1.0-text-value,41287fdb-f9bf-48c3-8631-0f7517dc3cdf
 pkg-wireconnector-1x19-d1.0-footprint-default,17b9f232-2b15-4281-a07d-ad0db5213f92
@@ -24675,6 +25643,8 @@ pkg-wireconnector-1x19-d1.0-pad-8,ee1ec686-732e-467a-bb4b-e04607245ad3
 pkg-wireconnector-1x19-d1.0-pad-9,8552607a-ff3c-4e46-be02-1b6b9d38d54b
 pkg-wireconnector-1x19-d1.0-pkg,009e35ef-1f50-4bf3-ab58-11eb85bf5503
 pkg-wireconnector-1x19-d1.0-polygon-contour,5e18e4ea-5667-42b3-b60f-fcc91b0461d3
+pkg-wireconnector-1x19-d1.0-polygon-courtyard,e98b5f25-39d1-498f-a88c-50983ededf1b
+pkg-wireconnector-1x19-d1.0-polygon-outline,33aba176-8bb2-46a2-82d5-9496be181da6
 pkg-wireconnector-1x19-d1.0-text-name,f16d1604-8a82-4688-bc58-be1c1375873f
 pkg-wireconnector-1x19-d1.0-text-value,e8deb078-4fb4-49c7-a46b-7ae020e69776
 pkg-wireconnector-1x2-d0.9-footprint-default,be6e39c3-7676-4647-8a63-551bdf7ecfcf
@@ -24689,6 +25659,8 @@ pkg-wireconnector-1x2-d1.0-pad-0,c2b81281-c12e-4d0f-b03a-23915580b92d
 pkg-wireconnector-1x2-d1.0-pad-1,b27197f0-d27f-44ac-900c-d65a11055d0f
 pkg-wireconnector-1x2-d1.0-pkg,9b9d0dae-0a4b-4e79-910a-5a295e416b36
 pkg-wireconnector-1x2-d1.0-polygon-contour,4004c087-1de9-4b9d-8cad-8854bba44923
+pkg-wireconnector-1x2-d1.0-polygon-courtyard,a399a78a-dd7f-4e86-9462-832cc65a32a2
+pkg-wireconnector-1x2-d1.0-polygon-outline,1db58869-3cf4-4f3e-a5c7-cc53ccc42928
 pkg-wireconnector-1x2-d1.0-text-name,4c2e94ba-eb1c-46bf-8cd9-448819dd5621
 pkg-wireconnector-1x2-d1.0-text-value,95002099-058d-43e0-b663-6e434f2003a4
 pkg-wireconnector-1x2-d1.1-footprint-default,f10b15ed-2234-4476-a79c-ceed50d06738
@@ -24721,6 +25693,8 @@ pkg-wireconnector-1x20-d1.0-pad-8,aef3fc71-1d0c-4b7e-a748-ee9412f2319e
 pkg-wireconnector-1x20-d1.0-pad-9,f7c682fd-1691-4731-8b7a-d20429e51618
 pkg-wireconnector-1x20-d1.0-pkg,e327b1d2-add7-4109-b727-e28b65e94758
 pkg-wireconnector-1x20-d1.0-polygon-contour,470bd4b8-48a0-4646-a33a-92bfad8df987
+pkg-wireconnector-1x20-d1.0-polygon-courtyard,9ec92d9f-e3fd-42d2-9d4a-80a0357482e2
+pkg-wireconnector-1x20-d1.0-polygon-outline,24c34a06-efc6-414a-bf27-e52b168591b9
 pkg-wireconnector-1x20-d1.0-text-name,a1bf09d6-e2e1-4332-ad7f-c6fd33bf099a
 pkg-wireconnector-1x20-d1.0-text-value,2357c9cb-512c-4803-ab8c-7b6630503b74
 pkg-wireconnector-1x21-d1.0-footprint-default,5f603991-61ab-431d-8944-5a97b2f39edb
@@ -24747,6 +25721,8 @@ pkg-wireconnector-1x21-d1.0-pad-8,6da5c120-5b3d-4396-9315-2574f9f34365
 pkg-wireconnector-1x21-d1.0-pad-9,28ca9999-ba0b-4c64-9e83-6a19b63f89ed
 pkg-wireconnector-1x21-d1.0-pkg,56e8fc3a-381b-4295-866f-9fe032526fbf
 pkg-wireconnector-1x21-d1.0-polygon-contour,57ae808d-fc3c-4e40-b4a7-fce71ab23d4b
+pkg-wireconnector-1x21-d1.0-polygon-courtyard,56ad6217-f6e7-4ba6-a6f9-7d930161f8ff
+pkg-wireconnector-1x21-d1.0-polygon-outline,144d9799-7ebd-4583-b724-70f2980775a4
 pkg-wireconnector-1x21-d1.0-text-name,6c8fb78d-07cd-42ed-bd40-ce335dbcf4eb
 pkg-wireconnector-1x21-d1.0-text-value,b58e2342-d2ad-4b08-9415-406cfcfb9213
 pkg-wireconnector-1x22-d1.0-footprint-default,1bdfcbdd-214c-4449-a5a2-d4693143f436
@@ -24774,6 +25750,8 @@ pkg-wireconnector-1x22-d1.0-pad-8,38cee5f1-3322-4ef2-9e75-63f29aa23fd2
 pkg-wireconnector-1x22-d1.0-pad-9,4e574a85-4bf6-4963-b5c1-c5ba2250a093
 pkg-wireconnector-1x22-d1.0-pkg,9ada3ff2-348e-4bff-8259-141c51fc316e
 pkg-wireconnector-1x22-d1.0-polygon-contour,69a5da4a-78b4-44d0-8b23-26828353a50f
+pkg-wireconnector-1x22-d1.0-polygon-courtyard,22951bd5-3b55-4754-8f77-cea3c4a10c58
+pkg-wireconnector-1x22-d1.0-polygon-outline,b950feba-6c91-4920-b7bc-d7f06f16cb5b
 pkg-wireconnector-1x22-d1.0-text-name,c3d252bb-a998-43cf-8f6b-67ba2a538989
 pkg-wireconnector-1x22-d1.0-text-value,2d9a62c2-2733-44f9-87c6-930f05ae11f1
 pkg-wireconnector-1x23-d1.0-footprint-default,637fee4f-6cd2-44c5-a322-7a5d849b66b1
@@ -24802,6 +25780,8 @@ pkg-wireconnector-1x23-d1.0-pad-8,12946be0-343f-43fb-bf19-e1c340d5a7e6
 pkg-wireconnector-1x23-d1.0-pad-9,7ce29a1e-4340-451d-8308-2260e3c4f6b7
 pkg-wireconnector-1x23-d1.0-pkg,cfd204b6-2ac9-4b8a-bc97-875d36302a33
 pkg-wireconnector-1x23-d1.0-polygon-contour,c9cdc33b-39d9-42f8-a0ae-719dd962979d
+pkg-wireconnector-1x23-d1.0-polygon-courtyard,cf5c4b97-e28f-40f1-bd95-809461e765c1
+pkg-wireconnector-1x23-d1.0-polygon-outline,6bdb00b1-9fbe-4968-bc62-75c22b94694c
 pkg-wireconnector-1x23-d1.0-text-name,fd3f003f-7889-4a38-9c4b-c6db5ca436fa
 pkg-wireconnector-1x23-d1.0-text-value,88a798b0-911b-4fc7-8ab6-03ef20ebef37
 pkg-wireconnector-1x24-d1.0-footprint-default,26b3a1f4-1322-4983-adb5-fd51b5d5a489
@@ -24831,6 +25811,8 @@ pkg-wireconnector-1x24-d1.0-pad-8,8a8b0758-2eb8-41b2-a078-177d2627caa7
 pkg-wireconnector-1x24-d1.0-pad-9,836c1e1d-e925-45e3-989f-bda519e3ceb5
 pkg-wireconnector-1x24-d1.0-pkg,318744a2-6e5c-4cf4-bdac-a3f9ab5a976f
 pkg-wireconnector-1x24-d1.0-polygon-contour,a65b444a-5478-4963-984e-b8daa41fec45
+pkg-wireconnector-1x24-d1.0-polygon-courtyard,9527ea78-3a0d-4e5a-9383-4a44ace43ef4
+pkg-wireconnector-1x24-d1.0-polygon-outline,b5741f50-a00f-4250-b1ed-1905b6250328
 pkg-wireconnector-1x24-d1.0-text-name,a1d618fb-9596-4811-ad62-58ce31e03ed7
 pkg-wireconnector-1x24-d1.0-text-value,afd10ae1-71d1-4349-b538-63c7f3de463f
 pkg-wireconnector-1x25-d1.0-footprint-default,093afe29-0257-451b-af74-df5b32052ddf
@@ -24861,6 +25843,8 @@ pkg-wireconnector-1x25-d1.0-pad-8,9b633427-885f-4a2f-be06-7dedc959def1
 pkg-wireconnector-1x25-d1.0-pad-9,2a0559d8-eb70-4ba7-a2db-729de9ca840e
 pkg-wireconnector-1x25-d1.0-pkg,83b4ac9b-8d3e-407d-b9a6-cfc943b5920c
 pkg-wireconnector-1x25-d1.0-polygon-contour,75de7639-aa65-4ecb-bd34-cee5757fb870
+pkg-wireconnector-1x25-d1.0-polygon-courtyard,7ada2111-4aac-4d5c-a248-65f4acd84eda
+pkg-wireconnector-1x25-d1.0-polygon-outline,0aeaabd4-e40e-4699-8521-50286746eef6
 pkg-wireconnector-1x25-d1.0-text-name,3655c8e4-bbbc-4b6d-b80f-8a6155e8fcff
 pkg-wireconnector-1x25-d1.0-text-value,0f17c0ec-a11b-48a2-9064-00eb2e7f9821
 pkg-wireconnector-1x26-d1.0-footprint-default,f254fd37-2616-4ddb-8ba8-9b5ea6111366
@@ -24892,6 +25876,8 @@ pkg-wireconnector-1x26-d1.0-pad-8,7169a8ec-237a-4883-8a39-41938249f571
 pkg-wireconnector-1x26-d1.0-pad-9,c59efc31-7d7d-44bc-a4ec-4b49f7e7b7e6
 pkg-wireconnector-1x26-d1.0-pkg,7adc6edd-5e2b-42ad-b807-5e488b57e558
 pkg-wireconnector-1x26-d1.0-polygon-contour,e8df8848-157b-4389-9b03-4368c788aae7
+pkg-wireconnector-1x26-d1.0-polygon-courtyard,c203f4d0-4f4a-423b-8c90-c4aef5293a0f
+pkg-wireconnector-1x26-d1.0-polygon-outline,750c7718-f0ef-4355-8769-aa7fba1d0874
 pkg-wireconnector-1x26-d1.0-text-name,8d281584-7a69-4064-a631-86093581f9bc
 pkg-wireconnector-1x26-d1.0-text-value,dd888e35-2090-4017-ad56-4e43e1ad86b5
 pkg-wireconnector-1x27-d1.0-footprint-default,d2aa3c57-eb47-458d-9977-b047e1b107ed
@@ -24924,6 +25910,8 @@ pkg-wireconnector-1x27-d1.0-pad-8,04376d7c-e9b5-4018-9426-1ebbea52838d
 pkg-wireconnector-1x27-d1.0-pad-9,8a55d106-7362-4e46-a011-baaf7288f28b
 pkg-wireconnector-1x27-d1.0-pkg,7a60554c-f173-4eed-b8c0-e1f88257638a
 pkg-wireconnector-1x27-d1.0-polygon-contour,d98e035c-b602-4913-b39e-9f5423b15740
+pkg-wireconnector-1x27-d1.0-polygon-courtyard,de14418f-25a1-47bc-8d8c-6ba6919c57eb
+pkg-wireconnector-1x27-d1.0-polygon-outline,aceac87d-f5b3-4920-9ca7-6cd0b6c00020
 pkg-wireconnector-1x27-d1.0-text-name,61b0a655-bbc8-496c-b229-2d0aaeb87bb8
 pkg-wireconnector-1x27-d1.0-text-value,f731fa44-9d30-4615-8505-cb32d734e0f2
 pkg-wireconnector-1x28-d1.0-footprint-default,0aac6090-b6a7-4cc4-bb18-ef7f6188bbbf
@@ -24957,6 +25945,8 @@ pkg-wireconnector-1x28-d1.0-pad-8,f2324778-9261-453f-85cc-e412e8f86e4f
 pkg-wireconnector-1x28-d1.0-pad-9,93095fc5-4030-4c56-9847-cbbb383c56b0
 pkg-wireconnector-1x28-d1.0-pkg,54ff637a-4354-427d-9526-9ce13af8377f
 pkg-wireconnector-1x28-d1.0-polygon-contour,827d8506-71cd-4e69-8320-c4912036204f
+pkg-wireconnector-1x28-d1.0-polygon-courtyard,0bf5921a-f043-48e5-a166-0bc88f4d03ba
+pkg-wireconnector-1x28-d1.0-polygon-outline,adedbac9-a3bb-4d2b-b59e-86be909117ab
 pkg-wireconnector-1x28-d1.0-text-name,2320fa2a-9763-4d9d-8810-c012819dcae2
 pkg-wireconnector-1x28-d1.0-text-value,34c744d3-06b8-43b3-a4b6-f194871f4eb9
 pkg-wireconnector-1x29-d1.0-footprint-default,417be979-f395-4d61-99fe-9113088e7c37
@@ -24991,6 +25981,8 @@ pkg-wireconnector-1x29-d1.0-pad-8,7a82bf7e-205c-49a0-a8ee-93f93afcc7d3
 pkg-wireconnector-1x29-d1.0-pad-9,d674066c-fb46-46c0-b270-87f0d4a348c0
 pkg-wireconnector-1x29-d1.0-pkg,5626f34c-64b0-4827-8ea5-0f5383652e52
 pkg-wireconnector-1x29-d1.0-polygon-contour,ff641041-8532-4b60-91cf-dece54a861c4
+pkg-wireconnector-1x29-d1.0-polygon-courtyard,277db8ab-c189-4fda-9c38-df1d478e6c94
+pkg-wireconnector-1x29-d1.0-polygon-outline,1cf3d231-00c4-47a9-8e7b-af85745f7958
 pkg-wireconnector-1x29-d1.0-text-name,a1fb1e44-5d42-4df0-ae17-941058d417e5
 pkg-wireconnector-1x29-d1.0-text-value,d3728141-a9d9-48b5-87f2-509b83b8fdad
 pkg-wireconnector-1x3-d0.9-footprint-default,d1f28ce2-fddb-4f47-85bc-d99599ec056d
@@ -25007,6 +25999,8 @@ pkg-wireconnector-1x3-d1.0-pad-1,ed99b82d-1f38-42ae-a30a-1afcc8fc2640
 pkg-wireconnector-1x3-d1.0-pad-2,b4e6301e-967b-42a5-b124-404020c4a8b6
 pkg-wireconnector-1x3-d1.0-pkg,25543ee4-e558-4784-b10b-f1e815c04259
 pkg-wireconnector-1x3-d1.0-polygon-contour,5c9aec22-be8f-4f07-8ee0-e04db0482ad7
+pkg-wireconnector-1x3-d1.0-polygon-courtyard,7fcfe4ab-1451-4d5e-adeb-358b52bdabe6
+pkg-wireconnector-1x3-d1.0-polygon-outline,b0251873-df05-4f65-9984-348b065cf230
 pkg-wireconnector-1x3-d1.0-text-name,64418ed4-5ab1-4bce-92ed-0b64c69eb08e
 pkg-wireconnector-1x3-d1.0-text-value,9ccd8b42-4376-4151-af46-ec2d149d03d2
 pkg-wireconnector-1x3-d1.1-footprint-default,00fb760e-4f8b-4b60-ae10-366491fab4c5
@@ -25050,6 +26044,8 @@ pkg-wireconnector-1x30-d1.0-pad-8,92273507-3f0e-443f-8625-c18ef765d1a4
 pkg-wireconnector-1x30-d1.0-pad-9,5bf2ba50-55b4-466f-b77e-c736d351f304
 pkg-wireconnector-1x30-d1.0-pkg,17e5a7ee-73b8-4872-83b4-c2a2cc108386
 pkg-wireconnector-1x30-d1.0-polygon-contour,ab0932df-6b0b-4d0f-8cd9-e6132bc22922
+pkg-wireconnector-1x30-d1.0-polygon-courtyard,2801bb23-205b-4c96-836f-d1118183ceca
+pkg-wireconnector-1x30-d1.0-polygon-outline,d861cd96-4dcc-425a-af54-2f2697032574
 pkg-wireconnector-1x30-d1.0-text-name,2bbc20bb-e70f-4926-be5f-8fc977aae482
 pkg-wireconnector-1x30-d1.0-text-value,5f23bb4c-9577-4dd9-8e9c-0d8b40e01d95
 pkg-wireconnector-1x31-d1.0-footprint-default,96ec36d6-c3d1-4a4b-8c2a-8c99d92b75ba
@@ -25086,6 +26082,8 @@ pkg-wireconnector-1x31-d1.0-pad-8,0b96dfdc-127c-473f-8b67-5ace533cf26e
 pkg-wireconnector-1x31-d1.0-pad-9,363b29e4-a33a-4f41-b092-966075f58c98
 pkg-wireconnector-1x31-d1.0-pkg,2c74d5dc-ab0d-4a0f-81e3-bd1162a26648
 pkg-wireconnector-1x31-d1.0-polygon-contour,28ef5e5c-7de8-465a-814f-22107845b8e8
+pkg-wireconnector-1x31-d1.0-polygon-courtyard,8cde212f-989e-4a4d-a311-1d1d89027544
+pkg-wireconnector-1x31-d1.0-polygon-outline,12b2d0ae-13c4-4c92-8094-93e2476f9f48
 pkg-wireconnector-1x31-d1.0-text-name,eb2db547-4256-4e0d-a170-c5d4b2e879f4
 pkg-wireconnector-1x31-d1.0-text-value,13abdf2f-d8b7-44a1-81a1-afc36f2228a0
 pkg-wireconnector-1x32-d1.0-footprint-default,3f1aebfe-58df-4a3e-a314-df5523d4d8d0
@@ -25123,6 +26121,8 @@ pkg-wireconnector-1x32-d1.0-pad-8,516c1969-c357-4df9-b60e-2b3a261246ed
 pkg-wireconnector-1x32-d1.0-pad-9,2d9dad25-4a67-4353-afd0-508fd8afd789
 pkg-wireconnector-1x32-d1.0-pkg,9fbc121a-5b00-4cce-8dd0-809c1a6a2e80
 pkg-wireconnector-1x32-d1.0-polygon-contour,3e7403aa-5e7c-4e5c-b6f7-3e8505925369
+pkg-wireconnector-1x32-d1.0-polygon-courtyard,0f67a2fc-09f6-4724-bad3-d6ab9e6e9273
+pkg-wireconnector-1x32-d1.0-polygon-outline,4c53149f-2e38-47a2-983f-bb559bb5f338
 pkg-wireconnector-1x32-d1.0-text-name,62daac72-86ed-4f27-9527-4c3a208203d6
 pkg-wireconnector-1x32-d1.0-text-value,c5398e99-988e-4257-82fe-65ee0032f8ef
 pkg-wireconnector-1x33-d1.0-footprint-default,96aff40c-0d98-4b68-b309-578a581a8f14
@@ -25161,6 +26161,8 @@ pkg-wireconnector-1x33-d1.0-pad-8,31998e01-fd86-4bf5-9bbd-12802efd4556
 pkg-wireconnector-1x33-d1.0-pad-9,def97115-db14-41b0-b6b1-b5d983ce8de0
 pkg-wireconnector-1x33-d1.0-pkg,37ad91e6-02f7-4770-9259-f5845a20dcfd
 pkg-wireconnector-1x33-d1.0-polygon-contour,88c39a91-7b8e-4bc7-8605-6048f38b0689
+pkg-wireconnector-1x33-d1.0-polygon-courtyard,dc1b7a4d-8758-499c-ac4f-0d8756931289
+pkg-wireconnector-1x33-d1.0-polygon-outline,a6085999-c1d1-4772-b680-e283b7ce7d9d
 pkg-wireconnector-1x33-d1.0-text-name,63c1e29f-52d8-4fe9-b03f-495f89b80955
 pkg-wireconnector-1x33-d1.0-text-value,0f4b32fc-628e-4a70-8390-6f51f0b6edfd
 pkg-wireconnector-1x34-d1.0-footprint-default,a5468473-45de-4523-9aa3-b93efc489c41
@@ -25200,6 +26202,8 @@ pkg-wireconnector-1x34-d1.0-pad-8,a778bfaa-370d-4601-9601-a618899cca3d
 pkg-wireconnector-1x34-d1.0-pad-9,34e74b89-a980-4219-8b0d-2a1eee4dba64
 pkg-wireconnector-1x34-d1.0-pkg,2e052e5c-9d49-4041-ac99-2160e3f1e071
 pkg-wireconnector-1x34-d1.0-polygon-contour,809a91fa-9a84-4817-b774-081d752763cf
+pkg-wireconnector-1x34-d1.0-polygon-courtyard,34620c43-a225-483d-bf31-d9ffd6184eaf
+pkg-wireconnector-1x34-d1.0-polygon-outline,a185eb39-722e-45e4-9726-7651f26486a1
 pkg-wireconnector-1x34-d1.0-text-name,c4d76db4-04c5-4000-bab4-3f433f95e03d
 pkg-wireconnector-1x34-d1.0-text-value,886318f2-0897-4d49-8281-822c358dcd34
 pkg-wireconnector-1x35-d1.0-footprint-default,2e7d6977-041d-47be-96ef-0455c127f9f3
@@ -25240,6 +26244,8 @@ pkg-wireconnector-1x35-d1.0-pad-8,7b882790-efb3-40e7-8db9-56eb3060c370
 pkg-wireconnector-1x35-d1.0-pad-9,a2271b0e-b7cd-4060-8536-f861063dd1f5
 pkg-wireconnector-1x35-d1.0-pkg,35f91d14-fe20-4a19-941b-35da69e90bb6
 pkg-wireconnector-1x35-d1.0-polygon-contour,6d84544b-cf32-4779-9d86-411d65911212
+pkg-wireconnector-1x35-d1.0-polygon-courtyard,072b543e-8a7c-4eb7-be12-5ad32ab4a0bc
+pkg-wireconnector-1x35-d1.0-polygon-outline,5b0bf74f-3621-4227-a96b-c05af6c6a53c
 pkg-wireconnector-1x35-d1.0-text-name,dad3d4a9-a535-4359-aa82-e7ee13ff1bfe
 pkg-wireconnector-1x35-d1.0-text-value,dd0c2f7a-1156-41c7-abfd-2c8c411d6bf7
 pkg-wireconnector-1x36-d1.0-footprint-default,f1a7fe3d-5272-42ba-b39e-99ef32285b57
@@ -25281,6 +26287,8 @@ pkg-wireconnector-1x36-d1.0-pad-8,7fb7cb1a-bb9c-4dd2-a0cc-64042310bfb8
 pkg-wireconnector-1x36-d1.0-pad-9,765207e5-8732-4cf9-be72-5c0f9ed1ff5f
 pkg-wireconnector-1x36-d1.0-pkg,c1cb5ac9-3cee-4523-8487-1c8c03674f97
 pkg-wireconnector-1x36-d1.0-polygon-contour,0203cc7b-c18a-42fe-8531-b4211aab40f7
+pkg-wireconnector-1x36-d1.0-polygon-courtyard,8491d3e1-1f19-484e-b725-7a7e69f323f1
+pkg-wireconnector-1x36-d1.0-polygon-outline,1acba44f-d73a-4b13-96ef-ca9b7c421c38
 pkg-wireconnector-1x36-d1.0-text-name,a4e3d5d2-4335-4245-9f69-1445dac168c4
 pkg-wireconnector-1x36-d1.0-text-value,a9f0f4a5-1e55-458e-b364-037846fe94f1
 pkg-wireconnector-1x37-d1.0-footprint-default,cd867d24-0022-4c23-897e-1fcc8992dadf
@@ -25323,6 +26331,8 @@ pkg-wireconnector-1x37-d1.0-pad-8,5bacc6e7-08d3-464c-97a3-588ca62bb645
 pkg-wireconnector-1x37-d1.0-pad-9,0ae4c099-b7d0-43b5-be43-2a5229324479
 pkg-wireconnector-1x37-d1.0-pkg,9e63f028-a74e-42be-9457-300d2ad0b873
 pkg-wireconnector-1x37-d1.0-polygon-contour,03587403-77c1-4b07-8420-6fdd39e3ed91
+pkg-wireconnector-1x37-d1.0-polygon-courtyard,cc7a395f-d9f2-4466-9760-63bbc5ed2907
+pkg-wireconnector-1x37-d1.0-polygon-outline,432abd51-9d57-4349-8895-e64e2c9a8914
 pkg-wireconnector-1x37-d1.0-text-name,9fe5c2ad-ad6b-44a8-b56e-d9144c7399e1
 pkg-wireconnector-1x37-d1.0-text-value,848b7611-ea17-4610-85cd-79166eb9119a
 pkg-wireconnector-1x38-d1.0-footprint-default,fe0bde72-4381-4364-9955-79a1e7579ba7
@@ -25366,6 +26376,8 @@ pkg-wireconnector-1x38-d1.0-pad-8,4f6d1777-6a2b-407d-b558-491191794bff
 pkg-wireconnector-1x38-d1.0-pad-9,373a5602-4ac5-4d67-adbd-1426fce96f12
 pkg-wireconnector-1x38-d1.0-pkg,3a14bba4-52b5-4df9-bf92-a4bfe37ce1cd
 pkg-wireconnector-1x38-d1.0-polygon-contour,31afd34d-2948-405d-991d-97ff9761aefa
+pkg-wireconnector-1x38-d1.0-polygon-courtyard,7471b82a-8ebc-4e6f-8280-de9f5b4e5623
+pkg-wireconnector-1x38-d1.0-polygon-outline,aa3cce6c-6d73-4a51-b0f3-084c33170c4b
 pkg-wireconnector-1x38-d1.0-text-name,dec18be3-ef33-4e06-9838-defaaae98350
 pkg-wireconnector-1x38-d1.0-text-value,70b2fa8a-8883-4537-a490-a481626445f4
 pkg-wireconnector-1x39-d1.0-footprint-default,befac2a9-82f5-4de2-a18e-35647e315d78
@@ -25410,6 +26422,8 @@ pkg-wireconnector-1x39-d1.0-pad-8,5daf2235-896b-4eb3-bb0d-ad3a46755292
 pkg-wireconnector-1x39-d1.0-pad-9,c140f503-54cc-45b8-bf18-92394be97780
 pkg-wireconnector-1x39-d1.0-pkg,879e4c92-ffba-4dda-a4ab-606d2b96141f
 pkg-wireconnector-1x39-d1.0-polygon-contour,7b434aa5-f969-43f5-980c-c86f89ba5f91
+pkg-wireconnector-1x39-d1.0-polygon-courtyard,ebc7d7fa-7368-4e99-8bfd-70aa423219fc
+pkg-wireconnector-1x39-d1.0-polygon-outline,34bb50d3-e913-4f78-aed9-24e3bfe98716
 pkg-wireconnector-1x39-d1.0-text-name,b0d5f66c-5c58-4476-b36a-3232233980a7
 pkg-wireconnector-1x39-d1.0-text-value,0a2ab982-e2ef-4bb7-bb5a-5f6b8a863182
 pkg-wireconnector-1x4-d0.9-footprint-default,692b890d-2e92-47bf-82fb-c542b841c5af
@@ -25428,6 +26442,8 @@ pkg-wireconnector-1x4-d1.0-pad-2,ad269a13-97f3-4f91-91d7-393ff42f63db
 pkg-wireconnector-1x4-d1.0-pad-3,63afe1f1-07aa-4fa6-ba45-90118a005ea0
 pkg-wireconnector-1x4-d1.0-pkg,c72170ab-340f-4025-9760-b8b88ade4581
 pkg-wireconnector-1x4-d1.0-polygon-contour,ce81b28b-d5e2-4b08-9f2f-1cbcfaa99f84
+pkg-wireconnector-1x4-d1.0-polygon-courtyard,ea4aa84a-a0bd-4d72-8798-4285df0e2c7c
+pkg-wireconnector-1x4-d1.0-polygon-outline,39f78c81-2bda-4f4e-853c-f4d068ba3bad
 pkg-wireconnector-1x4-d1.0-text-name,7b761f3b-e687-4fef-9548-eadc006622f7
 pkg-wireconnector-1x4-d1.0-text-value,c328269d-d28b-4428-bcd8-3379c2e1a83c
 pkg-wireconnector-1x4-d1.1-footprint-default,8bfe2852-d94a-41ee-83e6-1e3dc0c6f5d3
@@ -25482,6 +26498,8 @@ pkg-wireconnector-1x40-d1.0-pad-8,a943b7e4-36cd-44c8-a46b-02c025b1b7fd
 pkg-wireconnector-1x40-d1.0-pad-9,46256745-d0c2-4311-90b5-f2409e2f7c73
 pkg-wireconnector-1x40-d1.0-pkg,2f423388-275c-4c5e-9308-6bbf550edae1
 pkg-wireconnector-1x40-d1.0-polygon-contour,71ce6eeb-21d3-4138-baae-8b29bd06c554
+pkg-wireconnector-1x40-d1.0-polygon-courtyard,8af94eeb-5616-41b0-8c3c-707105908cfb
+pkg-wireconnector-1x40-d1.0-polygon-outline,7f83bac9-bea2-4343-b625-f07890f6055f
 pkg-wireconnector-1x40-d1.0-text-name,fd95185a-ae8b-4e7a-8619-7bad0594902f
 pkg-wireconnector-1x40-d1.0-text-value,59101e2d-c4c2-47fd-807f-a24861c915a4
 pkg-wireconnector-1x5-d0.9-footprint-default,f1ef928a-c640-4da2-a45c-eee59a9e3404
@@ -25502,6 +26520,8 @@ pkg-wireconnector-1x5-d1.0-pad-3,6a45d934-e99e-4606-b941-641a8424062a
 pkg-wireconnector-1x5-d1.0-pad-4,ed997905-cd64-45c3-b0c5-370a310d127f
 pkg-wireconnector-1x5-d1.0-pkg,7aa403ee-26d8-45cd-91ac-5521a26462af
 pkg-wireconnector-1x5-d1.0-polygon-contour,f15d2686-0352-463b-9be8-6926d6a26519
+pkg-wireconnector-1x5-d1.0-polygon-courtyard,8ef0262c-b06d-429d-878c-4e6c66ac87e0
+pkg-wireconnector-1x5-d1.0-polygon-outline,adad2628-f2d1-4ba3-ad67-d60dd5b41a52
 pkg-wireconnector-1x5-d1.0-text-name,cb17d620-3397-4ae2-b8f3-ac0fea2c1a74
 pkg-wireconnector-1x5-d1.0-text-value,7427977d-1e56-4457-8f96-f489d33e9c10
 pkg-wireconnector-1x5-d1.1-footprint-default,959f5d82-6b28-4d98-8954-55432c481e98
@@ -25534,6 +26554,8 @@ pkg-wireconnector-1x6-d1.0-pad-4,838f88d9-f689-4434-a393-ed144b654b98
 pkg-wireconnector-1x6-d1.0-pad-5,a5df0349-09d6-4b11-8b6b-ec890694eedc
 pkg-wireconnector-1x6-d1.0-pkg,ca94472d-017f-4aa8-af4a-ed874b086c68
 pkg-wireconnector-1x6-d1.0-polygon-contour,3180f26f-ef18-42ca-a264-18a5e89a4d66
+pkg-wireconnector-1x6-d1.0-polygon-courtyard,6e6ae9d1-3228-40ab-b0f6-6c6c7264fd4c
+pkg-wireconnector-1x6-d1.0-polygon-outline,28ef52f0-c40b-4a65-892d-643856184287
 pkg-wireconnector-1x6-d1.0-text-name,acdf7eda-0671-495b-9c50-f89483f6d9c7
 pkg-wireconnector-1x6-d1.0-text-value,541237be-26ad-410b-826c-2203f72c5547
 pkg-wireconnector-1x6-d1.1-footprint-default,8c047538-7659-4496-abe7-cbc2027038c1
@@ -25569,6 +26591,8 @@ pkg-wireconnector-1x7-d1.0-pad-5,e529de1f-ed47-43b6-8b8b-7efb88a1cdcf
 pkg-wireconnector-1x7-d1.0-pad-6,6b8ebd20-2e44-498f-aa9b-649879e589e6
 pkg-wireconnector-1x7-d1.0-pkg,23e75a80-ed9b-4eec-a4ab-ee05d3470500
 pkg-wireconnector-1x7-d1.0-polygon-contour,61bfaccb-11e8-478c-8e0e-b40edf562b34
+pkg-wireconnector-1x7-d1.0-polygon-courtyard,9f4c614f-1b94-4e17-ae04-2df9bb371db7
+pkg-wireconnector-1x7-d1.0-polygon-outline,108b6e23-c1a3-4e64-a447-347d61d7660c
 pkg-wireconnector-1x7-d1.0-text-name,74ae8501-a881-4914-846e-1f90b92661af
 pkg-wireconnector-1x7-d1.0-text-value,58a5b474-80b6-4e1c-a29f-265c19bce454
 pkg-wireconnector-1x7-d1.1-footprint-default,6e70d702-f67e-4eec-9b0d-b7fe4f176bc0
@@ -25607,6 +26631,8 @@ pkg-wireconnector-1x8-d1.0-pad-6,7e63cb71-1afd-496d-8ffc-9e90835fda91
 pkg-wireconnector-1x8-d1.0-pad-7,dbe4778d-429b-43d7-aa33-f0f3047b1f41
 pkg-wireconnector-1x8-d1.0-pkg,026badda-37e2-4e3e-affa-cec57a1310c0
 pkg-wireconnector-1x8-d1.0-polygon-contour,a0d0ef74-bd60-4748-93dc-28e948ca3ad0
+pkg-wireconnector-1x8-d1.0-polygon-courtyard,07368a6b-9593-4d65-894a-18b328151b9b
+pkg-wireconnector-1x8-d1.0-polygon-outline,efd4ab55-ace4-4cd1-998a-e59f6159a563
 pkg-wireconnector-1x8-d1.0-text-name,a08a01ca-3c28-4589-95b9-280f5339c50b
 pkg-wireconnector-1x8-d1.0-text-value,c21d2a81-32de-4fa3-86fd-c727cac0269f
 pkg-wireconnector-1x8-d1.1-footprint-default,c2bdd799-5e4d-4a3e-ab75-065465d30bca
@@ -25648,6 +26674,8 @@ pkg-wireconnector-1x9-d1.0-pad-7,f94866ef-6534-4463-939a-d37e48a141ed
 pkg-wireconnector-1x9-d1.0-pad-8,9c87ae0f-9722-4bff-95ad-4ca7c5ea88bd
 pkg-wireconnector-1x9-d1.0-pkg,76f91724-2d98-4173-b87f-b68c16e65fa9
 pkg-wireconnector-1x9-d1.0-polygon-contour,6ead3f3a-1ac2-4b06-b85e-eec5b8f28edb
+pkg-wireconnector-1x9-d1.0-polygon-courtyard,015622ca-4ae7-4b22-9bb5-2f6c9e3b0229
+pkg-wireconnector-1x9-d1.0-polygon-outline,55cd10e9-032b-4321-8e06-9f8987d99faa
 pkg-wireconnector-1x9-d1.0-text-name,0a3e42d1-4515-4ec4-bf21-7db9ad085c36
 pkg-wireconnector-1x9-d1.0-text-value,de6dce28-69f7-4213-ac34-7500e92eb48a
 pkg-wireconnector-1x9-d1.1-footprint-default,08aefe49-8c90-4dc9-a2ce-90798058eaa2


### PR DESCRIPTION
- Add package outline & courtyard polygons to packages
- Approve "suspicious assembly type" in soldered wire connector packages
- Approve "no default value set" message in soldered wire connector components
- Approve "no parts" message in all devices

Note: For the male pin headers the outline/courtyard polygons are not exactly following the legend:

![image](https://github.com/LibrePCB/librepcb-parts-generator/assets/5374821/752e4c23-0ecb-4e01-bf10-3df25ad22755)

However, these polygons do follow the outline of the 3D model. Also for the female sockets this inconsistency doesn't exist since their legend is simply a rectangle. Actually I think it would make more sense to simplify the legend for male headers as well, but since it's not related to this change (and not critical at all) I'd just keep it as-is for now...

Library PR: https://github.com/LibrePCB-Libraries/LibrePCB_Connectors.lplib/pull/17