### PR TITLE
Add Attribute support for Part

### DIFF
--- a/entities/attribute.py
+++ b/entities/attribute.py
@@ -27,10 +27,10 @@ class AttributeType(EnumValue):
 
 
 class Attribute():
-    def __init__(self, name: str, value: Value, attribute_type: AttributeType, unit: Optional[AttributeUnit]) -> None:
+    def __init__(self, name: str, value: Value | str, attribute_type: AttributeType, unit: Optional[AttributeUnit]) -> None:
         self.name = name
 
-        self.value = value
+        self.value = Value(value) if isinstance(value, str) else value
         self.unit = unit or UnitlessUnit.NONE
         self.attribute_type = attribute_type
 
@@ -47,7 +47,7 @@ class CapacitanceUnit(AttributeUnit):
 
 
 class CapacitanceAttribute(Attribute):
-    def __init__(self, name: str, value: Value, unit: CapacitanceUnit) -> None:
+    def __init__(self, name: str, value: Value | str, unit: CapacitanceUnit) -> None:
         super().__init__(name, value, AttributeType.CAPACITANCE, unit)
 
 
@@ -62,7 +62,7 @@ class CurrentUnit(AttributeUnit):
 
 
 class CurrentAttribute(Attribute):
-    def __init__(self, name: str, value: Value, unit: CurrentUnit) -> None:
+    def __init__(self, name: str, value: Value | str, unit: CurrentUnit) -> None:
         super().__init__(name, value, AttributeType.CURRENT, unit)
 
 
@@ -76,7 +76,7 @@ class FrequencyUnit(AttributeUnit):
 
 
 class FrequencyAttribute(Attribute):
-    def __init__(self, name: str, value: Value, unit: FrequencyUnit) -> None:
+    def __init__(self, name: str, value: Value | str, unit: FrequencyUnit) -> None:
         super().__init__(name, value, AttributeType.FREQUENCY, unit)
 
 
@@ -88,7 +88,7 @@ class InductanceUnit(AttributeUnit):
 
 
 class InductanceAttribute(Attribute):
-    def __init__(self, name: str, value: Value, unit: InductanceUnit) -> None:
+    def __init__(self, name: str, value: Value | str, unit: InductanceUnit) -> None:
         super().__init__(name, value, AttributeType.INDUCTANCE, unit)
 
 
@@ -103,7 +103,7 @@ class PowerUnit(AttributeUnit):
 
 
 class PowerAttribute(Attribute):
-    def __init__(self, name: str, value: Value, unit: PowerUnit) -> None:
+    def __init__(self, name: str, value: Value | str, unit: PowerUnit) -> None:
         super().__init__(name, value, AttributeType.POWER, unit)
 
 
@@ -116,7 +116,7 @@ class ResistanceUnit(AttributeUnit):
 
 
 class ResistanceAttribute(Attribute):
-    def __init__(self, name: str, value: Value, unit: ResistanceUnit) -> None:
+    def __init__(self, name: str, value: Value | str, unit: ResistanceUnit) -> None:
         super().__init__(name, value, AttributeType.RESISTANCE, unit)
 
 
@@ -130,10 +130,10 @@ class VoltageUnit(AttributeUnit):
 
 
 class VoltageAttribute(Attribute):
-    def __init__(self, name: str, value: Value, unit: VoltageUnit) -> None:
+    def __init__(self, name: str, value: Value | str, unit: VoltageUnit) -> None:
         super().__init__(name, value, AttributeType.VOLTAGE, unit)
 
 
 class StringAttribute(Attribute):
-    def __init__(self, name: str, value: Value) -> None:
+    def __init__(self, name: str, value: Value | str) -> None:
         super().__init__(name, value, AttributeType.STRING, None)

--- a/entities/attribute.py
+++ b/entities/attribute.py
@@ -1,17 +1,15 @@
-from enum import Enum
+from typing import Optional
 
 from entities.common import EnumValue, Value
 
 
-class Unit(Enum):
-    FARAD = 'farad'
-    AMPERE = 'ampere'
-    VOLT = 'volt'
-    HENRY = 'henry'
-    WATT = 'watt'
-    HERTZ = 'hertz'
-    OHM = 'ohm'
-    NONE = 'none'
+class AttributeUnit(EnumValue):
+    def get_name(self) -> str:
+        return 'unit'
+
+
+class UnitlessUnit(AttributeUnit):
+    NONE = "none"
 
 
 class AttributeType(EnumValue):
