### PR TITLE
Add dependency "numpy < 2"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 requires-python = ">=3.8"
 dependencies = [
     "cadquery == 2.3.1",
+    "numpy < 2",  # Dependency of cadquery, but not working with v2.x
 ]
 version = "0.1.0"
 


### PR DESCRIPTION
Installing cadquery now installs the dependency numpy 2.x, which is not compatible anymore. So let's add it as a direct dependency to ensure a v1.x version gets installed.

Not sure if this is the best way, but at least it fixes CI...