### PR TITLE
Always use Unix-style line endings in generator output

### DIFF
--- a/common.py
+++ b/common.py
@@ -3,7 +3,6 @@ Common functionality for generator scripts.
 """
 import collections
 import csv
-import os.path
 import re
 from datetime import datetime
 from os import makedirs, path
@@ -149,7 +148,7 @@ def get_pad_uuids(base_lib_path: str, pkg_uuid: str) -> Dict[str, str]:
     """
     Return a mapping from pad name to pad UUID.
     """
-    with open(os.path.join(base_lib_path, 'pkg', pkg_uuid, 'package.lp'), 'r') as f:
+    with open(path.join(base_lib_path, 'pkg', pkg_uuid, 'package.lp'), 'r') as f:
         lines = f.readlines()
     opt_matches = [
         re.match(r' \(pad ([^\s]*) \(name "([^"]*)"\)\)$', line)

--- a/common.py
+++ b/common.py
@@ -6,6 +6,7 @@ import csv
 import os.path
 import re
 from datetime import datetime
+from os import makedirs, path
 
 from typing import Any, Dict, Iterable, List, OrderedDict, Union
 
@@ -173,3 +174,17 @@ def human_sort_key(key: str) -> List[Any]:
         return int(text) if text.isdigit() else text
 
     return [_convert(x) for x in re.split(r'(\d+)', key) if x]
+
+
+def serialize_common(serializable: Any, output_directory: str, uuid: str, long_type: str, short_type: str) -> None:
+    """
+    Centralized serialize() implementation shared between Component, Symbol, Device, Package
+    """
+    dir_path = path.join(output_directory, uuid)
+    if not (path.exists(dir_path) and path.isdir(dir_path)):
+        makedirs(dir_path)
+    with open(path.join(dir_path, f'.librepcb-{short_type}'), 'w', newline='\n') as f:
+        f.write('1\n')
+    with open(path.join(dir_path, f'{long_type}.lp'), 'w', newline='\n') as f:
+        f.write(str(serializable))
+        f.write('\n')

--- a/entities/component.py
+++ b/entities/component.py
@@ -212,8 +212,10 @@ class Component:
         self.variants.append(variant)
 
     def serialize(self, output_directory: str) -> None:
-        serialize_common(serializable=self,
-                         output_directory=output_directory,
-                         uuid=self.uuid,
-                         long_type='component',
-                         short_type='cmp')
+        serialize_common(
+            serializable=self,
+            output_directory=output_directory,
+            uuid=self.uuid,
+            long_type='component',
+            short_type='cmp'
+        )

--- a/entities/component.py
+++ b/entities/component.py
@@ -1,6 +1,6 @@
-from os import makedirs, path
-
 from typing import Iterable, List
+
+from common import serialize_common
 
 from .common import (
     Author, BoolValue, Category, Created, Deprecated, Description, EnumValue, GeneratedBy, Keywords, Name, Position,
@@ -212,11 +212,8 @@ class Component:
         self.variants.append(variant)
 
     def serialize(self, output_directory: str) -> None:
-        dir_path = path.join(output_directory, self.uuid)
-        if not (path.exists(dir_path) and path.isdir(dir_path)):
-            makedirs(dir_path)
-        with open(path.join(dir_path, '.librepcb-cmp'), 'w') as f:
-            f.write('1\n')
-        with open(path.join(dir_path, 'component.lp'), 'w') as f:
-            f.write(str(self))
-            f.write('\n')
+        serialize_common(serializable=self,
+                         output_directory=output_directory,
+                         uuid=self.uuid,
+                         long_type='component',
+                         short_type='cmp')

--- a/entities/device.py
+++ b/entities/device.py
@@ -1,8 +1,6 @@
-from os import makedirs, path
-
 from typing import Iterable, List, Optional
 
-from common import escape_string
+from common import escape_string, serialize_common
 from entities.attribute import Attribute
 
 from .common import (
@@ -103,11 +101,8 @@ class Device():
         return ret
 
     def serialize(self, output_directory: str) -> None:
-        dir_path = path.join(output_directory, self.uuid)
-        if not (path.exists(dir_path) and path.isdir(dir_path)):
-            makedirs(dir_path)
-        with open(path.join(dir_path, '.librepcb-dev'), 'w') as f:
-            f.write('1\n')
-        with open(path.join(dir_path, 'device.lp'), 'w') as f:
-            f.write(str(self))
-            f.write('\n')
+        serialize_common(serializable=self,
+                         output_directory=output_directory,
+                         uuid=self.uuid,
+                         long_type='device',
+                         short_type='dev')

--- a/entities/device.py
+++ b/entities/device.py
@@ -101,8 +101,10 @@ class Device():
         return ret
 
     def serialize(self, output_directory: str) -> None:
-        serialize_common(serializable=self,
-                         output_directory=output_directory,
-                         uuid=self.uuid,
-                         long_type='device',
-                         short_type='dev')
+        serialize_common(
+            serializable=self,
+            output_directory=output_directory,
+            uuid=self.uuid,
+            long_type='device',
+            short_type='dev'
+        )

--- a/entities/package.py
+++ b/entities/package.py
@@ -343,8 +343,10 @@ class Package:
         return ret
 
     def serialize(self, output_directory: str) -> None:
-        serialize_common(serializable=self,
-                         output_directory=output_directory,
-                         uuid=self.uuid,
-                         long_type='package',
-                         short_type='pkg')
+        serialize_common(
+            serializable=self,
+            output_directory=output_directory,
+            uuid=self.uuid,
+            long_type='package',
+            short_type='pkg'
+        )

--- a/entities/package.py
+++ b/entities/package.py
@@ -1,8 +1,6 @@
-from os import makedirs, path
-
 from typing import Iterable, List
 
-from common import format_float
+from common import format_float, serialize_common
 
 from .common import (
     Align, Author, BoolValue, Category, Circle, Created, Deprecated, Description, EnumValue, FloatValue, GeneratedBy,
@@ -345,11 +343,8 @@ class Package:
         return ret
 
     def serialize(self, output_directory: str) -> None:
-        dir_path = path.join(output_directory, self.uuid)
-        if not (path.exists(dir_path) and path.isdir(dir_path)):
-            makedirs(dir_path)
-        with open(path.join(dir_path, '.librepcb-pkg'), 'w') as f:
-            f.write('1\n')
-        with open(path.join(dir_path, 'package.lp'), 'w') as f:
-            f.write(str(self))
-            f.write('\n')
+        serialize_common(serializable=self,
+                         output_directory=output_directory,
+                         uuid=self.uuid,
+                         long_type='package',
+                         short_type='pkg')

--- a/entities/symbol.py
+++ b/entities/symbol.py
@@ -1,8 +1,6 @@
-from os import makedirs, path
-
 from typing import Iterable, List
 
-from common import format_float
+from common import format_float, serialize_common
 
 from .common import (
     Author, Category, Circle, Created, Deprecated, Description, FloatValue, GeneratedBy, Keywords, Length, Name,
@@ -117,11 +115,8 @@ class Symbol:
         return ret
 
     def serialize(self, output_directory: str) -> None:
-        dir_path = path.join(output_directory, self.uuid)
-        if not (path.exists(dir_path) and path.isdir(dir_path)):
-            makedirs(dir_path)
-        with open(path.join(dir_path, '.librepcb-sym'), 'w') as f:
-            f.write('1\n')
-        with open(path.join(dir_path, 'symbol.lp'), 'w') as f:
-            f.write(str(self))
-            f.write('\n')
+        serialize_common(serializable=self,
+                         output_directory=output_directory,
+                         uuid=self.uuid,
+                         long_type='symbol',
+                         short_type='sym')

--- a/entities/symbol.py
+++ b/entities/symbol.py
@@ -115,8 +115,10 @@ class Symbol:
         return ret
 
     def serialize(self, output_directory: str) -> None:
-        serialize_common(serializable=self,
-                         output_directory=output_directory,
-                         uuid=self.uuid,
-                         long_type='symbol',
-                         short_type='sym')
+        serialize_common(
+            serializable=self,
+            output_directory=output_directory,
+            uuid=self.uuid,
+            long_type='symbol',
+            short_type='sym'
+        )

--- a/test_entities.py
+++ b/test_entities.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from entities.common import (
     Align, Angle, Author, Category, Circle, Created, Deprecated, Description, Diameter, Fill, GeneratedBy, GrabArea,
     Height, Keywords, Layer, Length, Name, Polygon, Position, Position3D, Rotation, Rotation3D, Text, Value, Version,
@@ -552,3 +554,113 @@ def test_sort_footprint_3d_models() -> None:
     model2 = Footprint3DModel('161c65b0-a386-4b45-9ac2-0293a812fb62')
     models = [model1, model2]
     assert sorted(models) == [model2, model1]
+
+
+def check_all_file_newlines_in_dir_are_unix(dir_with_files: Path) -> bool:
+    """
+    Checks if all files in the given directory have Unix-style line endings
+
+    Helper function, not a test!
+    """
+    for temp_file in dir_with_files.iterdir():
+        with temp_file.open(mode="r", newline='') as file_under_test:
+            file_under_test.readlines()  # read all lines to populate file_under_test.newlines
+            if file_under_test.newlines is None:
+                return False
+            if not all((newline == '\n') for newline in file_under_test.newlines):
+                return False
+    return True
+
+
+def test_serialized_component_line_endings(tmp_path: Path) -> None:
+
+    component_uuid = '00c36da8-e22b-43a1-9a87-c3a67e863f49'
+
+    component = Component(
+        component_uuid,
+        Name('Generic Connector 1x27'),
+        Description('A 1x27 soldered wire connector.\n\nNext line'),
+        Keywords('connector, 1x27'),
+        Author('Test R.'),
+        Version('0.2'),
+        Created('2018-10-17T19:13:41Z'),
+        Deprecated(False),
+        GeneratedBy('black magic'),
+        [Category('d0618c29-0436-42da-a388-fdadf7b23892')],
+        SchematicOnly(False),
+        DefaultValue(''),
+        Prefix('J'),
+    )
+
+    component.serialize(str(tmp_path))
+
+    assert check_all_file_newlines_in_dir_are_unix(tmp_path.joinpath(component_uuid))
+
+
+def test_serialized_symbol_line_endings(tmp_path: Path) -> None:
+
+    symbol_uuid = '01b03c10-7334-4bd5-b2bc-942c18325d2b'
+
+    symbol = Symbol(
+        symbol_uuid,
+        Name('Sym name'),
+        Description('A multiline description.\n\nDescription'),
+        Keywords('my, keywords'),
+        Author('Test'),
+        Version('0.2'),
+        Created('2018-10-17T19:13:41Z'),
+        Deprecated(False),
+        GeneratedBy('black magic'),
+        [Category('d0618c29-0436-42da-a388-fdadf7b23892')],
+    )
+
+    symbol.serialize(str(tmp_path))
+
+    assert check_all_file_newlines_in_dir_are_unix(tmp_path.joinpath(symbol_uuid))
+
+
+def test_serialized_device_line_endings(tmp_path: Path) -> None:
+
+    device_uuid = '00652f30-9f89-4027-91f5-7bd684eee751'
+
+    device = Device(
+        device_uuid,
+        Name('Foo'),
+        Description('Bar'),
+        Keywords('foo, bar'),
+        Author('J. Rando'),
+        Version('0.1'),
+        Created('2018-10-17T19:13:41Z'),
+        Deprecated(False),
+        GeneratedBy('black magic'),
+        [Category('ade6d8ff-3c4f-4dac-a939-cc540c87c280')],
+        ComponentUUID('bc911fcc-8b5c-4728-b596-d644797c55da'),
+        PackageUUID('b4e92c64-18c4-44a6-aa39-d1be3e8c29bd'),
+    )
+
+    device.serialize(str(tmp_path))
+
+    assert check_all_file_newlines_in_dir_are_unix(tmp_path.joinpath(device_uuid))
+
+
+def test_serialized_package_line_endings(tmp_path: Path) -> None:
+
+    package_uuid = '009e35ef-1f50-4bf3-ab58-11eb85bf5503'
+
+    package = Package(
+        package_uuid,
+        Name('Soldered Wire Connector 1x19 1.0mm'),
+        Description('A 1x19 soldered wire connector with 2.54mm pin spacing and 1.0mm drill holes.\n\nGenerated with librepcb-parts-generator (generate_connectors.py)'),
+        Keywords('connector, 1x19, d1.0, connector, soldering, generic'),
+        Author('Danilo B.'),
+        Version('0.1'),
+        Created('2018-10-17T19:13:41Z'),
+        Deprecated(False),
+        GeneratedBy('black magic'),
+        [Category('56a5773f-eeb4-4b39-8cb9-274f3da26f4f')],
+        AssemblyType.THT,
+    )
+
+    package.serialize(str(tmp_path))
+
+    assert check_all_file_newlines_in_dir_are_unix(tmp_path.joinpath(package_uuid))


### PR DESCRIPTION
This PR adds:
- A centralized `serialize()` implementation.
 I think this one made sense since it was the same for `Device`, `Symbol`, `Package` and `Component`. If these implementations differ in the future we could remove it again, but for now it prevents some code duplication.  (I wasn't sure how to name it and where to put it, I opted for `serialize_common` and put it in the _outer_ `common.py` file, suggestions welcome)
- Always use Unix-style line endings (LF) when serializing entities (should fix development on Windows, see discussion [here](https://github.com/LibrePCB-Libraries/JST.lplib/pull/6))
- Tests

I tried the `librepcb-cli open-library --all --strict --check --minify-step .` command before the changes in this PR and it gave me the "Non-canonical file". After applying the changes in this PR it seemed to work just fine! :-)

Edit: I verified the Tests on my Windows machine. They failed before applying the changes, but passed after applying the changes from this PR.