@@ -27,51 +25,115 @@ class AttributeType(EnumValue):
     def get_name(self) -> str:
         return 'type'
 
-    def to_unit(self) -> Unit:
-        if self == AttributeType.VOLTAGE:
-            return Unit.VOLT
-        elif self == AttributeType.CURRENT:
-            return Unit.AMPERE
-        elif self == AttributeType.FREQUENCY:
-            return Unit.HERTZ
-        elif self == AttributeType.RESISTANCE:
-            return Unit.OHM
-        elif self == AttributeType.STRING:
-            return Unit.NONE
-        elif self == AttributeType.INDUCTANCE:
-            return Unit.HENRY
-        elif self == AttributeType.POWER:
-            return Unit.WATT
-        else:
-            return Unit.NONE  # Type.STRING and fallback
-
-
-class MetricPrefix(Enum):
-    PICO = 'pico'
-    NANO = 'nano'
-    MICRO = 'micro'
-    MILLI = 'milli'
-    NONE = ''  # no prefix
-    KILO = 'kilo'
-    MEGA = 'mega'
-    GIGA = 'giga'
-
-
-class AttributeUnit():
-    def __init__(self, prefix: MetricPrefix, unit: Unit) -> None:
-        self.attribute_unit = prefix.value + unit.value
-
-    def __str__(self) -> str:
-        return '(unit {})'.format(self.attribute_unit)
-
 
 class Attribute():
-    def __init__(self, name: str, value: Value, attribute_type: AttributeType, prefix: MetricPrefix) -> None:
+    def __init__(self, name: str, value: Value, attribute_type: AttributeType, unit: Optional[AttributeUnit]) -> None:
         self.name = name
+
         self.value = value
-        self.prefix = prefix if prefix is not None else MetricPrefix.NONE
-        self.attribute_type = attribute_type if attribute_type is not None else AttributeType.STRING
-        self.unit = AttributeUnit(self.prefix, self.attribute_type.to_unit())
+        self.unit = unit or UnitlessUnit.NONE
+        self.attribute_type = attribute_type
 
     def __str__(self) -> str:
         return '(attribute "{}" {} {} {})'.format(self.name, self.attribute_type, self.unit, self.value)
+
+
+class CapacitanceUnit(AttributeUnit):
+    PICOFARAD = 'picofarad'
+    NANOFARAD = 'nanofarad'
+    MICROFARAD = 'microfarad'
+    MILLIFARAD = 'millifarad'
+    FARAD = 'farad'
+
+
+class CapacitanceAttribute(Attribute):
+    def __init__(self, name: str, value: Value, unit: CapacitanceUnit) -> None:
+        super().__init__(name, value, AttributeType.CAPACITANCE, unit)
+
+
+class CurrentUnit(AttributeUnit):
+    PICOAMPERE = 'picoampere'
+    NANOAMPERE = 'nanoampere'
+    MICROAMPERE = 'microampere'
+    MILLIAMPERE = 'milliampere'
+    AMPERE = 'ampere'
+    KILOAMPERE = 'kiloampere'
+    MEGAAMPERE = 'megaampere'
+
+
+class CurrentAttribute(Attribute):
+    def __init__(self, name: str, value: Value, unit: CurrentUnit) -> None:
+        super().__init__(name, value, AttributeType.CURRENT, unit)
+
+
+class FrequencyUnit(AttributeUnit):
+    MICROHERTZ = 'microhertz'
+    MILLIHERTZ = 'millihertz'
+    HERTZ = 'hertz'
+    KILOHERTZ = 'kilohertz'
+    MEGAHERTZ = 'megahertz'
+    GIGAHERTZ = 'gigahertz'
+
+
+class FrequencyAttribute(Attribute):
+    def __init__(self, name: str, value: Value, unit: FrequencyUnit) -> None:
+        super().__init__(name, value, AttributeType.FREQUENCY, unit)
+
+
+class InductanceUnit(AttributeUnit):
+    NANOHENRY = 'nanohenry'
+    MICROHENRY = 'microhenry'
+    MILLIHENRY = 'millihenry'
+    HENRY = 'henry'
+
+
+class InductanceAttribute(Attribute):
+    def __init__(self, name: str, value: Value, unit: InductanceUnit) -> None:
+        super().__init__(name, value, AttributeType.INDUCTANCE, unit)
+
+
+class PowerUnit(AttributeUnit):
+    NANOWATT = 'nanowatt'
+    MICROWATT = 'microwatt'
+    MILLIWATT = 'milliwatt'
+    WATT = 'watt'
+    KILOWATT = 'kilowatt'
+    MEGAWATT = 'megawatt'
+    GIGAWATT = 'gigawatt'
+
+
+class PowerAttribute(Attribute):
+    def __init__(self, name: str, value: Value, unit: PowerUnit) -> None:
+        super().__init__(name, value, AttributeType.POWER, unit)
+
+
+class ResistanceUnit(AttributeUnit):
+    MICROOHM = 'microohm'
+    MILLIOHM = 'milliohm'
+    OHM = 'ohm'
+    KILOOHM = 'kiloohm'
+    MEGAOHM = 'megaohm'
+
+
+class ResistanceAttribute(Attribute):
+    def __init__(self, name: str, value: Value, unit: ResistanceUnit) -> None:
+        super().__init__(name, value, AttributeType.RESISTANCE, unit)
+
+
+class VoltageUnit(AttributeUnit):
+    NANOVOLT = 'nanovolt'
+    MICROVOLT = 'microvolt'
+    MILLIVOLT = 'millivolt'
+    VOLT = 'volt'
+    KILOVOLT = 'kilovolt'
+    MEGAVOLT = 'megavolt'
+
+
+class VoltageAttribute(Attribute):
+    def __init__(self, name: str, value: Value, unit: VoltageUnit) -> None:
+        super().__init__(name, value, AttributeType.VOLTAGE, unit)
+
+
+class StringAttribute(Attribute):
+    def __init__(self, name: str, value: Value) -> None:
+        super().__init__(name, value, AttributeType.STRING, None)

--- a/entities/attribute.py
+++ b/entities/attribute.py
@@ -1,0 +1,76 @@
+from enum import Enum
+
+from entities.common import EnumValue, Value
+
+
+class Unit(Enum):
+    FARAD = 'farad'
+    AMPERE = 'ampere'
+    VOLT = 'volt'
+    HENRY = 'henry'
+    WATT = 'watt'
+    HERTZ = 'hertz'
+    OHM = 'ohm'
+    NONE = 'none'
+
+
+class AttributeType(EnumValue):
+    VOLTAGE = 'voltage'
+    STRING = 'string'
+    CURRENT = 'current'
+    RESISTANCE = 'resistance'
+    CAPACITANCE = 'capacitance'
+    POWER = 'power'
+    INDUCTANCE = 'inductance'
+    FREQUENCY = 'frequency'
+
+    def get_name(self) -> str:
+        return 'type'
+
+    def to_unit(self) -> Unit:
+        if self == AttributeType.VOLTAGE:
+            return Unit.VOLT
+        elif self == AttributeType.CURRENT:
+            return Unit.AMPERE
+        elif self == AttributeType.FREQUENCY:
+            return Unit.HERTZ
+        elif self == AttributeType.RESISTANCE:
+            return Unit.OHM
+        elif self == AttributeType.STRING:
+            return Unit.NONE
+        elif self == AttributeType.INDUCTANCE:
+            return Unit.HENRY
+        elif self == AttributeType.POWER:
+            return Unit.WATT
+        else:
+            return Unit.NONE  # Type.STRING and fallback
+
+
+class MetricPrefix(Enum):
+    PICO = 'pico'
+    MICRO = 'micro'
+    MILLI = 'milli'
+    NONE = ''  # no prefix
+    KILO = 'kilo'
+    MEGA = 'mega'
+    GIGA = 'giga'
+
+
+class AttributeUnit():
+    def __init__(self, prefix: MetricPrefix, unit: Unit) -> None:
+        self.attribute_unit = prefix.value + unit.value
+
+    def __str__(self) -> str:
+        return '(unit {})'.format(self.attribute_unit)
+
+
+class Attribute():
+    def __init__(self, name: str, value: Value, attribute_type: AttributeType, prefix: MetricPrefix) -> None:
+        self.name = name
+        self.value = value
+        self.prefix = prefix if prefix is not None else MetricPrefix.NONE
+        self.attribute_type = attribute_type if attribute_type is not None else AttributeType.STRING
+        self.unit = AttributeUnit(self.prefix, self.attribute_type.to_unit())
+
+    def __str__(self) -> str:
+        return '(attribute "{}" {} {} {})'.format(self.name, self.attribute_type, self.unit, self.value)

--- a/entities/attribute.py
+++ b/entities/attribute.py
@@ -48,6 +48,7 @@ class AttributeType(EnumValue):
 
 class MetricPrefix(Enum):
     PICO = 'pico'
+    NANO = 'nano'
     MICRO = 'micro'
     MILLI = 'milli'
     NONE = ''  # no prefix

--- a/entities/attribute.py
+++ b/entities/attribute.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 
 from entities.common import EnumValue, Value
 
@@ -27,7 +27,7 @@ class AttributeType(EnumValue):
 
 
 class Attribute():
-    def __init__(self, name: str, value: Value | str, attribute_type: AttributeType, unit: Optional[AttributeUnit]) -> None:
+    def __init__(self, name: str, value: Union[Value, str], attribute_type: AttributeType, unit: Optional[AttributeUnit]) -> None:
         self.name = name
 
         self.value = Value(value) if isinstance(value, str) else value
@@ -47,7 +47,7 @@ class CapacitanceUnit(AttributeUnit):
 
 
 class CapacitanceAttribute(Attribute):
-    def __init__(self, name: str, value: Value | str, unit: CapacitanceUnit) -> None:
+    def __init__(self, name: str, value: Union[Value, str], unit: CapacitanceUnit) -> None:
         super().__init__(name, value, AttributeType.CAPACITANCE, unit)
 
 
@@ -62,7 +62,7 @@ class CurrentUnit(AttributeUnit):
 
 
 class CurrentAttribute(Attribute):
-    def __init__(self, name: str, value: Value | str, unit: CurrentUnit) -> None:
+    def __init__(self, name: str, value: Union[Value, str], unit: CurrentUnit) -> None:
         super().__init__(name, value, AttributeType.CURRENT, unit)
 
 
@@ -76,7 +76,7 @@ class FrequencyUnit(AttributeUnit):
 
 
 class FrequencyAttribute(Attribute):
-    def __init__(self, name: str, value: Value | str, unit: FrequencyUnit) -> None:
+    def __init__(self, name: str, value: Union[Value, str], unit: FrequencyUnit) -> None:
         super().__init__(name, value, AttributeType.FREQUENCY, unit)
 
 
@@ -88,7 +88,7 @@ class InductanceUnit(AttributeUnit):
 
 
 class InductanceAttribute(Attribute):
-    def __init__(self, name: str, value: Value | str, unit: InductanceUnit) -> None:
+    def __init__(self, name: str, value: Union[Value, str], unit: InductanceUnit) -> None:
         super().__init__(name, value, AttributeType.INDUCTANCE, unit)
 
 
@@ -103,7 +103,7 @@ class PowerUnit(AttributeUnit):
 
 
 class PowerAttribute(Attribute):
-    def __init__(self, name: str, value: Value | str, unit: PowerUnit) -> None:
+    def __init__(self, name: str, value: Union[Value, str], unit: PowerUnit) -> None:
         super().__init__(name, value, AttributeType.POWER, unit)
 
 
@@ -116,7 +116,7 @@ class ResistanceUnit(AttributeUnit):
 
 
 class ResistanceAttribute(Attribute):
-    def __init__(self, name: str, value: Value | str, unit: ResistanceUnit) -> None:
+    def __init__(self, name: str, value: Union[Value, str], unit: ResistanceUnit) -> None:
         super().__init__(name, value, AttributeType.RESISTANCE, unit)
 
 
@@ -130,10 +130,10 @@ class VoltageUnit(AttributeUnit):
 
 
 class VoltageAttribute(Attribute):
-    def __init__(self, name: str, value: Value | str, unit: VoltageUnit) -> None:
+    def __init__(self, name: str, value: Union[Value, str], unit: VoltageUnit) -> None:
         super().__init__(name, value, AttributeType.VOLTAGE, unit)
 
 
 class StringAttribute(Attribute):
-    def __init__(self, name: str, value: Value | str) -> None:
+    def __init__(self, name: str, value: Union[Value, str]) -> None:
         super().__init__(name, value, AttributeType.STRING, None)

--- a/entities/device.py
+++ b/entities/device.py
@@ -1,6 +1,6 @@
 from os import makedirs, path
 
-from typing import Iterable, List
+from typing import Iterable, List, Optional
 
 from common import escape_string
 from entities.attribute import Attribute
@@ -37,10 +37,10 @@ class Manufacturer(StringValue):
 
 
 class Part():
-    def __init__(self, mpn: str, manufacturer: Manufacturer):
+    def __init__(self, mpn: str, manufacturer: Manufacturer, attributes: Optional[List[Attribute]] = None):
         self.mpn = mpn
         self.manufacturer = manufacturer
-        self.attributes = []  # type: List[Attribute]
+        self.attributes = attributes or []
 
     def __str__(self) -> str:
         ret = '(part "{}" {}\n'.format(escape_string(self.mpn), self.manufacturer)

--- a/entities/device.py
+++ b/entities/device.py
@@ -3,6 +3,7 @@ from os import makedirs, path
 from typing import Iterable, List
 
 from common import escape_string
+from entities.attribute import Attribute
 
 from .common import (
     Author, Category, Created, Deprecated, Description, GeneratedBy, Keywords, Name, StringValue, UUIDValue, Version
@@ -39,9 +40,16 @@ class Part():
     def __init__(self, mpn: str, manufacturer: Manufacturer):
         self.mpn = mpn
         self.manufacturer = manufacturer
+        self.attributes = []  # type: List[Attribute]
 
     def __str__(self) -> str:
-        return '(part "{}" {}\n)'.format(escape_string(self.mpn), self.manufacturer)
+        ret = '(part "{}" {}\n'.format(escape_string(self.mpn), self.manufacturer)
+        ret += indent_entities(self.attributes)
+        ret += ')'
+        return ret
+
+    def add_attribute(self, attr: Attribute) -> None:
+        self.attributes.append(attr)
 
 
 class Device():

--- a/test_attribute.py
+++ b/test_attribute.py
@@ -7,7 +7,6 @@ from entities.attribute import (
     FrequencyAttribute, FrequencyUnit, InductanceAttribute, InductanceUnit, PowerAttribute, PowerUnit,
     ResistanceAttribute, ResistanceUnit, StringAttribute, UnitlessUnit, VoltageAttribute, VoltageUnit
 )
-from entities.common import Value
 
 
 @pytest.mark.parametrize(['name', 'value', 'attribute_type', 'unit', 'output'], [
@@ -23,19 +22,19 @@ from entities.common import Value
     # add more for new types
 ])
 def test_attribute(name: str, value: str, attribute_type: AttributeType, unit: Optional[AttributeUnit], output: str) -> None:
-    attribute_s_exp = str(Attribute(name, Value(value), attribute_type, unit))
+    attribute_s_exp = str(Attribute(name, value, attribute_type, unit))
     assert attribute_s_exp == output
 
 
 @pytest.mark.parametrize(['attr', 'attribute_type'], [
-    (StringAttribute("s",       Value("a")),                        AttributeType.STRING),
-    (CurrentAttribute("c",      Value("1"), CurrentUnit.AMPERE),    AttributeType.CURRENT),
-    (CapacitanceAttribute("c",  Value("1"), CapacitanceUnit.FARAD), AttributeType.CAPACITANCE),
-    (FrequencyAttribute("f",    Value("1"), FrequencyUnit.HERTZ),   AttributeType.FREQUENCY),
-    (InductanceAttribute("i",   Value("1"), InductanceUnit.HENRY),  AttributeType.INDUCTANCE),
-    (PowerAttribute("p",        Value("1"), PowerUnit.WATT),        AttributeType.POWER),
-    (ResistanceAttribute("r",   Value("1"), ResistanceUnit.OHM),    AttributeType.RESISTANCE),
-    (VoltageAttribute("v",      Value("1"), VoltageUnit.VOLT),      AttributeType.VOLTAGE),
+    (StringAttribute("s", "a"),                             AttributeType.STRING),
+    (CurrentAttribute("c", "1",     CurrentUnit.AMPERE),    AttributeType.CURRENT),
+    (CapacitanceAttribute("c", "1", CapacitanceUnit.FARAD), AttributeType.CAPACITANCE),
+    (FrequencyAttribute("f", "1",   FrequencyUnit.HERTZ),   AttributeType.FREQUENCY),
+    (InductanceAttribute("i", "1",  InductanceUnit.HENRY),  AttributeType.INDUCTANCE),
+    (PowerAttribute("p", "1",       PowerUnit.WATT),        AttributeType.POWER),
+    (ResistanceAttribute("r", "1",  ResistanceUnit.OHM),    AttributeType.RESISTANCE),
+    (VoltageAttribute("v", "1",     VoltageUnit.VOLT),      AttributeType.VOLTAGE),
     # add more for new types
 ])
 def test_typed_attribute_has_correct_type(attr: Attribute, attribute_type: AttributeType) -> None:
@@ -43,7 +42,7 @@ def test_typed_attribute_has_correct_type(attr: Attribute, attribute_type: Attri
 
 
 @pytest.mark.parametrize('attr', [
-    StringAttribute("s", Value("a")),
+    StringAttribute("s", "a"),
     # add more for new unitless types
 ])
 def test_unitless_typed_types_have_unit_none(attr: Attribute) -> None:
@@ -52,21 +51,21 @@ def test_unitless_typed_types_have_unit_none(attr: Attribute) -> None:
 
 def test_none_unit_evaluates_to_unitless_none() -> None:
     # we pass None as unit
-    a = Attribute("n", Value("v"), AttributeType.STRING, None)
+    a = Attribute("n", "v", AttributeType.STRING, None)
     # check if it gets set to UnitlessUnit.NONE internally
     assert a.unit == UnitlessUnit.NONE
 
 
 @pytest.mark.parametrize(['typed', 'general'], [
-    (StringAttribute("s",       Value("a")),                        Attribute("s", Value("a"), AttributeType.STRING,       None)),
-    (StringAttribute("s",       Value("a")),                        Attribute("s", Value("a"), AttributeType.STRING,       UnitlessUnit.NONE)),
-    (CurrentAttribute("c",      Value("1"), CurrentUnit.AMPERE),    Attribute("c", Value("1"), AttributeType.CURRENT,      CurrentUnit.AMPERE)),
-    (CapacitanceAttribute("c",  Value("1"), CapacitanceUnit.FARAD), Attribute("c", Value("1"), AttributeType.CAPACITANCE,  CapacitanceUnit.FARAD)),
-    (FrequencyAttribute("f",    Value("1"), FrequencyUnit.HERTZ),   Attribute("f", Value("1"), AttributeType.FREQUENCY,    FrequencyUnit.HERTZ)),
-    (InductanceAttribute("i",   Value("1"), InductanceUnit.HENRY),  Attribute("i", Value("1"), AttributeType.INDUCTANCE,   InductanceUnit.HENRY)),
-    (PowerAttribute("p",        Value("1"), PowerUnit.WATT),        Attribute("p", Value("1"), AttributeType.POWER,        PowerUnit.WATT)),
-    (ResistanceAttribute("r",   Value("1"), ResistanceUnit.OHM),    Attribute("r", Value("1"), AttributeType.RESISTANCE,   ResistanceUnit.OHM)),
-    (VoltageAttribute("v",      Value("1"), VoltageUnit.VOLT),      Attribute("v", Value("1"), AttributeType.VOLTAGE,      VoltageUnit.VOLT)),
+    (StringAttribute("s",       "a"),                        Attribute("s", "a", AttributeType.STRING,       None)),
+    (StringAttribute("s",       "a"),                        Attribute("s", "a", AttributeType.STRING,       UnitlessUnit.NONE)),
+    (CurrentAttribute("c",      "1", CurrentUnit.AMPERE),    Attribute("c", "1", AttributeType.CURRENT,      CurrentUnit.AMPERE)),
+    (CapacitanceAttribute("c",  "1", CapacitanceUnit.FARAD), Attribute("c", "1", AttributeType.CAPACITANCE,  CapacitanceUnit.FARAD)),
+    (FrequencyAttribute("f",    "1", FrequencyUnit.HERTZ),   Attribute("f", "1", AttributeType.FREQUENCY,    FrequencyUnit.HERTZ)),
+    (InductanceAttribute("i",   "1", InductanceUnit.HENRY),  Attribute("i", "1", AttributeType.INDUCTANCE,   InductanceUnit.HENRY)),
+    (PowerAttribute("p",        "1", PowerUnit.WATT),        Attribute("p", "1", AttributeType.POWER,        PowerUnit.WATT)),
+    (ResistanceAttribute("r",   "1", ResistanceUnit.OHM),    Attribute("r", "1", AttributeType.RESISTANCE,   ResistanceUnit.OHM)),
+    (VoltageAttribute("v",      "1", VoltageUnit.VOLT),      Attribute("v", "1", AttributeType.VOLTAGE,      VoltageUnit.VOLT)),
     # add more for new types
 ])
 def test_typed_vs_general_attribute_equivalence(typed: Attribute, general: Attribute) -> None:

--- a/test_attribute.py
+++ b/test_attribute.py
@@ -1,0 +1,73 @@
+from typing import Optional
+
+import pytest
+
+from entities.attribute import (
+    Attribute, AttributeType, AttributeUnit, CapacitanceAttribute, CapacitanceUnit, CurrentAttribute, CurrentUnit,
+    FrequencyAttribute, FrequencyUnit, InductanceAttribute, InductanceUnit, PowerAttribute, PowerUnit,
+    ResistanceAttribute, ResistanceUnit, StringAttribute, UnitlessUnit, VoltageAttribute, VoltageUnit
+)
+from entities.common import Value
+
+
+@pytest.mark.parametrize(['name', 'value', 'attribute_type', 'unit', 'output'], [
+    ("n", "vvv", AttributeType.STRING,      None,                       '(attribute "n" (type string) (unit none) (value "vvv"))'),
+    ("n", "vvv", AttributeType.STRING,      UnitlessUnit.NONE,          '(attribute "n" (type string) (unit none) (value "vvv"))'),
+    ("n", "0.1", AttributeType.CURRENT,     CurrentUnit.MILLIAMPERE,    '(attribute "n" (type current) (unit milliampere) (value "0.1"))'),
+    ("n", "0.1", AttributeType.CAPACITANCE, CapacitanceUnit.MILLIFARAD, '(attribute "n" (type capacitance) (unit millifarad) (value "0.1"))'),
+    ("n", "0.1", AttributeType.FREQUENCY,   FrequencyUnit.KILOHERTZ,    '(attribute "n" (type frequency) (unit kilohertz) (value "0.1"))'),
+    ("n", "0.1", AttributeType.INDUCTANCE,  InductanceUnit.MICROHENRY,  '(attribute "n" (type inductance) (unit microhenry) (value "0.1"))'),
+    ("n", "0.1", AttributeType.POWER,       PowerUnit.WATT,             '(attribute "n" (type power) (unit watt) (value "0.1"))'),
+    ("n", "0.1", AttributeType.RESISTANCE,  ResistanceUnit.MEGAOHM,     '(attribute "n" (type resistance) (unit megaohm) (value "0.1"))'),
+    ("n", "0.1", AttributeType.VOLTAGE,     VoltageUnit.KILOVOLT,       '(attribute "n" (type voltage) (unit kilovolt) (value "0.1"))'),
+    # add more for new types
+])
+def test_attribute(name: str, value: str, attribute_type: AttributeType, unit: Optional[AttributeUnit], output: str) -> None:
+    attribute_s_exp = str(Attribute(name, Value(value), attribute_type, unit))
+    assert attribute_s_exp == output
+
+
+@pytest.mark.parametrize(['attr', 'attribute_type'], [
+    (StringAttribute("s",       Value("a")),                        AttributeType.STRING),
+    (CurrentAttribute("c",      Value("1"), CurrentUnit.AMPERE),    AttributeType.CURRENT),
+    (CapacitanceAttribute("c",  Value("1"), CapacitanceUnit.FARAD), AttributeType.CAPACITANCE),
+    (FrequencyAttribute("f",    Value("1"), FrequencyUnit.HERTZ),   AttributeType.FREQUENCY),
+    (InductanceAttribute("i",   Value("1"), InductanceUnit.HENRY),  AttributeType.INDUCTANCE),
+    (PowerAttribute("p",        Value("1"), PowerUnit.WATT),        AttributeType.POWER),
+    (ResistanceAttribute("r",   Value("1"), ResistanceUnit.OHM),    AttributeType.RESISTANCE),
+    (VoltageAttribute("v",      Value("1"), VoltageUnit.VOLT),      AttributeType.VOLTAGE),
+    # add more for new types
+])
+def test_typed_attribute_has_correct_type(attr: Attribute, attribute_type: AttributeType) -> None:
+    assert attr.attribute_type == attribute_type
+
+
+@pytest.mark.parametrize('attr', [
+    StringAttribute("s", Value("a")),
+    # add more for new unitless types
+])
+def test_unitless_typed_types_have_unit_none(attr: Attribute) -> None:
+    assert attr.unit == UnitlessUnit.NONE
+
+
+def test_none_unit_evaluates_to_unitless_none() -> None:
+    # we pass None as unit
+    a = Attribute("n", Value("v"), AttributeType.STRING, None)
+    # check if it gets set to UnitlessUnit.NONE internally
+    assert a.unit == UnitlessUnit.NONE
+
+
+@pytest.mark.parametrize(['typed', 'general'], [
+    (StringAttribute("s",       Value("a")),                        Attribute("s", Value("a"), AttributeType.STRING,       None)),
+    (StringAttribute("s",       Value("a")),                        Attribute("s", Value("a"), AttributeType.STRING,       UnitlessUnit.NONE)),
+    (CurrentAttribute("c",      Value("1"), CurrentUnit.AMPERE),    Attribute("c", Value("1"), AttributeType.CURRENT,      CurrentUnit.AMPERE)),
+    (CapacitanceAttribute("c",  Value("1"), CapacitanceUnit.FARAD), Attribute("c", Value("1"), AttributeType.CAPACITANCE,  CapacitanceUnit.FARAD)),
+    (FrequencyAttribute("f",    Value("1"), FrequencyUnit.HERTZ),   Attribute("f", Value("1"), AttributeType.FREQUENCY,    FrequencyUnit.HERTZ)),
+    (InductanceAttribute("i",   Value("1"), InductanceUnit.HENRY),  Attribute("i", Value("1"), AttributeType.INDUCTANCE,   InductanceUnit.HENRY)),
+    (PowerAttribute("p",        Value("1"), PowerUnit.WATT),        Attribute("p", Value("1"), AttributeType.POWER,        PowerUnit.WATT)),
+    (ResistanceAttribute("r",   Value("1"), ResistanceUnit.OHM),    Attribute("r", Value("1"), AttributeType.RESISTANCE,   ResistanceUnit.OHM)),
+    (VoltageAttribute("v",      Value("1"), VoltageUnit.VOLT),      Attribute("v", Value("1"), AttributeType.VOLTAGE,      VoltageUnit.VOLT)),
+    # add more for new types
+])
+def test_typed_vs_general_attribute_equivalence(typed: Attribute, general: Attribute) -> None:
+    assert str(typed) == str(general)


### PR DESCRIPTION

**_UPDATE: API was reworked, please scroll down for more info_**

This PR aims to integrate `Attribute` Entities into the `Part` API for generators. The API is small, simple and flexible while leaving little room for mistakes by the generator dev (like wrong `Unit` for `Type`, e.g. `Type.CURRENT` for `Unit.HENRY`) and should tie seamlessly into the existing Entities/Expressions. Furthermore, it could provide a basis for discussion about this feature in general 💪 

Need for this feature arose from https://github.com/LibrePCB/librepcb-parts-generator/pull/127#issuecomment-2094038914

Example:
```python
from entities.attribute import Attribute, AttributeType, MetricPrefix
from entities.common import Value
from entities.device import Manufacturer, Part

max_current_attr = Attribute("Max Current", Value("500"), AttributeType.CURRENT, MetricPrefix.MILLI)
features_attr = Attribute("Features", Value("Suction Cap"), AttributeType.STRING, None)

p = Part("XYZ123", Manufacturer("LibrePCB"))
p.add_attribute(max_current_attr)
p.add_attribute(features_attr)

print(p)
```

Output:
```
(part "XYZ123" (manufacturer "LibrePCB")
 (attribute "Max Current" (type current) (unit milliampere) (value "500"))
 (attribute "Features" (type string) (unit none) (value "Suction Cap"))
)
```

As always any feedback welcome! 😄 

